### PR TITLE
Secure notifications controller

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,7 @@
 class NotificationsController < ApplicationController
   before_filter :if_not_signed_in
   before_action :set_notification, only: [:destroy]
+  before_action :ensure_user_owns_notification!, only: [:destroy]
 
   # DELETE /notifications/1
   # DELETE /notifications/1.json
@@ -64,6 +65,14 @@ class NotificationsController < ApplicationController
           format.html { redirect_to new_user_session_path }
           format.json { head :no_content }
         end
+      end
+    end
+
+    # Stops here if the signed in user is not the owner of
+    # the notification set by :set_notification.
+    def ensure_user_owns_notification!
+      unless @notification.user == current_user
+        render :nothing => true
       end
     end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -8,13 +8,13 @@ class NotificationsController < ApplicationController
   def destroy
     @notification.destroy
     respond_to do |format|
-        format.html { redirect_to :back }
+      format.html { redirect_to :back }
       format.json { head :no_content }
     end
   end
 
   def clear
-    Notification.where(userid: current_user.id).destroy_all if !Notification.where(userid: current_user.id).nil?
+    Notification.where(userid: current_user.id).destroy_all
     render :nothing => true
   end
 

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,3 +1,68 @@
-describe NotificationsController do
+RSpec.describe NotificationsController, :type => :controller do
 
+  let(:user) { create(:user) }
+
+  describe 'DELETE #destroy' do
+    let(:notification) { build_stubbed(:notification) }
+    let(:last_visited_path) { '/' }
+
+    subject { delete :destroy, id: notification.id }
+
+    before { request.env['HTTP_REFERER'] = last_visited_path }
+
+    context 'when a user is singed in' do
+      include_context :logged_in_user
+
+      context 'when a notification with the given ID exists' do
+        before do
+          allow(Notification).to receive(:find).with(notification.id.to_s).and_return(notification)
+        end
+
+        context 'when the signed in user is the owner of the notification' do
+          before do
+            allow(notification).to receive(:user).and_return(user)
+          end
+
+          it 'destroys the notification' do
+            expect(notification).to receive(:destroy)
+            subject
+          end
+
+          it 'redirects to the last visited path' do
+            allow(notification).to receive(:destroy)
+            subject
+            expect(response).to redirect_to(last_visited_path)
+          end
+        end
+
+        context 'when the signed in user is not the owner of the notification' do
+          before do
+            allow(notification).to receive(:user).and_return(build_stubbed(:user))
+          end
+
+          after { subject }
+
+          it 'doesn\'t destroy the notification' do
+            expect(notification).not_to receive(:destroy)
+          end
+        end
+      end
+
+      context 'when no notification with the given ID exists' do
+        before do
+          allow(Notification).to receive(:find).and_raise('NotFoundException')
+          subject
+        end
+
+        it 'redirects to the last visited path' do
+          expect(response).to redirect_to(last_visited_path)
+        end
+      end
+    end
+
+    context 'when no user is signed in' do
+      before { subject }
+      it_behaves_like :with_no_logged_in_user
+    end
+  end
 end


### PR DESCRIPTION
I noticed that, right now, basically every user can delete any notification, so I've added an additional `before_action` to allow users to delete their own notifications only.
