### PR TITLE
Add package installation to start_app script

### DIFF
--- a/bin/start_app
+++ b/bin/start_app
@@ -3,12 +3,13 @@ require 'pathname'
 require 'fileutils'
 include FileUtils
 
-# path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
 chdir APP_ROOT do
-  # This script starts your application.
-
+  puts "\n== Installing gems =="
+  system('bundle install')
+  puts "\n== Installing npm packages =="
+  system('cd client/ && yarn install && cd ..')
   puts "\n== Starting application server (foreman) =="
   system('foreman start -f Procfile.dev')
 end


### PR DESCRIPTION
Saves having to do `cd client` and `yarn install` and `bundle install` each time and remembering that.

![](https://media.giphy.com/media/2hgAt92zs4qbp9Ld4W/giphy.gif)