### PR TITLE
Refactor for readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 # Ignore all IDE, TextEditor configuration files
 .idea/
 .tags
+*.swp
 
 # Ignore coverage results
 /coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
     - 'spec/**/*'
+    - 'client/node_modules/**/*'
 
 Documentation:
   Enabled: false
@@ -13,7 +14,7 @@ Rails:
   Enabled: true
 
 # There is a bug in the Rubocop 0.48 parser that causes it to incorrectly
-# complain about parenthese around blocks used with scopes. This should be
+# complain about parentheses around blocks used with scopes. This should be
 # removed once it is possible to upgrade to 0.49 or above.
 Lint/AmbiguousBlockAssociation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,5 +22,18 @@ Lint/AmbiguousBlockAssociation:
 # Rubocop should be used for style guide adherence, not testing for code smell
 Rails/OutputSafety:
   Enabled: false
+
 Rails/SkipsModelValidations:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/AbcSize:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,12 @@ Rails/OutputSafety:
 Rails/SkipsModelValidations:
   Enabled: false
 
+Rails/InverseOf:
+  Enabled: false
+
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,9 @@ Rails/InverseOf:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
+Style/MixinUsage:
+  Enabled: false
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+# for example lib/tasks/capistrano.rake, and they will automatically be
+# available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks

--- a/app/assets/javascripts/add_comment.js
+++ b/app/assets/javascripts/add_comment.js
@@ -1,112 +1,110 @@
 var onReadyAddComment = function() {
-	if (isShow(['moments', 'strategies', 'meetings'])) {
-		$(document).on('click', '#add_comment_button', function(event) {
-			event.preventDefault();
+  if (isShow(['moments', 'strategies', 'meetings'])) {
+    $(document).on('click', '#add_comment_button', function(event) {
+      event.preventDefault();
 
-			if (!$(this).prop('disabled')) {
-				$(this).prop('disabled', true);
-				$('#comment_comment').prop('disabled', true);
-				$(this).val(I18n.t('comment.posting'));
+      if (!$(this).prop('disabled')) {
+        $(this).prop('disabled', true);
+        $('#comment_comment').prop('disabled', true);
+        $(this).val(I18n.t('comment.posting'));
 
-				if ($('.comment').length > 0) {
-					$('.actions').removeClass('no_margin_bottom');
-				}
+        if ($('.comment').length > 0) {
+          $('.actions').removeClass('no_margin_bottom');
+        }
 
-				var url;
-				if (isShow(['moments'])) {
-					url = '/moments/comment';
-				} else if (isShow(['strategies'])) {
-					url = '/strategies/comment';
-				} else {
-					url = '/meetings/comment';
-				}
+        var url;
+        if (isShow(['moments'])) {
+          url = '/moments/comment';
+        } else if (isShow(['strategies'])) {
+          url = '/strategies/comment';
+        } else {
+          url = '/meetings/comment';
+        }
 
-				var viewers;
-				if ($('#comment_viewers').length) {
-					viewers = $('#comment_viewers').val();
-				}
+        var viewers;
+        if ($('#comment_viewers').length) {
+          viewers = $('#comment_viewers').val();
+        }
 
-				var data = {
-					commentable_type: $('#comment_commentable_type').val(),
-					commentable_id:$('#comment_commentable_id').val(),
-					comment_by: $('#comment_comment_by').val(),
-					comment: $('#comment_comment').val(),
-					visibility: $('#comment_visibility').val(),
-					viewers: viewers
-				};
+        var data = {
+          commentable_type: $('#comment_commentable_type').val(),
+          commentable_id:$('#comment_commentable_id').val(),
+          comment_by: $('#comment_comment_by').val(),
+          comment: $('#comment_comment').val(),
+          visibility: $('#comment_visibility').val(),
+          viewers: viewers
+        };
 
-				$.ajax({
-				    dataType: 'json',
-				    url: url,
-				    type: 'POST',
-				    data: data,
-				    success: function(json) {
-				    	if (json !== undefined) {
-				    		$('#add_comment_button').prop('disabled', false);
-				    		$('#comment_comment').prop('disabled', false);
-				    		$('#comment_comment').val('');
-							$('#add_comment_button').val(I18n.t('comment.singular'));
+        $.ajax({
+          dataType: 'json',
+          url: url,
+          type: 'POST',
+          data: data,
+          success: function(json) {
+            if (json !== undefined) {
+              $('#add_comment_button').prop('disabled', false);
+              $('#comment_comment').prop('disabled', false);
+              $('#comment_comment').val('');
+              $('#add_comment_button').val(I18n.t('comment.singular'));
 
-				    		if (!json.no_save) {
-					    		var commentid = 'comment_' + json.commentid;
-					    		var profile_picture = json.profile_picture;
-					    		var comment_info = json.comment_info;
-					    		var comment_text = json.comment_text;
-					    		var visibility = json.visibility;
-					    		var delete_comment = json.delete_comment;
+              if (!json.no_save) {
+                var commentid = 'comment_' + json.commentid;
+                var profile_picture = json.profile_picture;
+                var comment_info = json.comment_info;
+                var comment_text = json.comment_text;
+                var visibility = json.visibility;
+                var delete_comment = json.delete_comment;
 
-					    		// Remove no_margin_top on first comment
-					    		if ($('.comment').length > 0) {
-					    			$('.comment.no_margin_top').removeClass('no_margin_top');
-					    		}
+                // Remove no_margin_top on first comment
+                if ($('.comment').length > 0) {
+                  $('.comment.no_margin_top').removeClass('no_margin_top');
+                }
 
-					    		var newComment = '<div class="comment no_margin_top" id="' + commentid + '">';
-					    		newComment += '<div class="table">';
-					    		newComment += '<div class="table_row">';
+                var newComment = '<div class="comment no_margin_top" id="' + commentid + '">';
+                newComment += '<div class="table">';
+                newComment += '<div class="table_row">';
+                newComment += '<div class="table_cell small_profile_picture_div vertical_align_middle padding_right">';
+                newComment += profile_picture;
+                newComment += '</div>';
+                newComment += '<div class="table_cell">';
+                newComment += '<div class="comment_info">';
+                newComment += comment_info;
+                newComment += '</div>';
+                newComment += '<div class="comment_text">';
+                newComment += comment_text;
+                newComment += '</div>';
 
-					    		newComment += '<div class="table_cell small_profile_picture_div vertical_align_middle padding_right">';
-
-					    		newComment += profile_picture;
-					    		newComment += '</div>';
-
-					    		newComment += '<div class="table_cell">';
-					    		newComment += '<div class="comment_info">';
-					    		newComment += comment_info;
-					    		newComment += '</div>';
-					    		newComment += '<div class="comment_text">';
-					    		newComment += comment_text;
-					    		newComment += '</div>';
-					    		if (visibility !== null && visibility.length > 0) {
-					    			newComment += visibility;
-					    		}
-					    		newComment += '</div>';
+                if (visibility !== null && visibility.length > 0) {
+                  newComment += visibility;
+                }
+                newComment += '</div>';
 
 
-					    		if (delete_comment !== null && delete_comment.length > 0) {
-					    			newComment += delete_comment;
-					    		}
+                if (delete_comment !== null && delete_comment.length > 0) {
+                  newComment += delete_comment;
+                }
 
-					    		newComment += '</div>';
-					    		newComment += '</div>';
-					    		newComment += '</div>';
+                newComment += '</div>';
+                newComment += '</div>';
+                newComment += '</div>';
 
-					    		$('#comments').prepend(newComment);
+                $('#comments').prepend(newComment);
 
-					    		if ($('.comment').length > 0) {
-									$('.actions').removeClass('no_margin_bottom');
-								}
-					    	}
-				    	}
-				    },
-				    error: function() {
-				    	$('#add_comment_button').prop('disabled', false);
-				    	$('#comment_comment').prop('disabled', false);
-						$('#add_comment_button').val(I18n.t('comment.singular'));
-				    }
-				});
-			}
-		});
-	}
+                if ($('.comment').length > 0) {
+                  $('.actions').removeClass('no_margin_bottom');
+                }
+              }
+            }
+          },
+          error: function() {
+            $('#add_comment_button').prop('disabled', false);
+            $('#comment_comment').prop('disabled', false);
+          $('#add_comment_button').val(I18n.t('comment.singular'));
+          }
+        });
+      }
+    });
+  }
 };
 
 loadPage(onReadyAddComment);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,44 +31,44 @@ function isAllAlliesInputBoxIsChecked(inputTag) {
 }
 
 function setViewersCheckBoxToNotBeSelected() {
-	$(":checkbox[id='viewers_all']").prop("checked", false);
+  $(":checkbox[id='viewers_all']").prop("checked", false);
 }
 
 function newOrEdit(forms) {
-	var result = false;
-	_.each(forms, function(form) {
-		if ($("body").hasClass(form + " new") || $("body").hasClass(form + " create") || $("body").hasClass(form + " edit") || $("body").hasClass(form + " update")) {
-			result = true;
-			return;
-		}
-	});
+  var result = false;
+  _.each(forms, function(form) {
+    if ($("body").hasClass(form + " new") || $("body").hasClass(form + " create") || $("body").hasClass(form + " edit") || $("body").hasClass(form + " update")) {
+      result = true;
+      return;
+    }
+  });
 
-	return result;
+  return result;
 }
 
 function isShow(forms) {
-	var result = false;
-	_.each(forms, function(form) {
-		if ($("body").hasClass(form + " show")) {
-			result = true;
-			return;
-		}
-	});
+  var result = false;
+  _.each(forms, function(form) {
+    if ($("body").hasClass(form + " show")) {
+      result = true;
+      return;
+    }
+  });
 
-	return result;
+  return result;
 }
 
 var onReadyApplication = function() {
-	$.ajaxSetup({
-		headers: {
-			"X-CSRF-Token": $("meta[name='csrf-token']").attr("content")
-		}
-	});
+  $.ajaxSetup({
+    headers: {
+      "X-CSRF-Token": $("meta[name='csrf-token']").attr("content")
+    }
+  });
 
-	// Timezone detection
-	Cookies.set("timezone", jstz.determine().name());
+  // Timezone detection
+  Cookies.set("timezone", jstz.determine().name());
 
-	$(".yes_title").find(":not(.no_title)").tooltip();
+  $(".yes_title").find(":not(.no_title)").tooltip();
 };
 
 loadPage(onReadyApplication);

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -1,18 +1,18 @@
 function changeEditorCount(editorCount, remaining) {
   $(editorCount).html(remaining);
 
-    if (remaining <= 0) {
-      $(editorCount).css('color', '#990019');
+  if (remaining <= 0) {
+    $(editorCount).css('color', '#990019');
 
-      if (remaining === 0) {
-        $('input[type="submit"]').prop('disabled', false);
-      } else {
-        $('input[type="submit"]').prop('disabled', true);
-      }
-    } else {
-      $(editorCount).css('color', '#b5839b');
+    if (remaining === 0) {
       $('input[type="submit"]').prop('disabled', false);
+    } else {
+      $('input[type="submit"]').prop('disabled', true);
     }
+  } else {
+    $(editorCount).css('color', '#b5839b');
+    $('input[type="submit"]').prop('disabled', false);
+  }
 }
 
 function noCKEditor(editor) {
@@ -21,7 +21,7 @@ function noCKEditor(editor) {
   var editorCount = '#' + editorName + '_count';
   var remaining = 2000 - editorData.length;
 
-	 changeEditorCount(editorCount, remaining);
+  changeEditorCount(editorCount, remaining);
 }
 
 function yesCKEditor(editor) {

--- a/app/assets/javascripts/delete_comment.js
+++ b/app/assets/javascripts/delete_comment.js
@@ -1,30 +1,30 @@
 var onReadyDeleteComment = function() {
-	if (isShow(['moments', 'strategies', 'meetings'])) {
-		$(document).on('click', '.delete_comment_button', function(event) {
-			event.preventDefault();
+  if (isShow(['moments', 'strategies', 'meetings'])) {
+    $(document).on('click', '.delete_comment_button', function(event) {
+      event.preventDefault();
 
-			var commentid = $(this).attr('id').replace('delete_comment_', '');
-			var comment = '#comment_' + commentid;
-			$(comment).remove();
+      var commentid = $(this).attr('id').replace('delete_comment_', '');
+      var comment = '#comment_' + commentid;
+      $(comment).remove();
 
-			if ($('.comment').length === 0) {
-				$('.actions').addClass('no_margin_bottom');
-			} else {
-				$('.comment').first().addClass('no_margin_top');
-			}
+      if ($('.comment').length === 0) {
+        $('.actions').addClass('no_margin_bottom');
+      } else {
+        $('.comment').first().addClass('no_margin_top');
+      }
 
-			var url;
-			if ($('body').hasClass('moments show')) {
-				url = "/moments/delete_comment?commentid=" + commentid;
-			} else if ($('body').hasClass('strategies show')) {
-				url = "/strategies/delete_comment?commentid=" + commentid;
-			} else {
-				url = "/meetings/delete_comment?commentid=" + commentid;
-			}
+      var url;
+      if ($('body').hasClass('moments show')) {
+        url = "/moments/delete_comment?commentid=" + commentid;
+      } else if ($('body').hasClass('strategies show')) {
+        url = "/strategies/delete_comment?commentid=" + commentid;
+      } else {
+        url = "/meetings/delete_comment?commentid=" + commentid;
+      }
 
-			$.ajax(url);
-		});
-	}
+      $.ajax(url);
+    });
+  }
 };
 
 loadPage(onReadyDeleteComment);

--- a/app/assets/javascripts/expand_toggle.js
+++ b/app/assets/javascripts/expand_toggle.js
@@ -1,13 +1,13 @@
 var onReadyExpandToggle = function() {
   if (newOrEdit(["moments", "strategies"])) {
     $(".expand_toggle").click(function(event) {
-  		var toggleID = $(this).data("toggle");
-  		$(toggleID).toggle();
-  		$(this).find(".toggle_button i").toggleClass("fa-caret-down");
-  		$(this).find(".toggle_button i").toggleClass("fa-caret-up");
-  		event.preventDefault();
-  	});
-	}
+      var toggleID = $(this).data("toggle");
+      $(toggleID).toggle();
+      $(this).find(".toggle_button i").toggleClass("fa-caret-down");
+      $(this).find(".toggle_button i").toggleClass("fa-caret-up");
+      event.preventDefault();
+    });
+  }
 };
 
 loadPage(onReadyExpandToggle);

--- a/app/assets/javascripts/form_processing.js
+++ b/app/assets/javascripts/form_processing.js
@@ -1,141 +1,141 @@
 function complexCheck(dataType, emptyWhy) {
-	var name = dataType + '_name';
+  var name = dataType + '_name';
 
-	if ($('#' + name).val().length === 0) {
-		$('label[for="' + name + '"]').css('color', '#990019');
-	} else {
-		$('label[for="' + name + '"]').css('color', '#000');
-	}
+  if ($('#' + name).val().length === 0) {
+    $('label[for="' + name + '"]').css('color', '#990019');
+  } else {
+    $('label[for="' + name + '"]').css('color', '#000');
+  }
 
-	var why;
-	if (dataType === 'moment') {
-		why = 'moment_why';
-	} else if (dataType === 'strategy' || dataType === 'group' || dataType === 'meeting') {
-		why = dataType + '_description';
-	}
-	if (emptyWhy) {
-  		$('label[for="' + why + '"]').css('color', '#990019');
-  	} else {
-  		$('label[for="' + why + '"]').css('color', '#000');
-  	}
+  var why;
+  if (dataType === 'moment') {
+    why = 'moment_why';
+  } else if (dataType === 'strategy' || dataType === 'group' || dataType === 'meeting') {
+    why = dataType + '_description';
+  }
+  if (emptyWhy) {
+    $('label[for="' + why + '"]').css('color', '#990019');
+  } else {
+    $('label[for="' + why + '"]').css('color', '#000');
+  }
 
-	if ($('#' + name).val().length === 0 || emptyWhy) {
-		return false;
-	}
+  if ($('#' + name).val().length === 0 || emptyWhy) {
+    return false;
+  }
 
-	return true;
+  return true;
 }
 
 function handleEmptyWhy(editor) {
-	if (editor.getData().length === 0) {
-  		return true;
-  	} else {
-  		return false;
-  	}
+  if (editor.getData().length === 0) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 function simpleCheck(labels) {
-	var result = true;
+  var result = true;
 
-	_.each(labels, function(label) {
-		if ($('#' + label).val().length === 0) {
-			$('label[for="' + label + '"]').css('color', '#990019');
-			result = false;
-		} else {
-			$('label[for="' + label + '"]').css('color', '#000');
-		}
-	});
+  _.each(labels, function(label) {
+    if ($('#' + label).val().length === 0) {
+      $('label[for="' + label + '"]').css('color', '#990019');
+      result = false;
+    } else {
+      $('label[for="' + label + '"]').css('color', '#000');
+    }
+  });
 
-	return result;
+  return result;
 }
 
 var onReadyFormProcessing = function() {
-	var emptyWhy;
+  var emptyWhy;
 
-	if (newOrEdit(['moods'])) {
-		$('#new_mood').submit(function() {
-			return simpleCheck(['mood_name']);
-		});
-	}
+  if (newOrEdit(['moods'])) {
+    $('#new_mood').submit(function() {
+      return simpleCheck(['mood_name']);
+    });
+  }
 
-	if (newOrEdit(['categories'])) {
-		$('#new_category').submit(function() {
-			return simpleCheck(['category_name']);
-		});
-	}
+  if (newOrEdit(['categories'])) {
+    $('#new_category').submit(function() {
+      return simpleCheck(['category_name']);
+    });
+  }
 
-	if (newOrEdit(['moments'])) {
-		emptyWhy = false;
+  if (newOrEdit(['moments'])) {
+    emptyWhy = false;
 
-		CKEDITOR.on("instanceReady", function(event) {
-		  	var editor = event.editor;
-		  	emptyWhy = handleEmptyWhy(editor);
+    CKEDITOR.on("instanceReady", function(event) {
+      var editor = event.editor;
+      emptyWhy = handleEmptyWhy(editor);
 
-		  	return editor.on('change', function() {
-		  		emptyWhy = handleEmptyWhy(editor);
-		  	});
-		});
+      return editor.on('change', function() {
+        emptyWhy = handleEmptyWhy(editor);
+      });
+    });
 
-		$('#new_moment').submit(function() {
-			return complexCheck('moment', emptyWhy);
-		});
-	}
+    $('#new_moment').submit(function() {
+      return complexCheck('moment', emptyWhy);
+    });
+  }
 
-	if (newOrEdit(['strategies'])) {
-		emptyWhy = false;
+  if (newOrEdit(['strategies'])) {
+    emptyWhy = false;
 
-		CKEDITOR.on("instanceReady", function(event) {
-		  	var editor = event.editor;
-		  	emptyWhy = handleEmptyWhy(editor);
+    CKEDITOR.on("instanceReady", function(event) {
+      var editor = event.editor;
+      emptyWhy = handleEmptyWhy(editor);
 
-		  	return editor.on('change', function() {
-		  		emptyWhy = handleEmptyWhy(editor);
-		  	});
-		});
+      return editor.on('change', function() {
+        emptyWhy = handleEmptyWhy(editor);
+      });
+    });
 
-		$('#new_strategy').submit(function() {
-			return complexCheck('strategy', emptyWhy);
-		});
-	}
+    $('#new_strategy').submit(function() {
+      return complexCheck('strategy', emptyWhy);
+    });
+  }
 
-	if (newOrEdit(['medications'])) {
-		$('#new_medication').submit(function() {
-			return simpleCheck(['medication_name', 'medication_strength', 'medication_total', 'medication_dosage', 'medication_refill']);
-		});
-	}
+  if (newOrEdit(['medications'])) {
+    $('#new_medication').submit(function() {
+      return simpleCheck(['medication_name', 'medication_strength', 'medication_total', 'medication_dosage', 'medication_refill']);
+    });
+  }
 
-	if (newOrEdit(['groups'])) {
-		emptyWhy = false;
+  if (newOrEdit(['groups'])) {
+    emptyWhy = false;
 
-		CKEDITOR.on("instanceReady", function(event) {
-		  	var editor = event.editor;
-		  	emptyWhy = handleEmptyWhy(editor);
+    CKEDITOR.on("instanceReady", function(event) {
+      var editor = event.editor;
+      emptyWhy = handleEmptyWhy(editor);
 
-		  	return editor.on('change', function() {
-		  		emptyWhy = handleEmptyWhy(editor);
-		  	});
-		});
-	}
+      return editor.on('change', function() {
+        emptyWhy = handleEmptyWhy(editor);
+      });
+    });
+  }
 
-	if (newOrEdit(['meetings'])) {
-		emptyWhy = false;
+  if (newOrEdit(['meetings'])) {
+    emptyWhy = false;
 
-		CKEDITOR.on("instanceReady", function(event) {
-		  	var editor = event.editor;
-		  	emptyWhy = handleEmptyWhy(editor);
+    CKEDITOR.on("instanceReady", function(event) {
+      var editor = event.editor;
+      emptyWhy = handleEmptyWhy(editor);
 
-		  	return editor.on('change', function() {
-		  		emptyWhy = handleEmptyWhy(editor);
-		  	});
-		});
+      return editor.on('change', function() {
+        emptyWhy = handleEmptyWhy(editor);
+      });
+    });
 
-		$('#new_meeting').submit(function() {
-			var simple = simpleCheck(['meeting_location', 'meeting_time', 'meeting_date', 'meeting_maxmembers']);
-			var complex = complexCheck('meeting', emptyWhy);
+    $('#new_meeting').submit(function() {
+      var simple = simpleCheck(['meeting_location', 'meeting_time', 'meeting_date', 'meeting_maxmembers']);
+      var complex = complexCheck('meeting', emptyWhy);
 
-			return simple && complex;
-		});
-	}
+      return simple && complex;
+    });
+  }
 };
 
 loadPage(onReadyFormProcessing);

--- a/app/assets/javascripts/medications.js
+++ b/app/assets/javascripts/medications.js
@@ -1,5 +1,5 @@
 var onReadyMedications = function() {
-    if ($('body').hasClass('medications new') || $('body').hasClass('medications edit') || $('body').hasClass('medications create') || $('body').hasClass('medications update')) {
+  if ($('body').hasClass('medications new') || $('body').hasClass('medications edit') || $('body').hasClass('medications create') || $('body').hasClass('medications update')) {
     $("#medication_refill").datepicker();
   }
 };

--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -1,8 +1,8 @@
 var onReadyMeetings = function() {
-	if (newOrEdit(['meetings'])) {
-		$('#meeting_date').datepicker();
-		$('#meeting_time').timepicker({ 'scrollDefault': 'now', 'step': 15 });
-	}
+  if (newOrEdit(['meetings'])) {
+    $('#meeting_date').datepicker();
+    $('#meeting_time').timepicker({ 'scrollDefault': 'now', 'step': 15 });
+  }
 };
 
 loadPage(onReadyMeetings);

--- a/app/assets/javascripts/quick_create.js
+++ b/app/assets/javascripts/quick_create.js
@@ -11,30 +11,30 @@ function addToAutocomplete(json) {
 function quickCreate(form, data_type) {
   var values = $(form).serialize();
   $.ajax({
-      type: 'POST',
-      url: $(form).attr('action'),
-      data: values,
-      dataType: 'json'
+    type: 'POST',
+    url: $(form).attr('action'),
+    data: values,
+    dataType: 'json'
   }).success(function(json) {
-      // Update moments/strategies form
-      var wrapper = "<div id=\"" + json.wrapper_id + "\" class=\"display_block\">";
-      var content = wrapper + json.checkbox + json.label + "</div>";
-      if (data_type === 'category') {
-        $('#categories_list').prepend(content);
-      } else if (data_type === 'mood') {
-        $('#moods_list').prepend(content);
-      } else if (data_type === 'strategy') {
-        $('#strategies_list').prepend(content);
-      }
+    // Update moments/strategies form
+    var wrapper = "<div id=\"" + json.wrapper_id + "\" class=\"display_block\">";
+    var content = wrapper + json.checkbox + json.label + "</div>";
+    if (data_type === 'category') {
+      $('#categories_list').prepend(content);
+    } else if (data_type === 'mood') {
+      $('#moods_list').prepend(content);
+    } else if (data_type === 'strategy') {
+      $('#strategies_list').prepend(content);
+    }
 
-      // Checking the newly added checkbox.
-      var id = $(json.checkbox).attr('id');
-      $('#' + id).prop('checked', true);
+    // Checking the newly added checkbox.
+    var id = $(json.checkbox).attr('id');
+    $('#' + id).prop('checked', true);
 
-      addToAutocomplete(json);
+    addToAutocomplete(json);
 
-      $(form).trigger('reset');
-      $('.quick_create_close').click();
+    $(form).trigger('reset');
+    $('.quick_create_close').click();
   });
 }
 

--- a/app/assets/javascripts/strategies.js
+++ b/app/assets/javascripts/strategies.js
@@ -1,20 +1,20 @@
 var showTaggedMoments = function() {
-	$('#moment_tag_usage').addClass('display_block').removeClass('display_none');
-	$('#showTaggedMoments').addClass('display_none').removeClass('display_inline_block');
-	$('#hideTaggedMoments').addClass('display_inline_block').removeClass('display_none');
+  $('#moment_tag_usage').addClass('display_block').removeClass('display_none');
+  $('#showTaggedMoments').addClass('display_none').removeClass('display_inline_block');
+  $('#hideTaggedMoments').addClass('display_inline_block').removeClass('display_none');
 };
 
 var hideTaggedMoments = function() {
-	$('#moment_tag_usage').removeClass('display_block').addClass('display_none');
-	$('#showTaggedMoments').removeClass('display_none').addClass('display_inline_block');
-	$('#hideTaggedMoments').removeClass('display_inline_block').addClass('display_none');
+  $('#moment_tag_usage').removeClass('display_block').addClass('display_none');
+  $('#showTaggedMoments').removeClass('display_none').addClass('display_inline_block');
+  $('#hideTaggedMoments').removeClass('display_inline_block').addClass('display_none');
 };
 
 var onReadyStrategies = function() {
-	if (isShow(['strategies'])) {
-		$('#showTaggedMoments').click(showTaggedMoments);
-		$('#hideTaggedMoments').click(hideTaggedMoments);
-	}
+  if (isShow(['strategies'])) {
+    $('#showTaggedMoments').click(showTaggedMoments);
+    $('#hideTaggedMoments').click(hideTaggedMoments);
+  }
 };
 
 loadPage(onReadyStrategies);

--- a/app/assets/javascripts/toggle_locale.js
+++ b/app/assets/javascripts/toggle_locale.js
@@ -1,37 +1,37 @@
 function whenSignedOut(locale, previousLocale) {
-	if (locale !== previousLocale) {
-		window.document.cookie = "locale=" + locale;
-		window.location.reload();
-	}
+  if (locale !== previousLocale) {
+    window.document.cookie = "locale=" + locale;
+    window.location.reload();
+  }
 }
 
 function toggleLocale(locale, previousLocale) {
-	$.ajax({
-		url: "/toggle_locale",
-		data: {
-			locale: locale
-		}
-	}).done(function(data) {
-		if (data.signed_in_no_reload) {
-			Cookies.set("locale", data.signed_in_no_reload);
-		} else if (data.signed_in_reload) {
-			Cookies.set("locale", data.signed_in_reload);
-			window.location.reload();
-		} else {
-			whenSignedOut(locale, previousLocale);
-		}
-	});
+  $.ajax({
+    url: "/toggle_locale",
+    data: {
+      locale: locale
+    }
+  }).done(function(data) {
+    if (data.signed_in_no_reload) {
+      Cookies.set("locale", data.signed_in_no_reload);
+    } else if (data.signed_in_reload) {
+      Cookies.set("locale", data.signed_in_reload);
+      window.location.reload();
+    } else {
+      whenSignedOut(locale, previousLocale);
+    }
+  });
 }
 
 onReadyToggleLocale = function() {
-	$("#locale").change(function() {
-		if ($(this).val()) {
-			var previousLocale = Cookies.get("locale");
-			var updatedLocale = $(this).val();
-			Cookies.set("locale", updatedLocale);
-			toggleLocale(updatedLocale, previousLocale);
-		}
-	});
+  $("#locale").change(function() {
+    if ($(this).val()) {
+      var previousLocale = Cookies.get("locale");
+      var updatedLocale = $(this).val();
+      Cookies.set("locale", updatedLocale);
+      toggleLocale(updatedLocale, previousLocale);
+    }
+  });
 };
 
 loadPage(onReadyToggleLocale);

--- a/app/assets/javascripts/viewers.js
+++ b/app/assets/javascripts/viewers.js
@@ -1,9 +1,9 @@
 var onReadyViewers = function() {
   if (newOrEdit(["moments", "strategies"])) {
-  	$("#viewers_all").click(function() {
-  		$("#viewers_list :checkbox").prop("checked", $(this).prop("checked"));
-  	});
-	}
+    $("#viewers_all").click(function() {
+      $("#viewers_list :checkbox").prop("checked", $(this).prop("checked"));
+    });
+  }
 };
 
 loadPage(onReadyViewers);

--- a/app/assets/stylesheets/application/allies.scss
+++ b/app/assets/stylesheets/application/allies.scss
@@ -5,16 +5,16 @@
 /* Allies */
 
 .location {
-	color: $secondary-text-color;
-	opacity: 0.5;
+  color: $secondary-text-color;
+  opacity: 0.5;
 }
 
 #allies_search {
-	text-align: center;
+  text-align: center;
 }
 
 #invitations {
-	#user_email {
-		width: 100%;
-	}
+  #user_email {
+    width: 100%;
+  }
 }

--- a/app/assets/stylesheets/application/comments.scss
+++ b/app/assets/stylesheets/application/comments.scss
@@ -5,109 +5,109 @@
 /* Comments */
 
 .comment {
-	margin-top: 40px;
-	padding: 20px;
-	background-color: $background-color;
-	border: 2px solid $secondary-text-color;
+  margin-top: 40px;
+  padding: 20px;
+  background-color: $background-color;
+  border: 2px solid $secondary-text-color;
 
-	div.table {
-		display: table;
-		table-layout: auto;
-		width: 100%;
-		border-collapse: separate;
+  div.table {
+    display: table;
+    table-layout: auto;
+    width: 100%;
+    border-collapse: separate;
 
-		@media screen and (max-width: $medium) {
-			.padding_right {
-				padding-right: 10px !important;
-			}
-		}
+    @media screen and (max-width: $medium) {
+      .padding_right {
+        padding-right: 10px !important;
+      }
+    }
 
-		@media screen and (max-width: $small) {
-			.vertical_align_middle {
-				vertical-align: top !important;
-			}
-		}
-	}
+    @media screen and (max-width: $small) {
+      .vertical_align_middle {
+        vertical-align: top !important;
+      }
+    }
+  }
 
-	div.table div.table_row {
-		display: table-row;
-	}
+  div.table div.table_row {
+    display: table-row;
+  }
 
-	div.table div.table_cell {
-		display: table-cell;
-		word-break: break-word;
-	}
+  div.table div.table_cell {
+    display: table-cell;
+    word-break: break-word;
+  }
 
-	.align_left {
-		float: left;
-		display: inline-block;
-	}
+  .align_left {
+    float: left;
+    display: inline-block;
+  }
 
-	.align_right {
-		float: right;
-		display: inline-block;
-	}
+  .align_right {
+    float: right;
+    display: inline-block;
+  }
 
-	.delete_comment {
-		padding-left: 20px;
-		text-align: right;
-	}
+  .delete_comment {
+    padding-left: 20px;
+    text-align: right;
+  }
 
-	@media screen and (max-width: $medium) {
-		margin-top: 20px;
-		padding: 10px;
+  @media screen and (max-width: $medium) {
+    margin-top: 20px;
+    padding: 10px;
 
-		.delete_comment {
-			padding-left: 10px;
-		}
-	}
+    .delete_comment {
+      padding-left: 10px;
+    }
+  }
 
-	@media screen and (max-width: $small) {
-		.delete_comment {
-			padding-left: 5px;
-		}
-	}
+  @media screen and (max-width: $small) {
+    .delete_comment {
+      padding-left: 5px;
+    }
+  }
 }
 
 .comment_info {
-	color: $secondary-text-color;
-	padding-bottom: 10px;
-	padding-left: 10px;
-	padding-right: 10px;
-	border-bottom: 1px solid $subtle-secondary-text-color;
+  color: $secondary-text-color;
+  padding-bottom: 10px;
+  padding-left: 10px;
+  padding-right: 10px;
+  border-bottom: 1px solid $subtle-secondary-text-color;
 
-	@media screen and (max-width: $small) {
-		font-size: $font16;
-	}
+  @media screen and (max-width: $small) {
+    font-size: $font16;
+  }
 }
 
 .comment a:link,
 .comment a:visited,
 .comment a:hover {
-	color: $secondary-text-color;
-	border-color: $secondary-text-color;
+  color: $secondary-text-color;
+  border-color: $secondary-text-color;
 }
 
 .delete_comment a:link,
 .delete_comment a:visited,
 .delete_comment a:hover {
-	color: $secondary-text-color;
-	border: none;
+  color: $secondary-text-color;
+  border: none;
 }
 
 .comment_text {
-	word-wrap: break-word;
-	padding: 10px;
-	font-weight: 300;
+  word-wrap: break-word;
+  padding: 10px;
+  font-weight: 300;
 }
 
 .comment_textarea {
-	width: 100%;
-	margin: 0px !important;
+  width: 100%;
+  margin: 0px !important;
 }
 
 @media screen and (max-width: $medium) {
-	#comment_visibility {
-		margin-bottom: 10px;
-	}
+  #comment_visibility {
+    margin-bottom: 10px;
+  }
 }

--- a/app/assets/stylesheets/application/footer.scss
+++ b/app/assets/stylesheets/application/footer.scss
@@ -5,165 +5,165 @@
 /* Footer */
 
 #footer {
-	background-color: $secondary-background-color;
-	padding: 40px 0px;
+  background-color: $secondary-background-color;
+  padding: 40px 0px;
 
-	@media screen and (max-width: $medium) {
-		padding: 20px 0px;
-	}
+  @media screen and (max-width: $medium) {
+    padding: 20px 0px;
+  }
 
-	.license {
-		text-align: right;
-		color: $secondary-text-color;
+  .license {
+    text-align: right;
+    color: $secondary-text-color;
 
-		@media screen and (max-width: $small) {
-			text-align: center;
-		}
-	}
+    @media screen and (max-width: $small) {
+      text-align: center;
+    }
+  }
 
-	.footer_subtitle {
-		font-size: $small-font;
+  .footer_subtitle {
+    font-size: $small-font;
 
-		@media screen and (max-width: $medium) {
-			font-size: $font12;
-		}
+    @media screen and (max-width: $medium) {
+      font-size: $font12;
+    }
 
-		a:link, a:visited, a:hover {
-			display: inline;
-			color: $secondary-text-color;
-		}
-	}
+    a:link, a:visited, a:hover {
+      display: inline;
+      color: $secondary-text-color;
+    }
+  }
 }
 
 #footer_content {
-	padding: 0px 60px;
-	color: $footer-text-color;
-	line-height: 30px;
+  padding: 0px 60px;
+  color: $footer-text-color;
+  line-height: 30px;
 
-	@media screen and (max-width: $medium) {
-		padding: 0px 20px;
-		line-height: 26px;
-	}
+  @media screen and (max-width: $medium) {
+    padding: 0px 20px;
+    line-height: 26px;
+  }
 
-	@media screen and (max-width: $small) {
-		text-align: center;
-	}
+  @media screen and (max-width: $small) {
+    text-align: center;
+  }
 }
 
 #footer a:link,
 #footer a:visited {
-	text-decoration: none;
-	color: $footer-text-color;
-	border: none;
-	display: block;
-	margin: 0;
+  text-decoration: none;
+  color: $footer-text-color;
+  border: none;
+  display: block;
+  margin: 0;
 
-	@media screen and (max-width: $small) {
-		text-align: center;
-	}
+  @media screen and (max-width: $small) {
+    text-align: center;
+  }
 }
 
 #footer a:hover {
-	text-decoration: none;
-	color: $footer-text-color;
-	border: none;
-	opacity: 0.5;
-	display: block;
-	margin: 0;
+  text-decoration: none;
+  color: $footer-text-color;
+  border: none;
+  opacity: 0.5;
+  display: block;
+  margin: 0;
 
-	@media screen and (max-width: $small) {
-		text-align: center;
-	}
+  @media screen and (max-width: $small) {
+    text-align: center;
+  }
 }
 
 #footer .padding_right {
-	padding-right: 40px !important;
+  padding-right: 40px !important;
 
-	@media screen and (max-width: $medium) {
-		padding-right: 20px !important;
-	}
+  @media screen and (max-width: $medium) {
+    padding-right: 20px !important;
+  }
 
-	@media screen and (max-width: $small) {
-		padding-right: 0 !important;
-	}
+  @media screen and (max-width: $small) {
+    padding-right: 0 !important;
+  }
 }
 
 @media screen and (min-width: $small + 1) {
-	#footer .align_left {
-		float: left;
-		display: inline-block;
-	}
+  #footer .align_left {
+    float: left;
+    display: inline-block;
+  }
 
-	#footer .align_right {
-		float: right;
-		display: inline-block;
-	}
+  #footer .align_right {
+    float: right;
+    display: inline-block;
+  }
 
-	#footer div.table div.table_row {
-		display: table-row;
-	}
+  #footer div.table div.table_row {
+    display: table-row;
+  }
 
-	#footer div.table div.table_cell {
-		display: table-cell;
-		word-break: break-word;
-	}
+  #footer div.table div.table_cell {
+    display: table-cell;
+    word-break: break-word;
+  }
 
-	.large_padding_right {
-		padding-right: 80px;
-	}
+  .large_padding_right {
+    padding-right: 80px;
+  }
 
-	@media screen and (max-width: $medium) {
-		.large_padding_right {
-			padding-right: 40px;
-		}
-	}
+  @media screen and (max-width: $medium) {
+    .large_padding_right {
+      padding-right: 40px;
+    }
+  }
 }
 
 @media screen and (max-width: $small) {
-	#footer .align_left {
-		display: block;
-		text-align: left;
-		text-align: center;
-	}
+  #footer .align_left {
+    display: block;
+    text-align: left;
+    text-align: center;
+  }
 
-	#footer .align_right {
-		display: block;
-		text-align: left;
-		text-align: center;
-	}
+  #footer .align_right {
+    display: block;
+    text-align: left;
+    text-align: center;
+  }
 
-	#feedback {
-		margin-bottom: 10px !important;
-	}
+  #feedback {
+    margin-bottom: 10px !important;
+  }
 
-	#if_me_links {
-		margin-top: 0 !important;
-	}
+  #if_me_links {
+    margin-top: 0 !important;
+  }
 }
 
 .footer_heading {
-	text-transform: lowercase;
-	font-weight: 300;
-	font-size: $font30;
-	padding: 0;
-	margin-top: 0;
-	margin-bottom: 20px;
-	display: block;
-	color: $footer-text-color;
+  text-transform: lowercase;
+  font-weight: 300;
+  font-size: $font30;
+  padding: 0;
+  margin-top: 0;
+  margin-bottom: 20px;
+  display: block;
+  color: $footer-text-color;
 
-	@media screen and (max-width: $medium) {
-		font-size: $font26;
-		margin-top: 0;
-		margin-bottom: 10px;
-	}
+  @media screen and (max-width: $medium) {
+    font-size: $font26;
+    margin-top: 0;
+    margin-bottom: 10px;
+  }
 
-	@media screen and (max-width: $small) {
-		text-align: center;
-		margin-top: 10px;
-	}
+  @media screen and (max-width: $small) {
+    text-align: center;
+    margin-top: 10px;
+  }
 }
 
 #connect_links ~ a .fa {
-	text-align: center;
-	width: 1em;
+  text-align: center;
+  width: 1em;
 }

--- a/app/assets/stylesheets/application/profile.scss
+++ b/app/assets/stylesheets/application/profile.scss
@@ -5,14 +5,14 @@
 /* Profiles */
 
 @media screen and (max-width: $medium) {
-	#profile_info {
-		text-align: center;
+  #profile_info {
+    text-align: center;
 
-		.profile_picture_div {
-			margin-left: auto;
-			margin-right: auto;
-			margin-top: 0px;
-			margin-bottom: 10px;
-		}
-	}
+    .profile_picture_div {
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 0px;
+      margin-bottom: 10px;
+    }
+  }
 }

--- a/app/assets/stylesheets/application/registrations.scss
+++ b/app/assets/stylesheets/application/registrations.scss
@@ -3,7 +3,7 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 @media screen and (max-width: $medium) {
-	#user_password {
-		margin-bottom: 20px;
-	}
+  #user_password {
+    margin-bottom: 20px;
+  }
 }

--- a/app/assets/stylesheets/application/strategy.scss
+++ b/app/assets/stylesheets/application/strategy.scss
@@ -3,7 +3,7 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 @media screen and (max-width: $medium) {
-	#strategy_comment {
-		margin: 0;
-	}
+  #strategy_comment {
+    margin: 0;
+  }
 }

--- a/app/controllers/allies_controller.rb
+++ b/app/controllers/allies_controller.rb
@@ -13,6 +13,7 @@ class AlliesController < ApplicationController
                                           .sort_by! { |n| n.name.downcase }
   end
 
+  # rubocop:disable MethodLength
   def add
     ally_id = params[:ally_id]
     allyship = Allyship.find_by(
@@ -20,11 +21,8 @@ class AlliesController < ApplicationController
     )
 
     pusher_type = allyship ? 'accepted_ally_request' : 'new_ally_request'
-
     setup_allyship(allyship, ally_id)
-
     remove_allyship_request(ally_id)
-
     handle_allyship_notifications(pusher_type, ally_id)
 
     respond_to do |format|
@@ -32,6 +30,7 @@ class AlliesController < ApplicationController
       format.json { head :no_content }
     end
   end
+  # rubocop:enable MethodLength
 
   def remove
     user_id = current_user.id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ module UserRelation
   OTHER = 4
 end
 
+# rubocop:disable ClassLength
 class ApplicationController < ActionController::Base
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::DateHelper
@@ -16,7 +17,8 @@ class ApplicationController < ActionController::Base
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :null_session, if: proc { |c| c.request.format == 'application/json' }
+  protect_from_forgery with: :null_session,
+                       if: proc { |c| c.request.format == 'application/json' }
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :if_not_signed_in, unless: :devise_controller?
 
@@ -77,7 +79,7 @@ class ApplicationController < ActionController::Base
                                                invitation_token]
   end
 
-  helper_method :avatar_url, :is_viewer,
+  helper_method :avatar_url, :viewer_of?,
                 :are_allies?, :get_uid, :most_focus,
                 :tag_usage, :can_notify, :if_not_signed_in,
                 :generate_comment, :get_stories, :moments_stats
@@ -96,7 +98,7 @@ class ApplicationController < ActionController::Base
     users.first.mutual_allies?(users.last)
   end
 
-  def is_viewer(viewers)
+  def viewer_of?(viewers)
     viewers.include? current_user.id
   end
 
@@ -104,6 +106,7 @@ class ApplicationController < ActionController::Base
     User.find(userid).uid
   end
 
+  # rubocop:disable MethodLength
   def most_focus(data_type, profile_id)
     data = []
     userid = profile_id || current_user.id
@@ -135,7 +138,9 @@ class ApplicationController < ActionController::Base
 
     data.empty? ? {} : top_three_focus(data)
   end
+  # rubocop:enable MethodLength
 
+  # rubocop:disable MethodLength
   def tag_usage(data_id, data_type, userid)
     result = []
     moments = user_moments(userid).order('created_at DESC')
@@ -155,7 +160,9 @@ class ApplicationController < ActionController::Base
     end
     result
   end
+  # rubocop:enable MethodLength
 
+  # rubocop:disable MethodLength
   def generate_comment(data, data_type)
     profile = User.find(data.comment_by)
     profile_picture = ProfilePicture.fetch(profile.avatar.url,
@@ -189,9 +196,19 @@ class ApplicationController < ActionController::Base
       delete_comment += '</div>'
     end
 
-    { commentid: data.id, profile_picture: profile_picture, comment_info: comment_info, comment_text: comment_text, visibility: visibility, delete_comment: delete_comment, no_save: false }
+    {
+      commentid: data.id,
+      profile_picture: profile_picture,
+      comment_info: comment_info,
+      comment_text: comment_text,
+      visibility: visibility,
+      delete_comment: delete_comment,
+      no_save: false
+    }
   end
+  # rubocop:enable MethodLength
 
+  # rubocop:disable MethodLength
   def get_stories(user, include_allies)
     if user.id == current_user.id
       my_moments = user.moments.all.recent
@@ -222,11 +239,14 @@ class ApplicationController < ActionController::Base
 
     stories.sort_by(&:created_at).reverse!
   end
+  # rubocop:enable MethodLength
 
+  # rubocop:disable MethodLength
   def moments_stats
     result = ''
     count = current_user.moments.all.count
 
+    # rubocop:disable BlockNesting
     if count > 1
       result += '<div class="center" id="stats">'
 
@@ -235,22 +255,28 @@ class ApplicationController < ActionController::Base
       else
         result += t('stats.total_moments', count: count.to_s)
 
-        monthly_count = current_user.moments.where(created_at: Time.zone.now.beginning_of_month..Time.zone.now.end_of_month).all.count
+        beginning_of_month = Time.current.beginning_of_month
+        end_of_month = Time.current.end_of_month
+        monthly_count = current_user.moments.where(
+          created_at: beginning_of_month..end_of_month
+        ).all.count
         if count != monthly_count
           result += ' '
-          if monthly_count == 1
-            result += t('stats.monthly_moment', count: monthly_count.to_s)
-          else
-            result += t('stats.monthly_moments', count: monthly_count.to_s)
-          end
+          result += if monthly_count == 1
+                      t('stats.monthly_moment', count: monthly_count.to_s)
+                    else
+                      t('stats.monthly_moments', count: monthly_count.to_s)
+                    end
         end
       end
 
       result += '</div>'
     end
+    # rubocop:enable BlockNesting
 
     result
   end
+  # rubocop:enable MethodLength
 
   private
 
@@ -259,6 +285,7 @@ class ApplicationController < ActionController::Base
     data_id.in?(data[data_type])
   end
 
+  # rubocop:disable MethodLength
   def top_three_focus(data)
     result, freq = {}
     3.times do
@@ -272,6 +299,7 @@ class ApplicationController < ActionController::Base
     end
     result
   end
+  # rubocop:enable MethodLength
 
   def profile_exists?(profile, data)
     profile.present? &&
@@ -279,6 +307,7 @@ class ApplicationController < ActionController::Base
        data.viewers.include?(current_user.id))
   end
 
+  # rubocop:disable MethodLength
   def user_created_data?(id, data_type)
     case data_type
     when 'moment'
@@ -292,6 +321,7 @@ class ApplicationController < ActionController::Base
       false
     end
   end
+  # rubocop:enable MethodLength
 
   def comment_deletable?(data, data_type)
     data.comment_by == current_user.id ||
@@ -320,6 +350,7 @@ class ApplicationController < ActionController::Base
     set_show_with_comments_variables(subject, model_name)
   end
 
+  # rubocop:disable MethodLength
   def set_show_with_comments_variables(subject, model_name)
     if current_user.id == subject.userid
       @page_edit = send("edit_#{model_name}_path", subject)
@@ -330,6 +361,7 @@ class ApplicationController < ActionController::Base
                              profile_index_path(uid: get_uid(ally.id)))
     end
     @no_hide_page = true
+    # rubocop:disable GuardClause
     if subject.comment
       @comment = Comment.new
       @comments = Comment.where(
@@ -337,7 +369,9 @@ class ApplicationController < ActionController::Base
         commentable_type: model_name
       ).order(created_at: :desc)
     end
+    # rubocop:enable GuardClause
   end
+  # rubocop:enable MethodLength
 
   def record_model_name(record)
     record.class.name.downcase
@@ -375,6 +409,7 @@ class ApplicationController < ActionController::Base
     Moment.where(userid: userid)
   end
 
+  # rubocop:disable MethodLength
   def user_stories(user, collection)
     resources = []
     case collection
@@ -389,4 +424,6 @@ class ApplicationController < ActionController::Base
     end
     resources
   end
+  # rubocop:enable MethodLength
 end
+# rubocop:enable ClassLength

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -194,7 +194,7 @@ class ApplicationController < ActionController::Base
 
   def get_stories(user, include_allies)
     if user.id == current_user.id
-      my_moments = Moment.where(userid: user.id).all.recent
+      my_moments = user.moments.all.recent
       my_strategies = Strategy.where(userid: user.id).all.recent
     end
 
@@ -225,7 +225,7 @@ class ApplicationController < ActionController::Base
 
   def moments_stats
     result = ''
-    count = Moment.where(userid: current_user.id).all.count
+    count = current_user.moments.all.count
 
     if count > 1
       result += '<div class="center" id="stats">'
@@ -235,7 +235,7 @@ class ApplicationController < ActionController::Base
       else
         result += t('stats.total_moments', count: count.to_s)
 
-        monthly_count = Moment.where(userid: current_user.id, created_at: Time.zone.now.beginning_of_month..Time.zone.now.end_of_month).all.count
+        monthly_count = current_user.moments.where(created_at: Time.zone.now.beginning_of_month..Time.zone.now.end_of_month).all.count
         if count != monthly_count
           result += ' '
           if monthly_count == 1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -195,7 +195,7 @@ class ApplicationController < ActionController::Base
   def get_stories(user, include_allies)
     if user.id == current_user.id
       my_moments = user.moments.all.recent
-      my_strategies = Strategy.where(userid: user.id).all.recent
+      my_strategies = user.strategies.all.recent
     end
 
     if include_allies && user.id == current_user.id

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -79,7 +79,7 @@ class CategoriesController < ApplicationController
   # DELETE /categories/1.json
   def destroy
     # Remove categories from existing moments
-    @moments = Moment.where(userid: current_user.id).all
+    @moments = current_user.moments.all
 
     @moments.each do |item|
       item.category.delete(@category.id)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable ClassLength
 class CategoriesController < ApplicationController
   include CollectionPageSetup
   include QuickCreate
@@ -37,6 +38,7 @@ class CategoriesController < ApplicationController
 
   # POST /categories
   # POST /categories.json
+  # rubocop:disable MethodLength
   def create
     @category = Category.new(category_params.merge(userid: current_user.id))
     respond_to do |format|
@@ -45,24 +47,46 @@ class CategoriesController < ApplicationController
         format.json { render :show, status: :created, location: @category }
       else
         format.html { render :new }
-        format.json { render json: @category.errors, status: :unprocessable_entity }
+        format.json do
+          render json: @category.errors, status: :unprocessable_entity
+        end
       end
     end
   end
+  # rubocop:enable MethodLength
 
   # POST /categories
   # POST /categories.json
+  # rubocop:disable MethodLength
   def premade
-    Category.create(userid: current_user.id, name: t('categories.index.premade1_name'), description: t('categories.index.premade1_description'))
-    Category.create(userid: current_user.id, name: t('categories.index.premade2_name'), description: t('categories.index.premade2_description'))
-    Category.create(userid: current_user.id, name: t('categories.index.premade3_name'), description: t('categories.index.premade3_description'))
-    Category.create(userid: current_user.id, name: t('categories.index.premade4_name'), description: t('categories.index.premade4_description'))
+    Category.create(
+      userid: current_user.id,
+      name: t('categories.index.premade1_name'),
+      description: t('categories.index.premade1_description')
+    )
+    Category.create(
+      userid: current_user.id,
+      name: t('categories.index.premade2_name'),
+      description: t('categories.index.premade2_description')
+    )
+    Category.create(
+      userid: current_user.id,
+      name: t('categories.index.premade3_name'),
+      description: t('categories.index.premade3_description')
+    )
+    Category.create(
+      userid: current_user.id,
+      name: t('categories.index.premade4_name'),
+      description: t('categories.index.premade4_description')
+    )
 
     redirect_to_path(categories_path)
   end
+  # rubocop:enable MethodLength
 
   # PATCH/PUT /categories/1
   # PATCH/PUT /categories/1.json
+  # rubocop:disable MethodLength
   def update
     respond_to do |format|
       if @category.update(category_params)
@@ -70,10 +94,13 @@ class CategoriesController < ApplicationController
         format.json { render :show, status: :ok, location: @category }
       else
         format.html { render :edit }
-        format.json { render json: @category.errors, status: :unprocessable_entity }
+        format.json do
+          render json: @category.errors, status: :unprocessable_entity
+        end
       end
     end
   end
+  # rubocop:enable MethodLength
 
   # DELETE /categories/1
   # DELETE /categories/1.json
@@ -92,8 +119,13 @@ class CategoriesController < ApplicationController
     redirect_to_path(categories_path)
   end
 
+  # rubocop:disable MethodLength
   def quick_create
-    category = Category.new(userid: current_user.id, name: params[:category][:name], description: params[:category][:description])
+    category = Category.new(
+      userid: current_user.id,
+      name: params[:category][:name],
+      description: params[:category][:description]
+    )
 
     if category.save
       tag = params[:category][:tag].to_s
@@ -104,17 +136,21 @@ class CategoriesController < ApplicationController
 
     respond_with_json(result)
   end
+  # rubocop:enable MethodLength
 
   private
 
   # Use callbacks to share common setup or constraints between actions.
+  # rubocop:disable RescueStandardError
   def set_category
     @category = Category.friendly.find(params[:id])
   rescue
     redirect_to_path(categories_path)
   end
+  # rubocop:enable RescueStandardError
 
   def category_params
     params.require(:category).permit(:name, :description)
   end
 end
+# rubocop:enable ClassLength

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable ClassLength
 class GroupsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_group, only: %i[show edit update destroy]
@@ -54,6 +55,7 @@ class GroupsController < ApplicationController
 
   # PATCH/PUT /groups/1
   # PATCH/PUT /groups/1.json
+  # rubocop:disable MethodLength
   def update
     respond_to do |format|
       if @group.update(group_params)
@@ -63,10 +65,13 @@ class GroupsController < ApplicationController
         format.json { head :no_content }
       else
         format.html { render :edit }
-        format.json { render json: @group.errors, status: :unprocessable_entity }
+        format.json do
+          render json: @group.errors, status: :unprocessable_entity
+        end
       end
     end
   end
+  # rubocop:enable MethodLength
 
   def join
     @group_member = GroupMember.create!(group_member_params)
@@ -78,9 +83,13 @@ class GroupsController < ApplicationController
     redirect_to_group
   end
 
+  # rubocop:disable MethodLength
   def leave
     member_id = params[:memberid] || current_user.id
-    group_member = GroupMember.find_by(userid: member_id, groupid: params[:groupid])
+    group_member = GroupMember.find_by(
+      userid: member_id,
+      groupid: params[:groupid]
+    )
     group = group_member.group
 
     # Cannot leave When you are the only leader
@@ -89,16 +98,19 @@ class GroupsController < ApplicationController
     else
       group_member.destroy
 
-      if member_id == current_user.id
-        flash[:notice] = t('groups.leave.success', group: group.name)
-      else
-        flash[:notice] = t('groups.leave.remove_member_success',
+      flash[:notice] = if member_id == current_user.id
+                         t('groups.leave.success', group: group.name)
+                       else
+                         t(
+                           'groups.leave.remove_member_success',
                            user: group_member.user.name,
-                           group: group.name)
-      end
+                           group: group.name
+                         )
+                       end
     end
     redirect_to_index
   end
+  # rubocop:enable MethodLength
 
   # DELETE /groups/1
   # DELETE /groups/1.json
@@ -160,3 +172,4 @@ class GroupsController < ApplicationController
     end
   end
 end
+# rubocop:enable ClassLength

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -97,11 +97,13 @@ class MedicationsController < ApplicationController
   end
 
   # Use callbacks to share common setup or constraints between actions.
+  # rubocop:disable RescueStandardError
   def set_medication
     @medication = Medication.friendly.find(params[:id])
   rescue
     redirect_to_path(medications_path)
   end
+  # rubocop:enable RescueStandardError
 
   def medication_params
     params.require(:medication).permit(

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -434,12 +434,12 @@ class MeetingsController < ApplicationController
   end
 
   def hide_page(meeting)
-    _meeting = Meeting.where(id: meeting.id)
-    _meeting_member = MeetingMember.where(
+    meeting_obj = Meeting.where(id: meeting.id)
+    meeting_member = MeetingMember.where(
       meetingid: meeting.id,
       userid: current_user.id
     )
-    !(_meeting.exists? && _meeting_member.exists?)
+    !(meeting_obj.exists? && meeting_member.exists?)
   end
 end
 # rubocop:enable ClassLength

--- a/app/controllers/moments_controller.rb
+++ b/app/controllers/moments_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable ClassLength
 class MomentsController < ApplicationController
   include CollectionPageSetup
 
@@ -7,6 +8,7 @@ class MomentsController < ApplicationController
 
   # GET /moments
   # GET /moments.json
+  # rubocop:disable MethodLength
   def index
     if current_user
       @user_logged_in = true
@@ -26,6 +28,7 @@ class MomentsController < ApplicationController
 
     page_collection('@moments', 'moment')
   end
+  # rubocop:enable MethodLength
 
   # GET /moments/1
   # GET /moments/1.json
@@ -37,14 +40,18 @@ class MomentsController < ApplicationController
     comment_for('moment')
   end
 
+  # rubocop:disable MethodLength
   def delete_comment
     comment_exists = Comment.where(id: params[:commentid]).exists?
-    is_my_comment = Comment.where(id: params[:commentid], comment_by: current_user.id).exists?
+    is_my_comment = Comment.where(
+      id: params[:commentid],
+      comment_by: current_user.id
+    ).exists?
 
     if comment_exists
       momentid = Comment.where(id: params[:commentid]).first.commentable_id
       is_my_moment = Moment.where(id: momentid, userid: current_user.id).exists?
-      is_a_viewer = is_viewer(Moment.where(id: momentid).first.viewers)
+      is_a_viewer = viewer_of?(Moment.where(id: momentid).first.viewers)
     else
       is_my_moment = false
       is_a_viewer = false
@@ -63,7 +70,9 @@ class MomentsController < ApplicationController
 
     head :ok
   end
+  # rubocop:enable MethodLength
 
+  # rubocop:disable MethodLength
   def quick_moment
     # Assumme all viewers and comments allowed
     viewers = []
@@ -87,6 +96,7 @@ class MomentsController < ApplicationController
       format.json { render root_path }
     end
   end
+  # rubocop:enable MethodLength
 
   # GET /moments/new
   def new
@@ -105,6 +115,7 @@ class MomentsController < ApplicationController
 
   # POST /moments
   # POST /moments.json
+  # rubocop:disable MethodLength
   def create
     @moment = Moment.new(moment_params.merge(userid: current_user.id))
     @viewers = current_user.allies_by_status(:accepted)
@@ -118,13 +129,17 @@ class MomentsController < ApplicationController
         format.json { render :show, status: :created, location: @moment }
       else
         format.html { render :new }
-        format.json { render json: @moment.errors, status: :unprocessable_entity }
+        format.json do
+          render json: @moment.errors, status: :unprocessable_entity
+        end
       end
     end
   end
+  # rubocop:enable MethodLength
 
   # PATCH/PUT /moments/1
   # PATCH/PUT /moments/1.json
+  # rubocop:disable MethodLength
   def update
     @viewers = current_user.allies_by_status(:accepted)
     @category = Category.new
@@ -144,10 +159,13 @@ class MomentsController < ApplicationController
         format.json { render :show, status: :ok, location: @moment }
       else
         format.html { render :edit }
-        format.json { render json: @moment.errors, status: :unprocessable_entity }
+        format.json do
+          render json: @moment.errors, status: :unprocessable_entity
+        end
       end
     end
   end
+  # rubocop:enable MethodLength
 
   # DELETE /moments/1
   # DELETE /moments/1.json
@@ -158,11 +176,13 @@ class MomentsController < ApplicationController
 
   private
 
+  # rubocop:disable RescueStandardError
   def set_moment
     @moment = Moment.friendly.find(params[:id])
   rescue
     redirect_to_path(moments_path)
   end
+  # rubocop:enable RescueStandardError
 
   def moment_params
     params.require(:moment).permit(
@@ -224,3 +244,4 @@ class MomentsController < ApplicationController
     end
   end
 end
+# rubocop:enable ClassLength

--- a/app/controllers/moments_controller.rb
+++ b/app/controllers/moments_controller.rb
@@ -186,10 +186,10 @@ class MomentsController < ApplicationController
 
   def associated_strategies
     # current_user's strategies and all viewable strategies from allies
-    strategy_ids = Strategy.where(user: current_user).pluck(:id)
+    strategy_ids = current_user.strategies.pluck(:id)
 
     @viewers.each do |ally|
-      Strategy.where(userid: ally.id).each do |strategy|
+      ally.strategies.each do |strategy|
         strategy_ids << strategy.id if strategy.viewer?(current_user)
       end
     end

--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -78,7 +78,7 @@ class MoodsController < ApplicationController
   # DELETE /moods/1.json
   def destroy
     # Remove moods from existing moments
-    @moments = Moment.where(userid: current_user.id).all
+    @moments = current_user.moments.all
 
     @moments.each do |item|
       item.mood.delete(@mood.id)

--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable ClassLength
 class MoodsController < ApplicationController
   include CollectionPageSetup
   include QuickCreate
@@ -50,15 +51,37 @@ class MoodsController < ApplicationController
 
   # POST /moods
   # POST /moods.json
+  # rubocop:disable MethodLength
   def premade
-    Mood.create(userid: current_user.id, name: t('moods.index.premade1_name'), description: t('moods.index.premade1_description'))
-    Mood.create(userid: current_user.id, name: t('moods.index.premade2_name'), description: t('moods.index.premade2_description'))
-    Mood.create(userid: current_user.id, name: t('moods.index.premade3_name'), description: t('moods.index.premade3_description'))
-    Mood.create(userid: current_user.id, name: t('moods.index.premade4_name'), description: t('moods.index.premade4_description'))
-    Mood.create(userid: current_user.id, name: t('moods.index.premade5_name'), description: t('moods.index.premade5_description'))
+    Mood.create(
+      userid: current_user.id,
+      name: t('moods.index.premade1_name'),
+      description: t('moods.index.premade1_description')
+    )
+    Mood.create(
+      userid: current_user.id,
+      name: t('moods.index.premade2_name'),
+      description: t('moods.index.premade2_description')
+    )
+    Mood.create(
+      userid: current_user.id,
+      name: t('moods.index.premade3_name'),
+      description: t('moods.index.premade3_description')
+    )
+    Mood.create(
+      userid: current_user.id,
+      name: t('moods.index.premade4_name'),
+      description: t('moods.index.premade4_description')
+    )
+    Mood.create(
+      userid: current_user.id,
+      name: t('moods.index.premade5_name'),
+      description: t('moods.index.premade5_description')
+    )
 
     redirect_to_path(moods_path)
   end
+  # rubocop:enable MethodLength
 
   # PATCH/PUT /moods/1
   # PATCH/PUT /moods/1.json
@@ -90,8 +113,13 @@ class MoodsController < ApplicationController
     redirect_to_path(moods_path)
   end
 
+  # rubocop:disable MethodLength
   def quick_create
-    mood = Mood.new(userid: current_user.id, name: params[:mood][:name], description: params[:mood][:description])
+    mood = Mood.new(
+      userid: current_user.id,
+      name: params[:mood][:name],
+      description: params[:mood][:description]
+    )
 
     result = if mood.save
                render_checkbox(mood, 'mood', 'moment')
@@ -101,17 +129,21 @@ class MoodsController < ApplicationController
 
     respond_with_json(result)
   end
+  # rubocop:enable MethodLength
 
   private
 
   # Use callbacks to share common setup or constraints between actions.
+  # rubocop:disable RescueStandardError
   def set_mood
     @mood = Mood.friendly.find(params[:id])
   rescue
     redirect_to_path(moods_path)
   end
+  # rubocop:enable RescueStandardError
 
   def mood_params
     params.require(:mood).permit(:name, :description)
   end
 end
+# rubocop:enable ClassLength

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -39,6 +39,7 @@ class NotificationsController < ApplicationController
   private
 
   # Use callbacks to share common setup or constraints between actions.
+  # rubocop:disable RescueStandardError
   def set_notification
     @notification = Notification.find(params[:id])
   rescue
@@ -47,4 +48,5 @@ class NotificationsController < ApplicationController
       format.json { head :no_content }
     end
   end
+  # rubocop:enable RescueStandardError
 end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # rubocop:disable MethodLength
   def google_oauth2
-    @user = User.find_for_google_oauth2(request.env['omniauth.auth'], current_user)
+    @user = User.find_for_google_oauth2(
+      request.env['omniauth.auth'],
+      current_user
+    )
 
     if @user
       flash[:notice] = I18n.t('devise.omniauth_callbacks.success',
@@ -12,4 +16,5 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to new_user_session_path, notice: t('omniauth.access_denied')
     end
   end
+  # rubocop:enable MethodLength
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -8,9 +8,11 @@ class ProfileController < ApplicationController
 
     # Determine how the profile should be displayed based on the userid
     if user == current_user
-      @stories = Kaminari.paginate_array(get_stories(current_user, false)).page(params[:page])
+      @stories = Kaminari.paginate_array(get_stories(current_user, false))
+                         .page(params[:page])
     elsif current_user.allies_by_status(:accepted).include? user
-      @stories = Kaminari.paginate_array(get_stories(user, false)).page(params[:page])
+      @stories = Kaminari.paginate_array(get_stories(user, false))
+                         .page(params[:page])
     end
 
     @profile = user

--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class PusherController < ApplicationController
-  protect_from_forgery except: :auth # stop rails CSRF protection for this action
+  # stop rails CSRF protection for this action
+  protect_from_forgery except: :auth
 
   def auth
     if current_user

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable ClassLength
 class StrategiesController < ApplicationController
   include CollectionPageSetup
   include ReminderHelper
@@ -23,13 +24,20 @@ class StrategiesController < ApplicationController
     comment_for('strategy')
   end
 
+  # rubocop:disable MethodLength
   def delete_comment
     comment_exists = Comment.where(id: params[:commentid]).exists?
-    is_my_comment = Comment.where(id: params[:commentid], comment_by: current_user.id).exists?
+    is_my_comment = Comment.where(
+      id: params[:commentid],
+      comment_by: current_user.id
+    ).exists?
 
     if comment_exists
       strategyid = Comment.where(id: params[:commentid]).first.commentable_id
-      is_my_strategy = Strategy.where(id: strategyid, userid: current_user.id).exists?
+      is_my_strategy = Strategy.where(
+        id: strategyid,
+        userid: current_user.id
+      ).exists?
     else
       is_my_strategy = false
     end
@@ -41,13 +49,16 @@ class StrategiesController < ApplicationController
       public_uniqueid = 'comment_on_strategy_' + params[:commentid].to_s
       Notification.where(uniqueid: public_uniqueid).destroy_all
 
-      private_uniqueid = 'comment_on_strategy_private_' + params[:commentid].to_s
+      private_uniqueid = 'comment_on_strategy_private_' +
+                         params[:commentid].to_s
       Notification.where(uniqueid: private_uniqueid).destroy_all
     end
 
     head :ok
   end
+  # rubocop:enable MethodLength
 
+  # rubocop:disable MethodLength
   def quick_create
     # Assumme all viewers and comments allowed
     viewers = []
@@ -70,12 +81,15 @@ class StrategiesController < ApplicationController
 
     respond_with_json(result)
   end
+  # rubocop:enable MethodLength
 
   # GET /strategies/new
   def new
     @viewers = current_user.allies_by_status(:accepted)
     @strategy = Strategy.new
-    @categories = Category.where(userid: current_user.id).all.order('created_at DESC')
+    @categories = Category.where(userid: current_user.id)
+                          .all
+                          .order('created_at DESC')
     @category = Category.new
     @strategy.build_perform_strategy_reminder
   end
@@ -84,7 +98,9 @@ class StrategiesController < ApplicationController
   def edit
     if @strategy.userid == current_user.id
       @viewers = current_user.allies_by_status(:accepted)
-      @categories = Category.where(userid: current_user.id).all.order('created_at DESC')
+      @categories = Category.where(userid: current_user.id)
+                            .all
+                            .order('created_at DESC')
       @category = Category.new
       PerformStrategyReminder.find_or_initialize_by(strategy_id: @strategy.id)
     else
@@ -94,6 +110,7 @@ class StrategiesController < ApplicationController
 
   # POST /strategies
   # POST /strategies.json
+  # rubocop:disable MethodLength
   def create
     @strategy = Strategy.new(strategy_params.merge(userid: current_user.id))
     @viewers = current_user.allies_by_status(:accepted)
@@ -109,9 +126,11 @@ class StrategiesController < ApplicationController
       end
     end
   end
+  # rubocop:enable MethodLength
 
   # POST /strategies
   # POST /strategies.json
+  # rubocop:disable MethodLength
   def premade
     category = Category.find_by(name: 'Meditation', user: current_user)
     strategy = Strategy.new(
@@ -133,9 +152,11 @@ class StrategiesController < ApplicationController
       end
     end
   end
+  # rubocop:enable MethodLength
 
   # PATCH/PUT /strategies/1
   # PATCH/PUT /strategies/1.json
+  # rubocop:disable MethodLength
   def update
     @viewers = current_user.allies_by_status(:accepted)
     @category = Category.new
@@ -157,6 +178,7 @@ class StrategiesController < ApplicationController
       end
     end
   end
+  # rubocop:enable MethodLength
 
   # DELETE /strategies/1
   # DELETE /strategies/1.json
@@ -181,11 +203,13 @@ class StrategiesController < ApplicationController
   end
 
   # Use callbacks to share common setup or constraints between actions.
+  # rubocop:disable RescueStandardError
   def set_strategy
     @strategy = Strategy.friendly.find(params[:id])
   rescue
     redirect_to_path(strategies_path)
   end
+  # rubocop:enable RescueStandardError
 
   def strategy_params
     params.require(:strategy).permit(
@@ -209,3 +233,4 @@ class StrategiesController < ApplicationController
     end
   end
 end
+# rubocop:enable ClassLength

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -162,7 +162,7 @@ class StrategiesController < ApplicationController
   # DELETE /strategies/1.json
   def destroy
     # Remove strategies from existing moments
-    @moments = Moment.where(userid: current_user.id).all
+    @moments = current_user.moments.all
 
     @moments.each do |item|
       item.strategy.delete(@strategy.id)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,16 +5,18 @@ module ApplicationHelper
 
   def nav_link_to(body, url, html_options = {})
     environment = html_options[:method] ? { method: html_options[:method] } : {}
-    active_class = is_active?(url, environment) ? 'active' : nil
+    active_class = active?(url, environment) ? 'active' : nil
 
     content_tag :li, class: active_class do
       link_to body, url, html_options
     end
   end
 
-  def is_active?(link_path, environment = {})
+  # rubocop:disable MethodLength
+  def active?(link_path, environment = {})
     current_controller = params[:controller]
-    link_controller = Rails.application.routes.recognize_path(link_path, environment)[:controller]
+    link_controller = Rails.application.routes
+                           .recognize_path(link_path, environment)[:controller]
 
     nested_controllers = {
       'moments' => %w[categories moods]
@@ -23,10 +25,13 @@ module ApplicationHelper
     # Current page.
     current_page?(link_path) ||
       # Current controller.
-      (current_controller != 'profile' && current_controller != 'pages' && current_controller == link_controller) ||
+      (
+        current_controller != 'profile' &&
+        current_controller != 'pages' &&
+        current_controller == link_controller
+      ) ||
       # Parent of the active controller.
-      (nested_controllers[link_controller] &&
-       nested_controllers[link_controller].include?(current_controller)) ||
+      (nested_controllers[link_controller]&.include?(current_controller)) ||
       # New user session with devise.
       (link_path == new_user_session_path &&
        current_controller == 'devise/sessions' && action_name == 'new') ||
@@ -34,6 +39,7 @@ module ApplicationHelper
       (link_path == new_user_registration_path &&
        current_controller == 'devise/registrations' && action_name == 'create')
   end
+  # rubocop:enable MethodLength
 
   def title(page_title)
     content_for(:title) { page_title }
@@ -43,11 +49,13 @@ module ApplicationHelper
     content_for(:page_new) { page_new_path }
   end
 
+  # rubocop:disable RescueStandardError
   def i18n_set?(key)
     I18n.t key, raise: true
   rescue
     false
   end
+  # rubocop:enable RescueStandardError
 
   def get_icon_class(icon)
     if %w[envelope gift rss].include?(icon)

--- a/app/helpers/medication_refill_helper.rb
+++ b/app/helpers/medication_refill_helper.rb
@@ -3,6 +3,7 @@
 module MedicationRefillHelper
   include CalendarHelper
   # Save refill date to Google calendar
+  # rubocop:disable RescueStandardError
   def save_refill_to_google_calendar(medication)
     return true unless current_user.google_oauth2_enabled? &&
                        new_cal_refill_reminder_needed?(medication)
@@ -15,6 +16,7 @@ module MedicationRefillHelper
       true
     end
   end
+  # rubocop:enable RescueStandardError
 
   def calendar_uploader_params(medication)
     { summary: "Refill for #{medication.name}",

--- a/app/helpers/notification_mailer_helper.rb
+++ b/app/helpers/notification_mailer_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable ModuleLength
 module NotificationMailerHelper
   def comment_on_moment_subject(data)
     I18n.t(
@@ -156,3 +157,4 @@ module NotificationMailerHelper
     I18n.t(val(key), user: data['user'].to_s, group: data['group'].to_s)
   end
 end
+# rubocop:enable ModuleLength

--- a/app/helpers/reminder_helper.rb
+++ b/app/helpers/reminder_helper.rb
@@ -4,7 +4,7 @@ module ReminderHelper
   def print_reminders(data)
     reminders = ''
 
-    if data.active_reminders && data.active_reminders.any?
+    if data.active_reminders&.any?
       reminders = format_reminders(data.active_reminders.map(&:name))
     end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -19,6 +19,7 @@ class ApplicationMailer < ActionMailer::Base
     can_notify(recipient, 'comment_notify') && can_comment(data)
   end
 
+  # rubocop:disable MethodLength
   def comment_notify(data, recipient)
     @data = data
     @recipient = recipient
@@ -43,6 +44,7 @@ class ApplicationMailer < ActionMailer::Base
 
     mail(to: @recipient.email, subject: subject)
   end
+  # rubocop:enable MethodLength
 
   def can_ally_notify(data, recipient)
     can_notify(recipient, 'ally_notify') &&
@@ -62,6 +64,7 @@ class ApplicationMailer < ActionMailer::Base
       (can_notify(recipient, 'meeting_notify') && can_meeting(data))
   end
 
+  # rubocop:disable MethodLength
   def group_notify(data, recipient)
     @data = data
     @recipient = recipient
@@ -99,6 +102,7 @@ class ApplicationMailer < ActionMailer::Base
     end
     mail(to: @recipient.email, subject: subject)
   end
+  # rubocop:enable MethodLength
 
   private
 

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 # inviter_name method from InvitationsHelper
+include InvitationsHelper
 
 class CustomDeviseMailer < Devise::Mailer
-  include InvitationsHelper
-
   protected
 
   def subject_for(key)

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-
-include InvitationsHelper
 # inviter_name method from InvitationsHelper
 
 class CustomDeviseMailer < Devise::Mailer
+  include InvitationsHelper
+
   protected
 
   def subject_for(key)

--- a/app/models/allyship.rb
+++ b/app/models/allyship.rb
@@ -19,18 +19,22 @@ class Allyship < ApplicationRecord
   validate :different_users
 
   belongs_to :user
-  belongs_to :ally, class_name: 'User'
+  belongs_to :ally, class_name: 'User', inverse_of: :allyship
 
-  after_create :create_inverse, unless: :has_inverse?
+  after_create :create_inverse, unless: :inverse?
   after_update :approve_inverse, if: :inverse_unapproved?
-  after_destroy :destroy_inverses, if: :has_inverse?
+  after_destroy :destroy_inverses, if: :inverse?
 
   def approve_inverse
     inverses.update_all(status: User::ALLY_STATUS[:accepted])
   end
 
   def create_inverse
-    self.class.create(inverse_allyship_options.merge(status: User::ALLY_STATUS[:pending_from_user]))
+    self.class.create(
+      inverse_allyship_options.merge(
+        status: User::ALLY_STATUS[:pending_from_user]
+      )
+    )
   end
 
   def destroy_inverses
@@ -43,7 +47,7 @@ class Allyship < ApplicationRecord
     errors.add(:ally_id, 'ally_id is nil') if ally_id.nil?
   end
 
-  def has_inverse?
+  def inverse?
     self.class.exists?(inverse_allyship_options)
   end
 

--- a/app/models/allyship.rb
+++ b/app/models/allyship.rb
@@ -56,7 +56,7 @@ class Allyship < ApplicationRecord
   end
 
   def inverse_unapproved?
-    !inverses.where.not(status: User::ALLY_STATUS[:accepted]).empty?
+    inverses.where.not(status: User::ALLY_STATUS[:accepted]).any?
   end
 
   private

--- a/app/models/allyship.rb
+++ b/app/models/allyship.rb
@@ -19,7 +19,7 @@ class Allyship < ApplicationRecord
   validate :different_users
 
   belongs_to :user
-  belongs_to :ally, class_name: 'User', inverse_of: :allyship
+  belongs_to :ally, class_name: 'User'
 
   after_create :create_inverse, unless: :inverse?
   after_update :approve_inverse, if: :inverse_unapproved?

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,7 +19,7 @@ class Category < ApplicationRecord
   validates :description, length: { maximum: 2000 }
   validates :userid, :name, presence: true
 
-  belongs_to :user, foreign_key: :userid, inverse_of: :category
+  belongs_to :user, foreign_key: :userid
 
   def self.link
     '/categories/'

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,7 +19,7 @@ class Category < ApplicationRecord
   validates :description, length: { maximum: 2000 }
   validates :userid, :name, presence: true
 
-  belongs_to :user, foreign_key: :userid
+  belongs_to :user, foreign_key: :userid, inverse_of: :category
 
   def self.link
     '/categories/'

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -16,13 +16,10 @@ class Group < ApplicationRecord
   extend FriendlyId
   friendly_id :name
   validates :name, :description, presence: true
-  has_many :group_members,
-           foreign_key: :groupid,
-           dependent: :destroy,
-           inverse_of: :group
+  has_many :group_members, foreign_key: :groupid, dependent: :destroy
   has_many :members, -> { order 'name' }, through: :group_members, source: :user
   has_many :meetings, -> { order 'meetings.created_at DESC' },
-           foreign_key: :groupid, dependent: :destroy, inverse_of: :group
+           foreign_key: :groupid, dependent: :destroy
   has_many :leaders, -> { where(group_members: { leader: true }) },
            through: :group_members, source: :user
   after_destroy :destroy_notifications

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -16,10 +16,13 @@ class Group < ApplicationRecord
   extend FriendlyId
   friendly_id :name
   validates :name, :description, presence: true
-  has_many :group_members, foreign_key: :groupid, dependent: :destroy
+  has_many :group_members,
+           foreign_key: :groupid,
+           dependent: :destroy,
+           inverse_of: :group
   has_many :members, -> { order 'name' }, through: :group_members, source: :user
   has_many :meetings, -> { order 'meetings.created_at DESC' },
-           foreign_key: :groupid, dependent: :destroy
+           foreign_key: :groupid, dependent: :destroy, inverse_of: :group
   has_many :leaders, -> { where(group_members: { leader: true }) },
            through: :group_members, source: :user
   after_destroy :destroy_notifications

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -18,12 +18,14 @@ class GroupMember < ApplicationRecord
   validates :groupid, :userid, presence: true
   validates :leader, inclusion: [true, false]
 
-  belongs_to :group, foreign_key: :groupid
-  belongs_to :user, foreign_key: :userid
+  belongs_to :group, foreign_key: :groupid, inverse_of: :group_member
+  belongs_to :user, foreign_key: :userid, inverse_of: :group_member
 
   has_many :meetings, through: :group
   has_many :meeting_memberships,
-           ->(group_member) { where(meeting_members: { userid: group_member.userid }) },
+           lambda(group_member) {
+             where(meeting_members: { userid: group_member.userid })
+           },
            through: :meetings, source: :meeting_members
 
   def destroy_meeting_memberships

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -23,7 +23,7 @@ class GroupMember < ApplicationRecord
 
   has_many :meetings, through: :group
   has_many :meeting_memberships,
-           lambda(group_member) {
+           lambda { |group_member|
              where(meeting_members: { userid: group_member.userid })
            },
            through: :meetings, source: :meeting_members

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -18,8 +18,8 @@ class GroupMember < ApplicationRecord
   validates :groupid, :userid, presence: true
   validates :leader, inclusion: [true, false]
 
-  belongs_to :group, foreign_key: :groupid, inverse_of: :group_member
-  belongs_to :user, foreign_key: :userid, inverse_of: :group_member
+  belongs_to :group, foreign_key: :groupid
+  belongs_to :user, foreign_key: :userid
 
   has_many :meetings, through: :group
   has_many :meeting_memberships,

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -28,9 +28,9 @@ class Medication < ApplicationRecord
 
   extend FriendlyId
   friendly_id :name
-  belongs_to :user, foreign_key: :userid
-  has_one :take_medication_reminder
-  has_one :refill_reminder
+  belongs_to :user, foreign_key: :userid, inverse_of: :medication
+  has_one :take_medication_reminder, dependent: :destroy
+  has_one :refill_reminder, dependent: :destroy
   accepts_nested_attributes_for :take_medication_reminder
   accepts_nested_attributes_for :refill_reminder
   validates :name, :dosage, :refill, :userid, :total, :strength, :dosage_unit,

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -28,9 +28,9 @@ class Medication < ApplicationRecord
 
   extend FriendlyId
   friendly_id :name
-  belongs_to :user, foreign_key: :userid, inverse_of: :medication
-  has_one :take_medication_reminder, dependent: :destroy
-  has_one :refill_reminder, dependent: :destroy
+  belongs_to :user, foreign_key: :userid
+  has_one :take_medication_reminder
+  has_one :refill_reminder
   accepts_nested_attributes_for :take_medication_reminder
   accepts_nested_attributes_for :refill_reminder
   validates :name, :dosage, :refill, :userid, :total, :strength, :dosage_unit,

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -20,12 +20,19 @@
 class Meeting < ApplicationRecord
   extend FriendlyId
   friendly_id :name
-  validates :name, :description, :location, :time, :groupid, :date, presence: true
-  belongs_to :group, foreign_key: :groupid
+  validates :name, :description, :location, :time, :groupid, :date,
+            presence: true
+  belongs_to :group, foreign_key: :groupid, inverse_of: :meeting
   has_many :members, -> { order 'name' }, through: :meeting_members,
                                           source: :user
-  has_many :meeting_members, foreign_key: :meetingid, dependent: :destroy
+  has_many :meeting_members,
+           foreign_key: :meetingid,
+           dependent: :destroy,
+           inverse_of: :meeting
   has_many :leaders, -> { where(meeting_members: { leader: true }) },
            through: :meeting_members, source: :user
-  has_many :comments, as: :commentable
+  has_many :comments,
+           as: :commentable,
+           inverse_of: :meeting,
+           dependent: :destroy
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -22,17 +22,11 @@ class Meeting < ApplicationRecord
   friendly_id :name
   validates :name, :description, :location, :time, :groupid, :date,
             presence: true
-  belongs_to :group, foreign_key: :groupid, inverse_of: :meeting
+  belongs_to :group, foreign_key: :groupid
   has_many :members, -> { order 'name' }, through: :meeting_members,
                                           source: :user
-  has_many :meeting_members,
-           foreign_key: :meetingid,
-           dependent: :destroy,
-           inverse_of: :meeting
+  has_many :meeting_members, foreign_key: :meetingid, dependent: :destroy
   has_many :leaders, -> { where(meeting_members: { leader: true }) },
            through: :meeting_members, source: :user
-  has_many :comments,
-           as: :commentable,
-           inverse_of: :meeting,
-           dependent: :destroy
+  has_many :comments, as: :commentable
 end

--- a/app/models/meeting_member.rb
+++ b/app/models/meeting_member.rb
@@ -16,7 +16,7 @@ class MeetingMember < ApplicationRecord
   validates :meetingid, :userid, presence: true
   validates :leader, inclusion: [true, false]
 
-  belongs_to :meeting, foreign_key: :meetingid, inverse_of: :meeting_member
-  belongs_to :user, foreign_key: :userid, inverse_of: :meeting_member
-  belongs_to :group_member, foreign_key: :userid, inverse_of: :meeting_member
+  belongs_to :meeting, foreign_key: :meetingid
+  belongs_to :user, foreign_key: :userid
+  belongs_to :group_member, foreign_key: :userid
 end

--- a/app/models/meeting_member.rb
+++ b/app/models/meeting_member.rb
@@ -16,7 +16,7 @@ class MeetingMember < ApplicationRecord
   validates :meetingid, :userid, presence: true
   validates :leader, inclusion: [true, false]
 
-  belongs_to :meeting, foreign_key: :meetingid
-  belongs_to :user, foreign_key: :userid
-  belongs_to :group_member, foreign_key: :userid
+  belongs_to :meeting, foreign_key: :meetingid, inverse_of: :meeting_member
+  belongs_to :user, foreign_key: :userid, inverse_of: :meeting_member
+  belongs_to :group_member, foreign_key: :userid, inverse_of: :meeting_member
 end

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -35,8 +35,8 @@ class Moment < ApplicationRecord
   before_save :mood_array_data
   before_save :strategy_array_data
 
-  belongs_to :user, foreign_key: :userid, inverse_of: :moment
-  has_many :comments, as: :commentable, inverse_of: :moment, dependent: :destroy
+  belongs_to :user, foreign_key: :userid
+  has_many :comments, as: :commentable
 
   validates :comment, inclusion: [true, false]
   validates :userid, :name, :why, presence: true

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -1,5 +1,7 @@
+# rubocop:disable EmptyLineAfterMagicComment
 # frozen_string_literal: true
 # == Schema Information
+# rubocop:enable EmptyLineAfterMagicComment
 #
 # Table name: moments
 #
@@ -30,10 +32,13 @@ class Moment < ApplicationRecord
   serialize :mood, Array
   serialize :strategy, Array
 
-  before_save :array_data
+  before_save :category_array_data
+  before_save :viewers_array_data
+  before_save :mood_array_data
+  before_save :strategy_array_data
 
-  belongs_to :user, foreign_key: :userid
-  has_many :comments, as: :commentable
+  belongs_to :user, foreign_key: :userid, inverse_of: :moment
+  has_many :comments, as: :commentable, inverse_of: :moment, dependent: :destroy
 
   validates :comment, inclusion: [true, false]
   validates :userid, :name, :why, presence: true
@@ -52,10 +57,19 @@ class Moment < ApplicationRecord
     )
   end
 
-  def array_data
+  def category_array_data
     self.category = category.collect(&:to_i) if category.is_a?(Array)
+  end
+
+  def viewers_array_data
     self.viewers = viewers.collect(&:to_i) if viewers.is_a?(Array)
+  end
+
+  def mood_array_data
     self.mood = mood.collect(&:to_i) if mood.is_a?(Array)
+  end
+
+  def strategy_array_data
     self.strategy = strategy.collect(&:to_i) if strategy.is_a?(Array)
   end
 

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -1,7 +1,5 @@
-# rubocop:disable EmptyLineAfterMagicComment
 # frozen_string_literal: true
 # == Schema Information
-# rubocop:enable EmptyLineAfterMagicComment
 #
 # Table name: moments
 #

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -19,7 +19,7 @@ class Mood < ApplicationRecord
   validates :description, length: { maximum: 2000 }
   validates :userid, :name, presence: true
 
-  belongs_to :user, foreign_key: :userid, inverse_of: :mood
+  belongs_to :user, foreign_key: :userid
 
   def self.link
     'moods'

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -19,7 +19,7 @@ class Mood < ApplicationRecord
   validates :description, length: { maximum: 2000 }
   validates :userid, :name, presence: true
 
-  belongs_to :user, foreign_key: :userid
+  belongs_to :user, foreign_key: :userid, inverse_of: :mood
 
   def self.link
     'moods'

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,7 +14,7 @@
 
 class Notification < ApplicationRecord
   validates :userid, :uniqueid, :data, presence: true
-  belongs_to :user, foreign_key: :userid, inverse_of: :notification
+  belongs_to :user, foreign_key: :userid
 
   scope :for_ally, lambda { |user_id, ally_id|
     where(

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,7 +14,7 @@
 
 class Notification < ApplicationRecord
   validates :userid, :uniqueid, :data, presence: true
-  belongs_to :user, foreign_key: :userid
+  belongs_to :user, foreign_key: :userid, inverse_of: :notification
 
   scope :for_ally, lambda { |user_id, ally_id|
     where(

--- a/app/models/strategy.rb
+++ b/app/models/strategy.rb
@@ -27,13 +27,10 @@ class Strategy < ApplicationRecord
 
   before_save :array_data_to_i!
 
-  belongs_to :user, foreign_key: :userid, inverse_of: :strategy
-  has_many :comments,
-           as: :commentable,
-           inverse_of: :strategy,
-           dependent: :destroy
+  belongs_to :user, foreign_key: :userid
+  has_many :comments, as: :commentable
 
-  has_one :perform_strategy_reminder, dependent: :destroy
+  has_one :perform_strategy_reminder
   accepts_nested_attributes_for :perform_strategy_reminder
 
   validates :comment, inclusion: [true, false]

--- a/app/models/strategy.rb
+++ b/app/models/strategy.rb
@@ -27,10 +27,13 @@ class Strategy < ApplicationRecord
 
   before_save :array_data_to_i!
 
-  belongs_to :user, foreign_key: :userid
-  has_many :comments, as: :commentable
+  belongs_to :user, foreign_key: :userid, inverse_of: :strategy
+  has_many :comments,
+           as: :commentable,
+           inverse_of: :strategy,
+           dependent: :destroy
 
-  has_one :perform_strategy_reminder
+  has_one :perform_strategy_reminder, dependent: :destroy
   accepts_nested_attributes_for :perform_strategy_reminder
 
   validates :comment, inclusion: [true, false]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,6 @@ class User < ApplicationRecord
 
   # TODO: _signed_in_resource is unused and should be removed
   # rubocop:disable MethodLength
-  # rubocop:disable AbcSize
   def self.find_for_google_oauth2(access_token, _signed_in_resource = nil)
     data = access_token.info
     user = find_or_initialize_by(email: data.email) do |u|
@@ -127,7 +126,6 @@ class User < ApplicationRecord
     )
     user
   end
-  # rubocop:enable AbcSize
   # rubocop:enable MethodLength
 
   def google_access_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,6 @@
 #  access_expires_at      :datetime
 #  refresh_token          :string
 #
-# rubocop:disable ClassLength
 
 class User < ApplicationRecord
   ALLY_STATUS = {
@@ -61,34 +60,16 @@ class User < ApplicationRecord
 
   before_save :remove_leading_trailing_whitespace
 
-  has_many :allyships, dependent: :destroy
+  has_many :allyships
   has_many :allies, through: :allyships
-  has_many :alerts, inverse_of: :user, dependent: :destroy
-  has_many :group_members,
-           foreign_key: :userid,
-           inverse_of: :user,
-           dependent: :destroy
+  has_many :alerts
+  has_many :group_members, foreign_key: :userid
   has_many :groups, through: :group_members
-  has_many :meeting_members,
-           foreign_key: :userid,
-           inverse_of: :user,
-           dependent: :destroy
-  has_many :medications,
-           foreign_key: :userid,
-           inverse_of: :user,
-           dependent: :destroy
-  has_many :strategies,
-           foreign_key: :userid,
-           inverse_of: :user,
-           dependent: :destroy
-  has_many :notifications,
-           foreign_key: :userid,
-           inverse_of: :user,
-           dependent: :destroy
-  has_many :moments,
-           foreign_key: :userid,
-           inverse_of: :user,
-           dependent: :destroy
+  has_many :meeting_members, foreign_key: :userid
+  has_many :medications, foreign_key: :userid
+  has_many :strategies, foreign_key: :userid
+  has_many :notifications, foreign_key: :userid
+  has_many :moments, foreign_key: :userid
   after_initialize :set_defaults, unless: :persisted?
 
   validates :name, presence: true
@@ -182,5 +163,3 @@ class User < ApplicationRecord
          .where(group_members: { userid: accepted_ally_ids })
   end
 end
-
-# rubocop:enable ClassLength

--- a/app/services/medication_reminders.rb
+++ b/app/services/medication_reminders.rb
@@ -16,13 +16,15 @@ class MedicationReminders
   private
 
   def ready_for_refill
-    RefillReminder.active.joins(:medication).where('medications.refill': one_week_from_now_as_string)
+    RefillReminder.active
+                  .joins(:medication)
+                  .where('medications.refill': one_week_from_now_as_string)
   end
 
   # TODO: Medication Refill dates are currently stored as strings in the
   # database instead of timestamps. If we want to do more complicated reminders,
   # we should migrate the data to timestamps.
   def one_week_from_now_as_string
-    (Time.now + 1.week).strftime('%m/%d/%Y')
+    (Time.current + 1.week).strftime('%m/%d/%Y')
   end
 end

--- a/app/services/profile_picture.rb
+++ b/app/services/profile_picture.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-include CloudinaryHelper
-
 class ProfilePicture
+  include CloudinaryHelper
+
   DEFAULT_AVATAR = '/assets/default_ifme_avatar.png'
   # Future task: Optimize Cloudinary image size based on responsive layout
   DEFAULT_SIZE = 150

--- a/app/services/profile_picture.rb
+++ b/app/services/profile_picture.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
+include CloudinaryHelper
 
 class ProfilePicture
-  include CloudinaryHelper
-
   DEFAULT_AVATAR = '/assets/default_ifme_avatar.png'
   # Future task: Optimize Cloudinary image size based on responsive layout
   DEFAULT_SIZE = 150

--- a/app/services/time_ago.rb
+++ b/app/services/time_ago.rb
@@ -2,9 +2,10 @@
 
 require 'action_view'
 require 'action_view/helpers'
-include ActionView::Helpers::DateHelper
 
 class TimeAgo
+  include ActionView::Helpers::DateHelper
+
   class << self
     def formatted_ago(time_with_zone)
       if time_with_zone < 1.week.ago

--- a/app/services/time_ago.rb
+++ b/app/services/time_ago.rb
@@ -2,10 +2,9 @@
 
 require 'action_view'
 require 'action_view/helpers'
+include ActionView::Helpers::DateHelper
 
 class TimeAgo
-  include ActionView::Helpers::DateHelper
-
   class << self
     def formatted_ago(time_with_zone)
       if time_with_zone < 1.week.ago

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 class AvatarUploader < CarrierWave::Uploader::Base
@@ -21,7 +20,9 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url
   #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #   # ActionController::Base.helpers.asset_path(
+  #   #   "fallback/" + [version_name, "default.png"].compact.join('_')
+  #   # )
   #
   #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
   # end
@@ -49,7 +50,8 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # end
 
   # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # Avoid using model.id or version_name here, see uploader/store.rb for
+  # details.
   # def filename
   #   "something.jpg" if original_filename
   # end

--- a/app/views/allies/index.html.erb
+++ b/app/views/allies/index.html.erb
@@ -16,7 +16,7 @@
       <%= ProfilePicture.fetch(ally.avatar.url, 'profile_picture') %>
       <h1 class="ally_name"><%= link_to ally.name, profile_index_path(uid: get_uid(ally.id)) %></h1>
       <div class="location"><%= ally.location %></div>
-      <%= link_to t('allies.index.cancel'), remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+      <%= link_to t('allies.index.cancel'), remove_allies_path(ally_id: ally.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
     </div>
   <% end %>
   </div>
@@ -35,7 +35,7 @@
       <%= ProfilePicture.fetch(ally.avatar.url, 'profile_picture') %>
       <h1 class="ally_name"><%= link_to ally.name, profile_index_path(uid: get_uid(ally.id)) %></h1>
       <div class="location"><%= ally.location %></div>
-      <%= link_to t('allies.accept'), add_allies_path(ally_id: ally.id), method: :post %> | <%= link_to t('common.actions.remove'), remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+      <%= link_to t('allies.accept'), add_allies_path(ally_id: ally.id), method: :post %> | <%= link_to t('common.actions.remove'), remove_allies_path(ally_id: ally.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
     </div>
   <% end %>
   </div>
@@ -49,16 +49,16 @@
 <% end %>
 
 <% if @accepted_allies.present? %>
-<div class="allies_list">
-<% @accepted_allies.each do |ally| %>
-  <div class="ally center">
-    <%= ProfilePicture.fetch(ally.avatar.url, 'profile_picture') %>
-    <h1 class="ally_name"><%= link_to ally.name, profile_index_path(uid: get_uid(ally.id)) %></h1>
-    <div class="location"><%= ally.location %></div>
-    <%= link_to t('common.actions.remove'), remove_allies_path(ally_id: ally.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+  <div class="allies_list">
+    <% @accepted_allies.each do |ally| %>
+      <div class="ally center">
+        <%= ProfilePicture.fetch(ally.avatar.url, 'profile_picture') %>
+        <h1 class="ally_name"><%= link_to ally.name, profile_index_path(uid: get_uid(ally.id)) %></h1>
+        <div class="location"><%= ally.location %></div>
+        <%= link_to t('common.actions.remove'), remove_allies_path(ally_id: ally.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
+      </div>
+    <% end %>
   </div>
-<% end %>
-</div>
 <% end %>
 
 <% if @outgoing_ally_requests.empty? && @incoming_ally_requests.empty? && @accepted_allies.count == 0 %>

--- a/app/views/allies/index.html.erb
+++ b/app/views/allies/index.html.erb
@@ -1,6 +1,6 @@
 <% title t('allies.index.title') %>
 <div id="allies_search">
-  <%= render :partial => '/search/form' %>
+  <%= render partial: '/search/form' %>
   <div class="small_margin_top">
   <%= link_to t('allies.index.invite'), new_user_invitation_path %>
   </div>

--- a/app/views/allies/index.html.erb
+++ b/app/views/allies/index.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<% if !@outgoing_ally_requests.empty? %>
+<% if @outgoing_ally_requests.any? %>
   <strong><%= t('allies.index.outgoing') %></strong>
   <br>
   <br>
@@ -22,8 +22,8 @@
   </div>
 <% end %>
 
-<% if !@incoming_ally_requests.empty? %>
-  <% if !@outgoing_ally_requests.empty? %>
+<% if @incoming_ally_requests.any? %>
+  <% if @outgoing_ally_requests.any? %>
     <div class="spacer"></div>
   <% end %>
   <strong><%= t('allies.index.incoming') %></strong>

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,6 +1,5 @@
 <div class="category post">
 	<h1 class="category_name"><%= link_to category.name, category %></h1>
-
   	<%= strip_tags(category.description[0..80]) %>
   	<% if category.description.length >= 80 %>
     	<%= t('ellipsis') %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -14,7 +14,7 @@
       </div>
       <div class="clear"></div>
     </div>
-    <%= f.text_field :name, :class => "name_field" %>
+    <%= f.text_field :name, class: "name_field" %>
   </div>
 
   <div class="field">

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_for(@category) do |f| %>
 
-<% if @category.errors.any? %>
-  <div class="error_explanation">
-    <%= t('common.form.error_explanation') %>
-  </div>
-<% end %>
+  <% if @category.errors.any? %>
+    <div class="error_explanation">
+      <%= t('common.form.error_explanation') %>
+    </div>
+  <% end %>
 
   <div class="field">
     <div class="label">

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -7,9 +7,9 @@
 <div class="spacer"></div>
 
 <% if @categories.length > 0 %>
-  <%= render :partial => '/search/posts', locals: { data_type: 'category' } %>
+  <%= render partial: '/search/posts', locals: { data_type: 'category' } %>
 
-  <%= render :partial => '/shared/stats', locals: { data_type: 'category' } %>
+  <%= render partial: '/shared/stats', locals: { data_type: 'category' } %>
 
   <div id="pages">
     <div class="page">

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -10,4 +10,4 @@
 </div>
 <% end %>
 
-<%= render :partial => '/shared/tag_usage', locals: { data: @category.id, data_type: 'category', userid: @category.userid } %>
+<%= render partial: '/shared/tag_usage', locals: { data: @category.id, data_type: 'category', userid: @category.userid } %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,13 +1,14 @@
 <% title @category.name %>
+
 <% if !@category.description.blank? && @category.description.length > 0 %>
-<%= raw(@category.description) %>
+  <%= raw(@category.description) %>
 <% else %>
-<div class="main_message">
-	<%= t('warnings.no_description') %>
-</div>
-<div class="message_text no_margin_bottom">
-	<%= t('warnings.yes_description') %>
-</div>
+  <div class="main_message">
+    <%= t('warnings.no_description') %>
+  </div>
+  <div class="message_text no_margin_bottom">
+    <%= t('warnings.yes_description') %>
+  </div>
 <% end %>
 
 <%= render partial: '/shared/tag_usage', locals: { data: @category.id, data_type: 'category', userid: @category.userid } %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -2,23 +2,23 @@
   <%= devise_error_messages! %>
   <%= f.hidden_field :reset_password_token %>
 
-  	<div class="field">
-	  	<div class="label">
-	  		<%= f.label :password, t('devise.new_password') %>
-	  	</div>
-    	<%= f.password_field :password, autocomplete: "off" %>
-	</div>
-
-  	<div class="field">
-  		<div class="label">
-  			<%= f.label :password_confirmation, t('devise.passwords.edit.confirmation') %>
-  		</div>
-    	<%= f.password_field :password_confirmation, autocomplete: "off" %>
+  <div class="field">
+    <div class="label">
+      <%= f.label :password, t('devise.new_password') %>
     </div>
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
 
-  	<div class="actions">
-  		<%= f.submit t('devise.password_change') %>
-  	</div>
+  <div class="field">
+    <div class="label">
+      <%= f.label :password_confirmation, t('devise.passwords.edit.confirmation') %>
+    </div>
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit t('devise.password_change') %>
+  </div>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,76 +1,89 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-	<%= devise_error_messages! %>
+  <%= devise_error_messages! %>
 
-	<div class="field"><div class="label"><%= f.label t('common.name') %></div>
-	<%= f.text_field :name %></div>
+  <div class="field">
+    <div class="label"><%= f.label t('common.name') %></div>
+    <%= f.text_field :name %>
+  </div>
 
-	<div class="field"><div class="label"><%= f.label t('common.form.location') %></div>
-	<%= f.text_field :location, placeholder: t('devise.registrations.edit.placeholders.optional') %></div>
+  <div class="field">
+    <div class="label"><%= f.label t('common.form.location') %></div>
+    <%= f.text_field :location, placeholder: t('devise.registrations.edit.placeholders.optional') %>
+  </div>
 
-	<div class="field">
-		<div class="label">
-			<%= f.label t('common.form.email') %>
-		</div>
-		<% if current_user.provider == "google_oauth2" %>
-			<div class="small_font small_margin_bottom">
-				<%= raw t('devise.registrations.google_auth1') %>
-			</div>
-		<% end %>
+  <div class="field">
+    <div class="label">
+      <%= f.label t('common.form.email') %>
+    </div>
+    <% if current_user.provider == 'google_oauth2' %>
+      <div class="small_font small_margin_bottom">
+        <%= raw t('devise.registrations.google_auth1') %>
+      </div>
+    <% end %>
 
-		<%= f.email_field :email %>
-	</div>
+    <%= f.email_field :email %>
+  </div>
 
-	<div class="field">
-		<div class="label"><label><%= t('devise.registrations.email_notifications') %></label></div>
-		<%= f.check_box :comment_notify, {:checked => current_user.comment_notify || current_user.comment_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.comment_notify_text') %><br>
-		<%= f.check_box :ally_notify, {:checked => current_user.ally_notify || current_user.ally_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.ally_notify_text') %><br>
-		<%= f.check_box :group_notify, {:checked => current_user.group_notify || current_user.group_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.group_notify_text') %><br>
-		<%= f.check_box :meeting_notify, {:checked => current_user.meeting_notify || current_user.meeting_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.meeting_notify_text') %>
-	</div>
+  <div class="field">
+    <div class="label"><label><%= t('devise.registrations.email_notifications') %></label></div>
+    <%= f.check_box :comment_notify, {:checked => current_user.comment_notify || current_user.comment_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.comment_notify_text') %><br>
+    <%= f.check_box :ally_notify, {:checked => current_user.ally_notify || current_user.ally_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.ally_notify_text') %><br>
+    <%= f.check_box :group_notify, {:checked => current_user.group_notify || current_user.group_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.group_notify_text') %><br>
+    <%= f.check_box :meeting_notify, {:checked => current_user.meeting_notify || current_user.meeting_notify.nil?}, 'true', 'false' %><%= t('devise.registrations.meeting_notify_text') %>
+  </div>
 
-	<% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-	<div class="field">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-	<% end %>
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div class="field">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
 
-	<div class="field"><div class="label"><%= f.label t('devise.registrations.edit.labels.profile_picture') %></div>
-	<%= ProfilePicture.fetch(resource.avatar.url, 'mini_profile_picture') %>
-	<br>
-	<%= f.file_field :avatar %>
-	<% unless resource.avatar.blank? %>
-        <%= f.label :remove_avatar, class: 'checkbox' do %>
-            <%= f.check_box :remove_avatar %>
-            <%= t('devise.registrations.edit.labels.remove_picture')%>
-        <% end %>
-	<% end %>
-	</div>
+  <div class="field">
+    <div class="label">
+      <%= f.label t('devise.registrations.edit.labels.profile_picture') %>
+    </div>
+    <%= ProfilePicture.fetch(resource.avatar.url, 'mini_profile_picture') %>
+    <br>
+    <%= f.file_field :avatar %>
+    <% unless resource.avatar.blank? %>
+      <%= f.label :remove_avatar, class: 'checkbox' do %>
+        <%= f.check_box :remove_avatar %>
+        <%= t('devise.registrations.edit.labels.remove_picture')%>
+      <% end %>
+    <% end %>
+  </div>
 
-	<div class="field"><div class="label"><%= f.label t('navigation.about') %></div>
-	<%= f.text_area :about, placeholder: t('devise.registrations.edit.placeholders.about') %></div>
+  <div class="field">
+    <div class="label"><%= f.label t('navigation.about') %></div>
+    <%= f.text_area :about, placeholder: t('devise.registrations.edit.placeholders.about') %>
+  </div>
 
-	<div class="field">
-		<div class="label">
-			<label> <%= raw t('devise.registrations.edit.labels.password_for') %></label>
-		</div>
+  <div class="field">
+    <div class="label">
+      <label> <%= raw t('devise.registrations.edit.labels.password_for') %></label>
+    </div>
 
-		<% if current_user.provider == "google_oauth2" %>
-			<div class="small_font">
-				<%= raw t('devise.registrations.google_auth2') %>
-			</div>
-		<% end %>
-	</div>
+    <% if current_user.provider == 'google_oauth2' %>
+      <div class="small_font">
+        <%= raw t('devise.registrations.google_auth2') %>
+      </div>
+    <% end %>
+  </div>
 
-	<div class="field"><div class="label"><%= f.label t('devise.new_password') %></div>
-	<%= f.password_field :password, autocomplete: "off", placeholder: t('devise.password') %>
-	<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: t('devise.registrations.placeholders.repeat_password') %></div>
+  <div class="field">
+    <div class="label"><%= f.label t('devise.new_password') %></div>
+    <%= f.password_field :password, autocomplete: "off", placeholder: t('devise.password') %>
+    <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: t('devise.registrations.placeholders.repeat_password') %>
+  </div>
 
-	<% if current_user.provider != "google_oauth2" %>
-	<div class="field"><div class="label"><%= f.label t('devise.current_password') %></div>
-	<%= f.password_field :current_password, autocomplete: "off", placeholder: t('devise.registrations.edit.placeholders.required') %></div>
-	<% end %>
+	<% if current_user.provider != 'google_oauth2' %>
+    <div class="field">
+      <div class="label"><%= f.label t('devise.current_password') %></div>
+      <%= f.password_field :current_password, autocomplete: "off", placeholder: t('devise.registrations.edit.placeholders.required') %>
+    </div>
+  <% end %>
 
-	<div class="actions">
-		<%= f.submit t('devise.registrations.edit.labels.update') %>
-	</div>
+  <div class="actions">
+    <%= f.submit t('devise.registrations.edit.labels.update') %>
+  </div>
 <% end %>
 
 <div class="label"><label><%= raw t('devise.registrations.edit.delete.text') %></label></div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,7 +2,7 @@
 <div class="spacer"></div>
 
 <div class="center">
-  <%= render "devise/shared/links" %>
+  <%= render 'devise/shared/links' %>
 </div>
 
 <div class="horizonal_divider"></div>
@@ -10,16 +10,22 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= devise_error_messages! %>
   <div class="center">
-    <div class="field"><div class="label"><%= f.label t('common.name') %></div>
-    <%= f.text_field :name %></div>
+    <div class="field">
+      <div class="label"><%= f.label t('common.name') %></div>
+      <%= f.text_field :name %>
+    </div>
 
-    <div class="field"><div class="label"><%= f.label t('devise.registrations.new.label') %></div>
-    <%= f.text_field :location, class: 'spacing', placeholder: t('common.form.location') %>
-    <%= f.email_field :email, placeholder: t('common.form.email') %></div>
+    <div class="field">
+      <div class="label"><%= f.label t('devise.registrations.new.label') %></div>
+      <%= f.text_field :location, class: 'spacing', placeholder: t('common.form.location') %>
+      <%= f.email_field :email, placeholder: t('common.form.email') %>
+    </div>
 
-    <div class="field"><div class="label"><%= f.label t('devise.password') %></div>
-      <%= f.password_field :password, autocomplete: "off", class: 'spacing', placeholder: t('devise.password') %>
-      <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: t('devise.registrations.placeholders.repeat_password') %></div>
+    <div class="field">
+      <div class="label"><%= f.label t('devise.password') %></div>
+      <%= f.password_field :password, autocomplete: 'off', class: 'spacing', placeholder: t('devise.password') %>
+      <%= f.password_field :password_confirmation, autocomplete: 'off', placeholder: t('devise.registrations.placeholders.repeat_password') %>
+    </div>
 
     <div class="actions">
       <%= f.submit t('account.sign_up') %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,23 +2,32 @@
 <div class="spacer"></div>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  	<div class="center">
-		<div class="field"><div class="label"><%= f.label t('common.form.email') %></div>
-	  	<%= f.email_field :email %></div>
+  <div class="center">
+    <div class="field">
+      <div class="label"><%= f.label t('common.form.email') %></div>
+      <%= f.email_field :email %>
+    </div>
 
-	  	<div class="field"><div class="label"><%= f.label t('devise.password') %></div>
-	    <%= f.password_field :password, autocomplete: "off" %></div>
+    <div class="field">
+      <div class="label"><%= f.label t('devise.password') %></div>
+      <%= f.password_field :password, autocomplete: 'off' %>
+    </div>
 
-	  	<% if devise_mapping.rememberable? -%>
-	    	<div class="field"><div class="label"><%= f.check_box :remember_me %> <%= f.label t('devise.remember_me') %></div></div>
-	  	<% end -%>
+    <% if devise_mapping.rememberable? -%>
+      <div class="field">
+        <div class="label">
+          <%= f.check_box :remember_me %>
+          <%= f.label t('devise.remember_me') %>
+        </div>
+      </div>
+    <% end -%>
 
-	  	<div class="actions"><%= f.submit t('account.sign_in') %></div>
-	</div>
+    <div class="actions"><%= f.submit t('account.sign_in') %></div>
+  </div>
 <% end %>
 
 <div class="horizonal_divider"></div>
 
 <div class="center">
-	<%= render "devise/shared/links" %>
+  <%= render 'devise/shared/links' %>
 </div>

--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -1,13 +1,13 @@
 <%- if devise_mapping.omniauthable? and request.base_url != 'http://0.0.0.0:3000' %>
-<div class="small_margin_bottom">
-  <%- resource_class.omniauth_providers.each do |provider| %>
-  	<% if provider.to_s == "google_oauth2" && (current_page?(new_user_session_path) || current_page?(new_user_password_path)) %>
-      <%= button_to t('devise.shared.sign_in_google'), omniauth_authorize_path(resource_name, provider) %>
-    <% elsif provider.to_s == "google_oauth2" %>
-      <%= button_to t('devise.shared.sign_up_google'), omniauth_authorize_path(resource_name, provider) %>
+  <div class="small_margin_bottom">
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <% if provider.to_s == "google_oauth2" && (current_page?(new_user_session_path) || current_page?(new_user_password_path)) %>
+        <%= button_to t('devise.shared.sign_in_google'), omniauth_authorize_path(resource_name, provider) %>
+      <% elsif provider.to_s == "google_oauth2" %>
+        <%= button_to t('devise.shared.sign_up_google'), omniauth_authorize_path(resource_name, provider) %>
+      <% end -%>
     <% end -%>
-  <% end -%>
-</div>
+  </div>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -3,10 +3,12 @@
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= devise_error_messages! %>
 
-  <div class="field"><%= f.label t('common.form.email') %><br>
-  <%= f.email_field :email %></div>
+  <div class="field">
+    <%= f.label t('common.form.email') %><br>
+    <%= f.email_field :email %>
+  </div>
 
   <div class="actions"><%= f.submit t('devise.unlock.resend') %></div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<%= render 'devise/shared/links' %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -16,7 +16,7 @@
       <i class="fa fa-asterisk align_right"></i>
       <div class="clear"></div>
     </div>
-    <%= f.text_field :name, :class => "name_field" %>
+    <%= f.text_field :name, class: "name_field" %>
   </div>
 
   <div class="field">
@@ -34,7 +34,7 @@
   <div class="table_cell vertical_align_top padding_right sidebar">
     <div class="sidebar_field">
       <div class="sidebar_label"><%= f.label t('common.name') %></div>
-      <%= f.text_field :name, :class => "name_field" %>
+      <%= f.text_field :name, class: "name_field" %>
     </div>
 
       <div class="sidebar_field">

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -9,80 +9,79 @@
     </div>
   <% end %>
 
-<% if action_name == "new" || action_name == "create" %>
-  <div class="field">
-    <div class="label">
-      <%= f.label t('common.name'), for: 'group_name' %>
-      <i class="fa fa-asterisk align_right"></i>
-      <div class="clear"></div>
-    </div>
-    <%= f.text_field :name, class: "name_field" %>
-  </div>
-
-  <div class="field">
-    <div class="label">
-      <%= f.label t('common.form.description'), for: 'group_description' %>
-      <i class="fa fa-asterisk align_right"></i>
-      <div class="clear"></div>
-    </div>
-    <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>
-  </div>
-
-<% elsif action_name == "edit" || action_name == "update" %>
-<div class="table">
-
-  <div class="table_cell vertical_align_top padding_right sidebar">
-    <div class="sidebar_field">
-      <div class="sidebar_label"><%= f.label t('common.name') %></div>
+  <% if action_name == "new" || action_name == "create" %>
+    <div class="field">
+      <div class="label">
+        <%= f.label t('common.name'), for: 'group_name' %>
+        <i class="fa fa-asterisk align_right"></i>
+        <div class="clear"></div>
+      </div>
       <%= f.text_field :name, class: "name_field" %>
     </div>
 
-      <div class="sidebar_field">
-
-      <% if @group.group_members.count > 1 %>
-        <div class="sidebar_label">
-          <%= f.label t('groups.form.leaders') %>
-        </div>
-
-        <% @group.group_members.each do |member| %>
-        <%= f.check_box(:leader, {:multiple => true, :checked => member.leader}, member.userid, nil) %>
-        <%= link_to User.where(id: member.userid).first.name, profile_index_path(uid: get_uid(member.userid)) %>
-        <br>
-        <% end %>
-      <% else %>
-        <div class="small_font subtle">
-          <%= t('groups.form.only_leader') %>
-        </div>
-      <% end %>
-      </div>
-  </div>
-
-  <div class="table_cell vertical_align_top">
-
     <div class="field">
       <div class="label">
-        <%= f.label t('common.form.description') %>
+        <%= f.label t('common.form.description'), for: 'group_description' %>
+        <i class="fa fa-asterisk align_right"></i>
+        <div class="clear"></div>
       </div>
-
       <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>
     </div>
 
-  </div>
+  <% elsif action_name == "edit" || action_name == "update" %>
+    <div class="table">
 
-</div>
-<% end %>
+      <div class="table_cell vertical_align_top padding_right sidebar">
+        <div class="sidebar_field">
+          <div class="sidebar_label"><%= f.label t('common.name') %></div>
+          <%= f.text_field :name, class: "name_field" %>
+        </div>
 
-<div class="clear"></div>
+        <div class="sidebar_field">
 
-<div class="actions align_right no_margin_bottom right">
-  <% if action_name == "new" || action_name == "create" %>
-    <div class="small_margin_bottom subtle small_font">
-      <%= t('groups.form.cannot_delete') %>
+          <% if @group.group_members.any? %>
+            <div class="sidebar_label">
+              <%= f.label t('groups.form.leaders') %>
+            </div>
+
+            <% @group.group_members.each do |member| %>
+              <%= f.check_box(:leader, { multiple: true, checked: member.leader }, member.userid, nil) %>
+              <%= link_to member.user.name, profile_index_path(uid: get_uid(member.userid)) %>
+              <br>
+            <% end %>
+          <% else %>
+            <div class="small_font subtle">
+              <%= t('groups.form.only_leader') %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="table_cell vertical_align_top">
+
+        <div class="field">
+          <div class="label">
+            <%= f.label t('common.form.description') %>
+          </div>
+
+          <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>
+        </div>
+
+      </div>
+
     </div>
   <% end %>
-  <%= f.submit t('common.actions.submit') %>
-</div>
 
-<div class="clear"></div>
+  <div class="clear"></div>
 
+  <div class="actions align_right no_margin_bottom right">
+    <% if action_name == "new" || action_name == "create" %>
+      <div class="small_margin_bottom subtle small_font">
+        <%= t('groups.form.cannot_delete') %>
+      </div>
+    <% end %>
+    <%= f.submit t('common.actions.submit') %>
+  </div>
+
+  <div class="clear"></div>
 <% end %>

--- a/app/views/layouts/_title.html.erb
+++ b/app/views/layouts/_title.html.erb
@@ -4,12 +4,12 @@
   - <%= t('account.sign_in') %>
 <% elsif current_page?(new_user_registration_path) ||
   (params[:controller] == "devise/registrations" && action_name == "create") %>
-- <%= t('account.sign_up') %>
-    <% elsif current_page?(new_user_password_path) ||
-      (params[:controller] == "devise/passwords" && action_name == "new") %>
-    - <%= t('account.forgot_password') %>
-  <% elsif current_page?(edit_user_registration_path) ||
-    (params[:controller] == "registrations" && action_name == "update") %>
+  - <%= t('account.sign_up') %>
+<% elsif current_page?(new_user_password_path) ||
+  (params[:controller] == "devise/passwords" && action_name == "new") %>
+  - <%= t('account.forgot_password') %>
+<% elsif current_page?(edit_user_registration_path) ||
+  (params[:controller] == "registrations" && action_name == "update") %>
   - <%= t('account.singular') %>
 <% elsif current_page?(root_path) %>
   - <%= t('app_description') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <% if user_signed_in? %>
       <!-- Pusher -->
       <script src="https://js.pusher.com/3.0/pusher.min.js"></script>
-      <%= tag :meta, :name => "pusher-key", :content => ENV['PUSHER_KEY'] %>
+      <%= tag :meta, name: 'pusher-key', content: ENV['PUSHER_KEY'] %>
     <% end %>
     <!-- jQuery UI -->
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/flick/jquery-ui.min.css" />
@@ -58,67 +58,61 @@
             <div id="page_title_content">
               <% if current_page?(new_user_session_path) ||
                   (params[:controller] == "devise/sessions" && action_name == "new") %>
-                <%= t('layouts.application.signin') %>
-
+                  <%= t('layouts.application.signin') %>
               <% elsif current_page?(new_user_registration_path) ||
                 (params[:controller] == "devise/registrations" && action_name == "create") %>
-              <%= t('layouts.application.create_account') %>
-
-            <% elsif current_page?(new_user_password_path) ||
-              (params[:controller] == "devise/passwords" && action_name == "new") %>
-            <%= t('account.forgot_password') %>
-
-          <% elsif current_page?(edit_user_registration_path) ||
-            (params[:controller] == "registrations" && action_name == "update") %>
-          <%= t('layouts.application.update_account') %>
-
-        <% elsif !@page_edit.blank? && @page_tooltip %>
-          <div class="align_left">
-            <%= yield(:title) %>
-          </div>
-          <div class="align_right">
-            <%= link_to(raw('<i class="fa fa-pencil-alt"></i>'), @page_edit, class: 'page_edit yes_title', title: @page_tooltip) %>
-          </div>
-          <div class="clear"></div>
-
-        <% elsif yield(:page_new).present? && @page_tooltip %>
-          <div class="align_left">
-            <%= yield(:title) %>
-          </div>
-          <div class="align_right">
-            <%= link_to(raw('<i class="fa fa-plus-circle"></i>'), yield(:page_new), class: 'page_new yes_title', title: @page_tooltip) %>
-          </div>
-          <div class="clear"></div>
-
-        <% elsif !@page_author.blank? %>
-          <div id="other_user">
-            <div class="align_left">
-              <%= yield(:title) %>
-            </div>
-            <div class="align_right" id="page_author">
-              <%= @page_author %>
-            </div>
-            <div class="clear"></div>
-          </div>
-        <% elsif current_page?(root_path) && !user_signed_in? %>
-          <div class="headline center">
-            <span class="branding_title">
-              <%= t('layouts.application.if') %> <span class="branding_subtitle"><%= t('layouts.application.me') %></span>
-            </span><%= t('app_description') %>
-        </div>
-      <% elsif current_page?(new_user_invitation_path) ||
-        (params[:controller] == "devise/invitations" && action_name == "new") ||
-        (params[:controller] == "users/invitations" && action_name == "create") %>
-      <%= t('devise.invitations.new.header') %>
-    <% elsif current_page?(accept_user_invitation_path) ||
-      (params[:controller] == "devise/invitations" && action_name == "accept") %>
-    <%= t('devise.invitations.edit.header') %>
-  <% elsif current_page?(edit_user_password_path) ||
-    (params[:controller] == "devise/passwords" && action_name == "edit") %>
-  <%= t('layouts.title.reset_password') %>
-<% else %>
-  <%= yield(:title) %>
-<% end %>
+                <%= t('layouts.application.create_account') %>
+              <% elsif current_page?(new_user_password_path) ||
+                (params[:controller] == "devise/passwords" && action_name == "new") %>
+                <%= t('account.forgot_password') %>
+              <% elsif current_page?(edit_user_registration_path) ||
+                (params[:controller] == "registrations" && action_name == "update") %>
+                <%= t('layouts.application.update_account') %>
+              <% elsif @page_edit.present? && @page_tooltip %>
+                <div class="align_left">
+                  <%= yield(:title) %>
+                </div>
+                <div class="align_right">
+                  <%= link_to(raw('<i class="fa fa-pencil-alt"></i>'), @page_edit, class: 'page_edit yes_title', title: @page_tooltip) %>
+                </div>
+                <div class="clear"></div>
+              <% elsif yield(:page_new).present? && @page_tooltip %>
+                <div class="align_left">
+                  <%= yield(:title) %>
+                </div>
+                <div class="align_right">
+                  <%= link_to(raw('<i class="fa fa-plus-circle"></i>'), yield(:page_new), class: 'page_new yes_title', title: @page_tooltip) %>
+                </div>
+                <div class="clear"></div>
+              <% elsif @page_author.present? %>
+                <div id="other_user">
+                  <div class="align_left">
+                    <%= yield(:title) %>
+                  </div>
+                  <div class="align_right" id="page_author">
+                    <%= @page_author %>
+                  </div>
+                  <div class="clear"></div>
+                </div>
+              <% elsif current_page?(root_path) && !user_signed_in? %>
+                <div class="headline center">
+                  <span class="branding_title">
+                    <%= t('layouts.application.if') %> <span class="branding_subtitle"><%= t('layouts.application.me') %></span>
+                  </span><%= t('app_description') %>
+                </div>
+              <% elsif current_page?(new_user_invitation_path) ||
+                (params[:controller] == "devise/invitations" && action_name == "new") ||
+                (params[:controller] == "users/invitations" && action_name == "create") %>
+                <%= t('devise.invitations.new.header') %>
+              <% elsif current_page?(accept_user_invitation_path) ||
+                (params[:controller] == "devise/invitations" && action_name == "accept") %>
+                <%= t('devise.invitations.edit.header') %>
+              <% elsif current_page?(edit_user_password_path) ||
+                (params[:controller] == "devise/passwords" && action_name == "edit") %>
+                <%= t('layouts.title.reset_password') %>
+              <% else %>
+                <%= yield(:title) %>
+              <% end %>
             </div>
 
           </div>
@@ -127,7 +121,7 @@
         <div id="announcement" class="display_none"></div>
 
         <div id="content">
-          <% if !notice.blank? %>
+          <% if notice.present? %>
             <% if current_page?(root_path) %>
               <div class="notice display_none"><%= notice %></div>
             <% else %>
@@ -135,7 +129,7 @@
             <% end %>
           <% end %>
 
-          <% if !alert.blank? %>
+          <% if alert.present? %>
             <% if current_page?(root_path) %>
               <div class="alert display_none"><%= alert %></div>
             <% else %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,21 +1,21 @@
 <html>
-  	<body>
-   		<%= yield %>
+  <body>
+    <%= yield %>
 
-   		<p>
-   		-----
-   		</p>
+    <p>
+    -----
+    </p>
 
-   		<p>
-        <%= t('layouts.mailer.html.app_description',
-              app_name: link_to(t('app_name'), root_url)
-        ).html_safe %>
-   		</p>
-
-		<p>
-      <%= t('layouts.mailer.html.no_reply',
-            email: link_to(t('email'), "mailto:join.ifme@gmail.com")
+    <p>
+      <%= t('layouts.mailer.html.app_description',
+        app_name: link_to(t('app_name'), root_url)
       ).html_safe %>
-		</p>
-  	</body>
+    </p>
+
+    <p>
+      <%= t('layouts.mailer.html.no_reply',
+        email: link_to(t('email'), "mailto:join.ifme@gmail.com")
+      ).html_safe %>
+    </p>
+  </body>
 </html>

--- a/app/views/medications/_form.html.erb
+++ b/app/views/medications/_form.html.erb
@@ -11,7 +11,7 @@
           <i class="fa fa-asterisk align_right"></i>
           <div class="clear"></div>
         </div>
-        <%= f.text_field :name, :class => "name_field" %>
+        <%= f.text_field :name, class: "name_field" %>
       </div>
 
       <div class="form_container">
@@ -81,7 +81,7 @@
           </div>
           <div class="clear"></div>
         </div>
-        <%= f.text_area :comments, :class => "comments" %>
+        <%= f.text_area :comments, class: "comments" %>
       </div>
 
       <div class="field">

--- a/app/views/medications/_form.html.erb
+++ b/app/views/medications/_form.html.erb
@@ -23,7 +23,7 @@
             <div class="clear"></div>
           </div>
           <div class="inline-block">
-            <%= f.number_field :strength, :placeholder => t('medications.form.strength_placeholder') %>
+            <%= f.number_field :strength, placeholder: t('medications.form.strength_placeholder') %>
             <%= f.select(:strength_unit, [[t('medications.units.mg'), 'mg'], [t('medications.units.ml'), 'ml']]) %>
           </div>
         </div>
@@ -36,7 +36,7 @@
             <div class="clear"></div>
           </div>
           <div class="inline-block">
-            <%= f.number_field :total, :placeholder => t('medications.form.total_placeholder') %>
+            <%= f.number_field :total, placeholder: t('medications.form.total_placeholder') %>
             <%= f.select(:total_unit, [
                   [t('medications.units.tablets.other'), 'tablets'],
                   [t('medications.units.mg'), 'mg'],
@@ -49,12 +49,12 @@
         <div class="field">
           <div class="label">
             <%= f.label t('medications.form.dosage'), for: 'medication_dosage' %>
-              <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title medication_tooltip_padding', title: t('medications.form.dosage_hint')) %>
-              <i class="fa fa-asterisk"></i>
+            <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title medication_tooltip_padding', title: t('medications.form.dosage_hint')) %>
+            <i class="fa fa-asterisk"></i>
             <div class="clear"></div>
           </div>
           <div class="inline-block">
-            <%= f.number_field :dosage, :placeholder => t('medications.form.dosage_placeholder') %>
+            <%= f.number_field :dosage, placeholder: t('medications.form.dosage_placeholder') %>
             <%= f.select(:dosage_unit, [
                   [t('medications.units.tablets.other'), 'tablets'],
                   [t('medications.units.mg'), 'mg'],
@@ -65,8 +65,8 @@
         <div class="field refill_medication">
           <div class="label">
             <%= f.label t('medications.form.refill'), for: 'medication_refill' %>
-              <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title medication_tooltip_padding', title: t('medications.form.refill_hint')) %>
-              <i class="fa fa-asterisk"></i>
+            <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title medication_tooltip_padding', title: t('medications.form.refill_hint')) %>
+            <i class="fa fa-asterisk"></i>
             <div class="clear"></div>
           </div>
           <%= f.text_field :refill, { readonly: true } %>

--- a/app/views/medications/_medication.html.erb
+++ b/app/views/medications/_medication.html.erb
@@ -1,5 +1,5 @@
 <div class="medication">
-	<h1 class="medication_name"><%= link_to medication.name, medication %></h1>
+  <h1 class="medication_name"><%= link_to medication.name, medication %></h1>
 
   <strong><%= t('medications.strength') %></strong> <%= t('medications.units.display', count: medication.strength, unit: t("medications.units.#{medication.strength_unit}", count: medication.strength)) %>
   <br><strong><%= t('medications.index.total') %></strong> <%= t('medications.units.display', count: medication.total, unit: t("medications.units.#{medication.total_unit}", count: medication.total)) %>
@@ -8,8 +8,8 @@
 
   <%= print_reminders(medication) %>
 
-	<div class="small_margin_top">
-  	<i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), edit_medication_path(medication) %>
-  	<i class="fa fa-trash-alt action small_margin_left"></i><%= link_to t('common.actions.delete'), medication, method: :delete, data: { confirm: t('common.actions.confirm') } %>
-	</div>
+  <div class="small_margin_top">
+    <i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), edit_medication_path(medication) %>
+    <i class="fa fa-trash-alt action small_margin_left"></i><%= link_to t('common.actions.delete'), medication, method: :delete, data: { confirm: t('common.actions.confirm') } %>
+  </div>
 </div>

--- a/app/views/medications/index.html.erb
+++ b/app/views/medications/index.html.erb
@@ -8,7 +8,7 @@
 <div class="spacer"></div>
 
 <% if @medications.length > 0 %>
-  <%= render :partial => '/search/posts', locals: { data_type: 'medication' } %>
+  <%= render partial: '/search/posts', locals: { data_type: 'medication' } %>
 
   <div id="pages">
     <div class="page">

--- a/app/views/medications/index.html.erb
+++ b/app/views/medications/index.html.erb
@@ -18,22 +18,22 @@
 
   <%= paginate @medications %>
 <% else %>
-<%= raw t('medications.index.instructions', {
+  <%= raw t('medications.index.instructions', {
     icon: '<i class="fa fa-plus-circle"></i>'
   }) %>
 
-<div class="spacer"></div>
+  <div class="spacer"></div>
 
-<div id="pages">
-  <div class="page">
-    <div class="medication no_margin_bottom">
-      <h1 class="medication_name"><%= t('medications.index.example_name') %></h1>
+  <div id="pages">
+    <div class="page">
+      <div class="medication no_margin_bottom">
+        <h1 class="medication_name"><%= t('medications.index.example_name') %></h1>
 
-      <strong><%= t('medications.strength') %></strong> <%= t('medications.index.example_strength') %>
-      <br><strong><%= t('medications.index.total') %></strong> <%= t('medications.index.example_total') %>
-      <br><strong><%= t('medications.dosage') %></strong> <%= t('medications.index.example_dosage') %>
-      <br><strong><%= t('medications.refill') %></strong> <%= t('medications.index.example_refill') %>
+        <strong><%= t('medications.strength') %></strong> <%= t('medications.index.example_strength') %>
+        <br><strong><%= t('medications.index.total') %></strong> <%= t('medications.index.example_total') %>
+        <br><strong><%= t('medications.dosage') %></strong> <%= t('medications.index.example_dosage') %>
+        <br><strong><%= t('medications.refill') %></strong> <%= t('medications.index.example_refill') %>
+      </div>
     </div>
   </div>
-</div>
 <% end %>

--- a/app/views/medications/show.html.erb
+++ b/app/views/medications/show.html.erb
@@ -2,16 +2,22 @@
 <strong><%= t('medications.strength') %></strong>
 <%= t('medications.units.display', count: @medication.strength, unit: t("medications.units.#{@medication.strength_unit}", count: @medication.strength)) %>
 
-<br><strong><%= t('medications.quantity') %></strong>
+<br>
+
+<strong><%= t('medications.quantity') %></strong>
 <%= t('medications.units.display', count: @medication.total, unit: t("medications.units.#{@medication.total_unit}", count: @medication.total)) %>
 
-<br><strong><%= t('medications.dosage') %></strong>
+<br>
+
+<strong><%= t('medications.dosage') %></strong>
 <%= t('medications.units.display', count: @medication.dosage, unit: t("medications.units.#{@medication.dosage_unit}", count: @medication.dosage)) %>
 
-<br><strong><%= t('medications.refill') %></strong>
+<br>
+
+<strong><%= t('medications.refill') %></strong>
 <%= @medication.refill %>
 
-<% if !@medication.comments.blank? %>
+<% if @medication.comments.present? %>
   <div class="spacer"></div>
 	<strong><%= t('medications.show.comments') %></strong>
 	<%= @medication.comments %>

--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -1,4 +1,4 @@
 <% title @meeting.name %>
-<%= render :partial => '/shared/meeting_info', locals: { meeting: @meeting, is_leader: @is_leader, show_group: true } %>
+<%= render partial: '/shared/meeting_info', locals: { meeting: @meeting, is_leader: @is_leader, show_group: true } %>
 
-<%= render :partial => '/shared/comments', locals: { data: @meeting, comments: @comments, comment: @comment, no_hide_page: @no_hide_page, commentable_type: 'meeting', is_member: @is_member, is_leader: @is_leader } %>
+<%= render partial: '/shared/comments', locals: { data: @meeting, comments: @comments, comment: @comment, no_hide_page: @no_hide_page, commentable_type: 'meeting', is_member: @is_member, is_leader: @is_leader } %>

--- a/app/views/moments/_form.html.erb
+++ b/app/views/moments/_form.html.erb
@@ -40,31 +40,31 @@
       } %>
 
     <% if !@viewers.nil? && @viewers.length > 0 %>
-    <div class="sidebar_field">
-      <div class="sidebar_label expand_toggle" data-toggle="#viewers">
-        <a href="#" class="toggle_button">
-          <i class="fa fa-caret-down"></i>
-        </a>
-        <%= f.label t('shared.viewers.plural') %>
-        <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title smaller_margin_left', title: t('moments.form.viewers_hint')) %>
+      <div class="sidebar_field">
+        <div class="sidebar_label expand_toggle" data-toggle="#viewers">
+          <a href="#" class="toggle_button">
+            <i class="fa fa-caret-down"></i>
+          </a>
+          <%= f.label t('shared.viewers.plural') %>
+          <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title smaller_margin_left', title: t('moments.form.viewers_hint')) %>
+        </div>
       </div>
-    </div>
 
-    <div id="viewers" class="display_none">
-      <div id="viewers_list">
-        <label>
-          <input type="checkbox" id="viewers_all" />
-          <span id="viewers_label"><%= t('common.actions.select_all') %></span>
-        </label>
-
-        <% @viewers.each do |item| %>
+      <div id="viewers" class="display_none">
+        <div id="viewers_list">
           <label>
-            <%= f.check_box(:viewers, {:multiple => true, :checked => @moment.viewers.include?(item.id)}, item.id, nil) %>
-            <%= User.where(id: item.id).first.name %>
+            <input type="checkbox" id="viewers_all" />
+            <span id="viewers_label"><%= t('common.actions.select_all') %></span>
           </label>
-        <% end %>
+
+          <% @viewers.each do |item| %>
+            <label>
+              <%= f.check_box(:viewers, { multiple: true, checked: @moment.viewers.include?(item.id)}, item.id, nil) %>
+              <%= User.where(id: item.id).first.name %>
+            </label>
+          <% end %>
+        </div>
       </div>
-    </div>
     <% end %>
 
      <div class="sidebar_field">

--- a/app/views/moments/_form.html.erb
+++ b/app/views/moments/_form.html.erb
@@ -12,7 +12,7 @@
         <i class="fa fa-asterisk align_right"></i>
         <div class="clear"></div>
       </div>
-      <%= f.text_field :name, :class => "name_field" %>
+      <%= f.text_field :name, class: "name_field" %>
     </div>
 
     <%= render partial: '/shared/autocomplete_checkboxes', locals: {

--- a/app/views/moments/_form.html.erb
+++ b/app/views/moments/_form.html.erb
@@ -87,7 +87,7 @@
       </div>
       <%= f.cktext_area :why, class: 'no_title special_textarea ckeditor' %>
 
-      <%= render :partial => '/shared/character_count', locals: { data: 'moment_why' } %>
+      <%= render partial: '/shared/character_count', locals: { data: 'moment_why' } %>
     </div>
     <div class="field">
       <div class="label">
@@ -95,13 +95,13 @@
       </div>
       <%= f.cktext_area :fix, class: 'no_title special_textarea ckeditor' %>
 
-      <%= render :partial => '/shared/character_count', locals: { data: 'moment_fix' } %>
+      <%= render partial: '/shared/character_count', locals: { data: 'moment_fix' } %>
     </div>
     <div class="field slider-container">
       <div class="label draft_label">
         <%= f.label t('moments.form.draft_question') %>
       </div>
-      <%= render :partial => '/shared/draft_slider', locals: {published: @moment.published? } %>
+      <%= render partial: '/shared/draft_slider', locals: { published: @moment.published? } %>
     </div>
   </div>
 
@@ -117,8 +117,8 @@
 
 <% end %>
 
-<%= render :partial => '/shared/quick_create', locals: { data_type: 'category', data: @category, tag: 'moment' } %>
+<%= render partial: '/shared/quick_create', locals: { data_type: 'category', data: @category, tag: 'moment' } %>
 
-<%= render :partial => '/shared/quick_create', locals: { data_type: 'mood', data: @mood , tag: 'moment' } %>
+<%= render partial: '/shared/quick_create', locals: { data_type: 'mood', data: @mood , tag: 'moment' } %>
 
-<%= render :partial => '/shared/quick_create', locals: { data_type: 'strategy', data: @strategy, tag: 'moment' } %>
+<%= render partial: '/shared/quick_create', locals: { data_type: 'strategy', data: @strategy, tag: 'moment' } %>

--- a/app/views/moments/_info.html.erb
+++ b/app/views/moments/_info.html.erb
@@ -42,27 +42,27 @@
 <% if local_assigns[:home] %>
   <div class="spacer"></div>
   <% if local_assigns[:data].class.name == 'Moment' %>
-  <%= strip_tags(local_assigns[:data].why[0..200]) %>
-  <% if local_assigns[:data].why.length >= 200 %>
-    <%= t('ellipsis') %>
-  <% end %>
+    <%= strip_tags(local_assigns[:data].why[0..200]) %>
+    <% if local_assigns[:data].why.length >= 200 %>
+      <%= t('ellipsis') %>
+    <% end %>
   <% elsif local_assigns[:data].class.name == 'Strategy' %>
-  <%= strip_tags(local_assigns[:data].description[0..200]) %>
-  <% if local_assigns[:data].description.length >= 200 %>
-    <%= t('ellipsis') %>
-  <% end %>
+    <%= strip_tags(local_assigns[:data].description[0..200]) %>
+    <% if local_assigns[:data].description.length >= 200 %>
+      <%= t('ellipsis') %>
+    <% end %>
   <% end %>
 <% end %>
 
 <% if local_assigns[:class_name] %>
-<br>
-<div class="align_right subtle class_name">
-<% if local_assigns[:data].class.name == 'Moment' %>
-  <%= t('moments.singular') %>
-<% elsif local_assigns[:data].class.name == 'Strategy' %>
-  <%= t('strategies.singular') %>
-<% end %>
-</div>
+  <br>
+  <div class="align_right subtle class_name">
+    <% if local_assigns[:data].class.name == 'Moment' %>
+      <%= t('moments.singular') %>
+    <% elsif local_assigns[:data].class.name == 'Strategy' %>
+      <%= t('strategies.singular') %>
+    <% end %>
+  </div>
 <% end %>
 
 <div class="clear"></div>

--- a/app/views/moments/_info.html.erb
+++ b/app/views/moments/_info.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'shared/draft_badge', locals: {published: local_assigns[:data].published? } %>
+<%= render partial: 'shared/draft_badge', locals: { published: local_assigns[:data].published? } %>
 <%= ::TimeAgo.created_or_edited(local_assigns[:data]) %>
 <% if local_assigns[:data].category.count > 0 %>
   <br>
@@ -8,7 +8,7 @@
   <% local_assigns[:data].category.each do |item| %>
     <span class="notification_wrapper">
       <span class="tip_notifications_button link_style"><%= Category.where(id: item).first.name %></span><% if local_assigns[:data].category.last != item %><%= ', ' %><% end %>
-      <%= render :partial => '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
+      <%= render partial: '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
     </span>
   <% end %>
 <% end %>
@@ -21,7 +21,7 @@
   <% local_assigns[:data].mood.each do |item| %>
     <span class="notification_wrapper">
       <span class="tip_notifications_button link_style"><%= Mood.where(id: item).first.name %></span><% if local_assigns[:data].mood.last != item %><%= ', ' %><% end %>
-      <%= render :partial => '/notifications/preview', locals: { data: Mood.where(id: item).first, edit: edit_mood_path(item) } %>
+      <%= render partial: '/notifications/preview', locals: { data: Mood.where(id: item).first, edit: edit_mood_path(item) } %>
     </span>
   <% end %>
 <% end %>
@@ -34,7 +34,7 @@
   <% local_assigns[:data].strategy.each do |item| %>
     <span class="notification_wrapper">
       <span class="tip_notifications_button link_style"><%= Strategy.where(id: item).first.name %></span><% if local_assigns[:data].strategy.last != item %><%= ', ' %><% end %>
-      <%= render :partial => '/notifications/preview', locals: { data: Strategy.where(id: item).first, edit: edit_strategy_path(item) } %>
+      <%= render partial: '/notifications/preview', locals: { data: Strategy.where(id: item).first, edit: edit_strategy_path(item) } %>
     </span>
   <% end %>
 <% end %>

--- a/app/views/moments/_moment.html.erb
+++ b/app/views/moments/_moment.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => '/shared/moments_strategies', locals: { items: @moments, item: moment, data_type: 'moment' } %>
+<%= render partial: '/shared/moments_strategies', locals: { items: @moments, item: moment, data_type: 'moment' } %>

--- a/app/views/moments/_quick_moment.html.erb
+++ b/app/views/moments/_quick_moment.html.erb
@@ -8,8 +8,8 @@
   <div class="table" id="quick_moment">
     <div class="table_row">
       <div class="table_cell small_padding_right vertical_align_middle">
-        <%= f.text_field :name, placeholder: t('common.title'), :required => true %>
-        <%= f.text_area :why, placeholder: t('moments.form.what_happened'), :required => true %>
+        <%= f.text_field :name, placeholder: t('common.title'), required: true %>
+        <%= f.text_area :why, placeholder: t('moments.form.what_happened'), required: true %>
         <div class="quick_moment_disclaimer">
           <%= content_tag(:span, '<i class="fa fa-lock"></i>'.html_safe, class: 'yes_title subtle smaller_margin_right', title: t('moments.quick_moment_disclaimer')) %>
           <%= render partial: '/shared/character_count', locals: { data: 'moment_why' } %>

--- a/app/views/moments/_quick_moment.html.erb
+++ b/app/views/moments/_quick_moment.html.erb
@@ -12,13 +12,13 @@
         <%= f.text_area :why, placeholder: t('moments.form.what_happened'), :required => true %>
         <div class="quick_moment_disclaimer">
           <%= content_tag(:span, '<i class="fa fa-lock"></i>'.html_safe, class: 'yes_title subtle smaller_margin_right', title: t('moments.quick_moment_disclaimer')) %>
-          <%= render :partial => '/shared/character_count', locals: { data: 'moment_why' } %>
+          <%= render partial: '/shared/character_count', locals: { data: 'moment_why' } %>
         </div>
       </div>
 
       <div class="table_cell center vertical_align_middle">
 
-        <%= render :partial => '/notifications/categories_moods', locals: { categories: local_assigns[:categories], moods: local_assigns[:moods], f: f } %>
+        <%= render partial: '/notifications/categories_moods', locals: { categories: local_assigns[:categories], moods: local_assigns[:moods], f: f } %>
 
         <div class="clear"></div>
 

--- a/app/views/moments/index.html.erb
+++ b/app/views/moments/index.html.erb
@@ -14,13 +14,13 @@
 
   <div class="hide_on_mobile">
     <%= react_component("ChartControl", props: {
-        types: [],
-        initialParams: {
-            type: 'Moments',
-            data: {
-                Moments: @react_moments,
-            }
+      types: [],
+      initialParams: {
+        type: 'Moments',
+        data: {
+          Moments: @react_moments,
         }
+      }
     })%>
 
     <div class="spacer"></div>
@@ -30,29 +30,29 @@
 
   <div id="pages">
     <div class="page">
-    <%= render @moments %>
+      <%= render @moments %>
     </div>
   </div>
 
   <%= paginate @moments %>
 <% else %>
-<%= raw t('moments.index.instructions', {
+  <%= raw t('moments.index.instructions', {
     icon: '<i class="fa fa-plus-circle"></i>'
   }) %>
 
-<div class="spacer"></div>
+  <div class="spacer"></div>
 
-<div id="pages">
-  <div class="page">
-    <div class="moment no_margin_bottom">
-    	<h1 class="moment_name">
-          <%= content_tag(:span, '<i class="fa fa-lock"></i>'.html_safe, class: 'yes_title small_margin_right', title: t('comment.control')) %>
-          <%= t('moments.index.example_name') %>
-      	</h1>
+  <div id="pages">
+    <div class="page">
+      <div class="moment no_margin_bottom">
+        <h1 class="moment_name">
+            <%= content_tag(:span, '<i class="fa fa-lock"></i>'.html_safe, class: 'yes_title small_margin_right', title: t('comment.control')) %>
+            <%= t('moments.index.example_name') %>
+          </h1>
 
-        <strong><%= t('categories.label', count: 1) %></strong> <%= t('moments.index.example_category') %>
-        <br><strong><%= t('moods.label', count: 3) %></strong> <%= t('moods.example_moods') %>
+          <strong><%= t('categories.label', count: 1) %></strong> <%= t('moments.index.example_category') %>
+          <br><strong><%= t('moods.label', count: 3) %></strong> <%= t('moods.example_moods') %>
+      </div>
     </div>
   </div>
-</div>
 <% end %>

--- a/app/views/moments/index.html.erb
+++ b/app/views/moments/index.html.erb
@@ -8,7 +8,7 @@
 <div class="spacer"></div>
 
 <% if @moments.length > 0 %>
-  <%= render :partial => '/search/posts', locals: { data_type: 'moment' } %>
+  <%= render partial: '/search/posts', locals: { data_type: 'moment' } %>
 
   <div class="stats_divider"></div>
 
@@ -26,7 +26,7 @@
     <div class="spacer"></div>
  </div>
 
-  <%= render :partial => '/shared/stats', locals: { data_type: 'moment' } %>
+  <%= render partial: '/shared/stats', locals: { data_type: 'moment' } %>
 
   <div id="pages">
     <div class="page">

--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -21,14 +21,14 @@
   </div>
 <% end %>
 
-<% if !@moment.why.blank? %>
+<% if @moment.why.present? %>
   <p>
     <div class="label"><%= label_tag t('moments.form.why') %></div>
     <%= raw(@moment.why) %>
   </p>
 <% end %>
 
-<% if !@moment.fix.blank? %>
+<% if @moment.fix.present? %>
   <p>
     <div class="label"><%= label_tag t('moments.form.fix') %></div>
     <%= raw(@moment.fix) %>

--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -1,5 +1,5 @@
 <% title @moment.name %>
-<%= render :partial => '/moments/info', locals: { data: @moment } %>
+<%= render partial: '/moments/info', locals: { data: @moment } %>
 <% if Rails.configuration.secret_share_enabled && @moment.owned_by?(current_user) %>
   <button class="secret-share-button" onclick="$('#secret-share-area').toggleClass('display_none')">
     <%= t ('moments.secret_share.singular') %>
@@ -41,14 +41,14 @@
     <% @moment.strategy.each do |item| %>
         <span class="notification_wrapper">
           <span class="tip_notifications_button link_style"><%= Strategy.where(id: item).first.name %></span><% if @moment.strategy.last != item %><%= ', ' %><% end %>
-          <%= render :partial => '/notifications/preview', locals: { data: Strategy.where(id: item).first, edit: edit_strategy_path(item) } %>
+          <%= render partial: '/notifications/preview', locals: { data: Strategy.where(id: item).first, edit: edit_strategy_path(item) } %>
         </span>
     <% end %>
   </p>
 <% end %>
 
-<%= render :partial => '/shared/viewers_indicator', locals: { data: @moment } %>
+<%= render partial: '/shared/viewers_indicator', locals: { data: @moment } %>
 
 <% if @comment.present? %>
-  <%= render :partial => '/shared/comments', locals: { data: @moment, comments: @comments, comment: @comment, no_hide_page: @no_hide_page, commentable_type: 'moment' } %>
+  <%= render partial: '/shared/comments', locals: { data: @moment, comments: @comments, comment: @comment, no_hide_page: @no_hide_page, commentable_type: 'moment' } %>
 <% end %>

--- a/app/views/moods/_form.html.erb
+++ b/app/views/moods/_form.html.erb
@@ -11,7 +11,7 @@
       <i class="fa fa-asterisk align_right"></i>
       <div class="clear"></div>
     </div>
-    <%= f.text_field :name, :class => "name_field" %>
+    <%= f.text_field :name, class: "name_field" %>
   </div>
 
   <div class="field">

--- a/app/views/moods/_form.html.erb
+++ b/app/views/moods/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_for(@mood) do |f| %>
-<% if @mood.errors.any? %>
-  <div class="error_explanation">
-    <%= t('common.form.error_explanation') %>
-  </div>
-<% end %>
+  <% if @mood.errors.any? %>
+    <div class="error_explanation">
+      <%= t('common.form.error_explanation') %>
+    </div>
+  <% end %>
 
   <div class="field">
     <div class="label">

--- a/app/views/moods/_mood.html.erb
+++ b/app/views/moods/_mood.html.erb
@@ -1,13 +1,13 @@
 <div class="mood">
-	<h1 class="mood_name"><%= link_to mood.name, mood %></h1>
+  <h1 class="mood_name"><%= link_to mood.name, mood %></h1>
 
-  	<%= strip_tags(mood.description[0..80]) %>
-  	<% if mood.description.length >= 80 %>
-    	<%= t('ellipsis') %>
-  	<% end %>
+  <%= strip_tags(mood.description[0..80]) %>
+  <% if mood.description.length >= 80 %>
+    <%= t('ellipsis') %>
+  <% end %>
 
-  	<div class="small_margin_top">
-    	<i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), edit_mood_path(mood) %>
-    	<i class="fa fa-trash-o action small_margin_left"></i><%= link_to t('common.actions.delete'), mood, method: :delete, data: { confirm: t('common.actions.confirm') } %>
-  	</div>
+  <div class="small_margin_top">
+    <i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), edit_mood_path(mood) %>
+    <i class="fa fa-trash-o action small_margin_left"></i><%= link_to t('common.actions.delete'), mood, method: :delete, data: { confirm: t('common.actions.confirm') } %>
+  </div>
 </div>

--- a/app/views/moods/index.html.erb
+++ b/app/views/moods/index.html.erb
@@ -8,9 +8,9 @@
 <div class="spacer"></div>
 
 <% if @moods.length > 0 %>
-  <%= render :partial => '/search/posts', locals: { data_type: 'mood' } %>
+  <%= render partial: '/search/posts', locals: { data_type: 'mood' } %>
 
-  <%= render :partial => '/shared/stats', locals: { data_type: 'mood' } %>
+  <%= render partial: '/shared/stats', locals: { data_type: 'mood' } %>
 
   <div id="pages">
     <div class="page">

--- a/app/views/moods/index.html.erb
+++ b/app/views/moods/index.html.erb
@@ -7,9 +7,8 @@
 
 <div class="spacer"></div>
 
-<% if @moods.length > 0 %>
+<% if @moods.any? %>
   <%= render partial: '/search/posts', locals: { data_type: 'mood' } %>
-
   <%= render partial: '/shared/stats', locals: { data_type: 'mood' } %>
 
   <div id="pages">
@@ -21,8 +20,8 @@
   <%= paginate @moods %>
 <% else %>
   <%= raw t('moods.index.instructions', {
-      icon: '<i class="fa fa-plus-circle"></i>'
-    }) %>
+    icon: '<i class="fa fa-plus-circle"></i>'
+  }) %>
 
   <div class="actions align_right">
     <%= button_to t('common.actions.add_all'), premade_moods_path %>

--- a/app/views/moods/show.html.erb
+++ b/app/views/moods/show.html.erb
@@ -10,4 +10,4 @@
 </div>
 <% end %>
 
-<%= render :partial => '/shared/tag_usage', locals: { data: @mood.id, data_type: 'mood', userid: @mood.userid } %>
+<%= render partial: '/shared/tag_usage', locals: { data: @mood.id, data_type: 'mood', userid: @mood.userid } %>

--- a/app/views/moods/show.html.erb
+++ b/app/views/moods/show.html.erb
@@ -1,13 +1,13 @@
 <% title @mood.name %>
-<% if !@mood.description.blank? && @mood.description.length > 0 %>
-<%= raw(@mood.description) %>
+<% if @mood.description.present? && @mood.description.length > 0 %>
+  <%= raw(@mood.description) %>
 <% else %>
-<div class="main_message">
-	<%= t('warnings.no_description') %>
-</div>
-<div class="message_text no_margin_bottom">
-	<%= t('warnings.yes_description') %>
-</div>
+  <div class="main_message">
+    <%= t('warnings.no_description') %>
+  </div>
+  <div class="message_text no_margin_bottom">
+    <%= t('warnings.yes_description') %>
+  </div>
 <% end %>
 
 <%= render partial: '/shared/tag_usage', locals: { data: @mood.id, data_type: 'mood', userid: @mood.userid } %>

--- a/app/views/notification_mailer/notification_email.html.erb
+++ b/app/views/notification_mailer/notification_email.html.erb
@@ -1,5 +1,5 @@
 <p>
-	<%= t('salutation', name: @recipient.name) %>
+  <%= t('salutation', name: @recipient.name) %>
 </p>
 
 <%= raw(@message) %>

--- a/app/views/notifications/_categories_moods.html.erb
+++ b/app/views/notifications/_categories_moods.html.erb
@@ -1,55 +1,55 @@
 <div id="categories_moods" class="display_none no_center">
-	<div id="categories_moods_text">
-		<% if !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 && !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
-			<% modal_title = t('moments.categories_and_moods') %>
-		<% elsif !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 %>
-			<% modal_title = t('categories.plural') %>
-		<% elsif !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
-			<% modal_title = t('moods.plural') %>
-		<% end %>
+  <div id="categories_moods_text">
+    <% if !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 && !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
+      <% modal_title = t('moments.categories_and_moods') %>
+    <% elsif !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 %>
+      <% modal_title = t('categories.plural') %>
+    <% elsif !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
+      <% modal_title = t('moods.plural') %>
+    <% end %>
 
-		<%= render partial: '/shared/modal',
-			locals: {
-				modal_title: modal_title,
-				modal_close_id: 'close_categories_moods'
-			}
-		%>
+    <%= render partial: '/shared/modal',
+      locals: {
+        modal_title: modal_title,
+        modal_close_id: 'close_categories_moods'
+      }
+    %>
 
-		<div class="modal_text">
-		<% if !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 %>
-			<div id="categories_cell">
-				<% if !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
-				<%= local_assigns[:f].label t('categories.plural') %>
-				<% end %>
+    <div class="modal_text">
+      <% if !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 %>
+        <div id="categories_cell">
+          <% if !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
+            <%= local_assigns[:f].label t('categories.plural') %>
+          <% end %>
 
-			    <% local_assigns[:categories].each do |item| %>
-			    	<div class="checkbox">
-				    	<%= local_assigns[:f].check_box(:category, {:multiple => true}, item.id, nil) %>
-				      	<span class="notification_wrapper">
-				        	<span class="tip_notifications_button link_style"><%= item.name %></span>
-				        	<%= render partial: '/notifications/preview', locals: { data: item, edit: edit_category_path(item) } %>
-				      	</span>
-				    </div>
-			    <% end %>
-		    </div>
-		<% end %>
+          <% local_assigns[:categories].each do |item| %>
+            <div class="checkbox">
+              <%= local_assigns[:f].check_box(:category, { multiple: true }, item.id, nil) %>
+              <span class="notification_wrapper">
+                <span class="tip_notifications_button link_style"><%= item.name %></span>
+                <%= render partial: '/notifications/preview', locals: { data: item, edit: edit_category_path(item) } %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
 
-		<% if !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
-			<div id="moods_cell">
-				<% if !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 %>
-				<%= local_assigns[:f].label t('moods.plural'), class: 'small_margin_top' %>
-				<% end %>
-				<% local_assigns[:moods].each do |item| %>
-					<div class="checkbox">
-						<%= local_assigns[:f].check_box(:mood, {:multiple => true}, item.id, nil) %>
-						<span class="notification_wrapper">
-							<span class="tip_notifications_button link_style"><%= item.name %></span>
-						<%= render partial: '/notifications/preview', locals: { data: item, edit: edit_mood_path(item) } %>
-						</span>
-					</div>
-				<% end %>
-			</div>
-		<% end %>
-		</div>
-	</div>
+      <% if !local_assigns[:moods].nil? && local_assigns[:moods].length > 0 %>
+        <div id="moods_cell">
+          <% if !local_assigns[:categories].nil? && local_assigns[:categories].length > 0 %>
+            <%= local_assigns[:f].label t('moods.plural'), class: 'small_margin_top' %>
+          <% end %>
+          <% local_assigns[:moods].each do |item| %>
+            <div class="checkbox">
+              <%= local_assigns[:f].check_box(:mood, { multiple: true }, item.id, nil) %>
+              <span class="notification_wrapper">
+                <span class="tip_notifications_button link_style"><%= item.name %></span>
+                <%= render partial: '/notifications/preview', locals: { data: item, edit: edit_mood_path(item) } %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/notifications/_categories_moods.html.erb
+++ b/app/views/notifications/_categories_moods.html.erb
@@ -8,7 +8,7 @@
 			<% modal_title = t('moods.plural') %>
 		<% end %>
 
-		<%= render :partial => '/shared/modal',
+		<%= render partial: '/shared/modal',
 			locals: {
 				modal_title: modal_title,
 				modal_close_id: 'close_categories_moods'
@@ -27,7 +27,7 @@
 				    	<%= local_assigns[:f].check_box(:category, {:multiple => true}, item.id, nil) %>
 				      	<span class="notification_wrapper">
 				        	<span class="tip_notifications_button link_style"><%= item.name %></span>
-				        	<%= render :partial => '/notifications/preview', locals: { data: item, edit: edit_category_path(item) } %>
+				        	<%= render partial: '/notifications/preview', locals: { data: item, edit: edit_category_path(item) } %>
 				      	</span>
 				    </div>
 			    <% end %>
@@ -44,7 +44,7 @@
 						<%= local_assigns[:f].check_box(:mood, {:multiple => true}, item.id, nil) %>
 						<span class="notification_wrapper">
 							<span class="tip_notifications_button link_style"><%= item.name %></span>
-						<%= render :partial => '/notifications/preview', locals: { data: item, edit: edit_mood_path(item) } %>
+						<%= render partial: '/notifications/preview', locals: { data: item, edit: edit_mood_path(item) } %>
 						</span>
 					</div>
 				<% end %>

--- a/app/views/notifications/_list.html.erb
+++ b/app/views/notifications/_list.html.erb
@@ -1,7 +1,7 @@
 <div id="notifications" class="display_none">
   <div id="notifications_text">
 
-    <%= render :partial => '/shared/modal',
+    <%= render partial: '/shared/modal',
       locals: {
         modal_title: t('notifications.plural'),
         modal_close_id: 'close_categories_moods',

--- a/app/views/notifications/_members.html.erb
+++ b/app/views/notifications/_members.html.erb
@@ -1,6 +1,6 @@
 <div class="tip_notifications display_none">
   <div class="tip_notifications_text">
-    <%= render :partial => '/shared/modal',
+    <%= render partial: '/shared/modal',
       locals: {
         modal_title: t('notifications.members.title'),
         modal_close_class: 'tip_close_notifications',

--- a/app/views/notifications/_members.html.erb
+++ b/app/views/notifications/_members.html.erb
@@ -9,39 +9,39 @@
 
     <%# group can be an instance of either group or meeting %>
     <div class="modal_text">
-    <% group.members.each do |member| %>
-      <div class="table">
-        <div class="table_row">
+      <% group.members.each do |member| %>
+        <div class="table">
+          <div class="table_row">
 
-          <% if group.members.last == member %>
-            <div class="table_cell small_profile_picture_div padding_right">
-          <% else %>
-            <div class="table_cell small_profile_picture_div padding_right small_padding_bottom">
-          <% end %>
-
-            <%= ProfilePicture.fetch(member.avatar.url, 'mini_profile_picture') %>
-            <br>
-          </div>
-
-          <% if group.members.last == member %>
-            <div class="table_cell vertical_align_middle">
-          <% else %>
-            <div class="table_cell small_padding_bottom vertical_align_middle">
-          <% end %>
-          <%= link_to member.name, profile_index_path(uid: member.uid) %>
-
-          <% if member != current_user &&
-              group.instance_of?(Group) &&
-              group.leaders.include?(current_user) %>
-              <i class="fa fa-times action small_margin_left"></i>
-              <%= link_to t('common.actions.remove'),
-                          leave_groups_path(groupid: group.id,
-                          memberid: member.id), id: 'leave' %>
+            <% if group.members.last == member %>
+              <div class="table_cell small_profile_picture_div padding_right">
+            <% else %>
+              <div class="table_cell small_profile_picture_div padding_right small_padding_bottom">
             <% end %>
+
+              <%= ProfilePicture.fetch(member.avatar.url, 'mini_profile_picture') %>
+              <br>
+            </div>
+
+            <% if group.members.last == member %>
+              <div class="table_cell vertical_align_middle">
+            <% else %>
+              <div class="table_cell small_padding_bottom vertical_align_middle">
+            <% end %>
+            <%= link_to member.name, profile_index_path(uid: member.uid) %>
+
+            <% if member != current_user &&
+                group.instance_of?(Group) &&
+                group.leaders.include?(current_user) %>
+                <i class="fa fa-times action small_margin_left"></i>
+                <%= link_to t('common.actions.remove'),
+                            leave_groups_path(groupid: group.id,
+                            memberid: member.id), id: 'leave' %>
+              <% end %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/notifications/_preview.html.erb
+++ b/app/views/notifications/_preview.html.erb
@@ -1,6 +1,6 @@
 <div class="tip_notifications display_none no_center">
 	<div class="tip_notifications_text">
-		<%= render :partial => '/shared/modal',
+		<%= render partial: '/shared/modal',
 			locals: {
 				modal_title: local_assigns[:data].name,
 				modal_close_class: 'tip_close_notifications',

--- a/app/views/notifications/_preview.html.erb
+++ b/app/views/notifications/_preview.html.erb
@@ -1,35 +1,35 @@
 <div class="tip_notifications display_none no_center">
-	<div class="tip_notifications_text">
-		<%= render partial: '/shared/modal',
-			locals: {
-				modal_title: local_assigns[:data].name,
-				modal_close_class: 'tip_close_notifications',
-			}
-		%>
+  <div class="tip_notifications_text">
+    <%= render partial: '/shared/modal',
+      locals: {
+        modal_title: local_assigns[:data].name,
+        modal_close_class: 'tip_close_notifications',
+      }
+    %>
 
-		<div class="modal_text">
-		<% if !local_assigns[:data].description.blank? && local_assigns[:data].description.length > 0 %>
-		<%= raw(local_assigns[:data].description) %>
-		<% elsif current_user.id == local_assigns[:data].userid %>
-			<strong><%= t('warnings.no_description') %></strong>
-			<br><%= t('warnings.yes_description') %>
-		<% end %>
+    <div class="modal_text">
+      <% if local_assigns[:data].description.present? && local_assigns[:data].description.length > 0 %>
+        <%= raw(local_assigns[:data].description) %>
+      <% elsif current_user.id == local_assigns[:data].userid %>
+        <strong><%= t('warnings.no_description') %></strong>
+        <br><%= t('warnings.yes_description') %>
+      <% end %>
 
-		<% if local_assigns[:data].class.name == 'Strategy' && (local_assigns[:data].viewers.include?(current_user.id) || local_assigns[:data].userid == current_user.id) %>
+      <% if local_assigns[:data].class.name == 'Strategy' && (local_assigns[:data].viewers.include?(current_user.id) || local_assigns[:data].userid == current_user.id) %>
         <div class="small_margin_top">
-        	<%= link_to t('notifications.preview'), local_assigns[:data], target: "blank" %>
+          <%= link_to t('notifications.preview'), local_assigns[:data], target: "blank" %>
         </div>
-        <% end %>
+      <% end %>
 
-		<div class="small_margin_top">
-		<% if local_assigns[:data].userid == current_user.id %>
-        	<i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), local_assigns[:edit], target: "blank" %>
+      <div class="small_margin_top">
+        <% if local_assigns[:data].userid == current_user.id %>
+          <i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), local_assigns[:edit], target: "blank" %>
         <% else %>
           <%= t('notifications.created_by_html',
-                name: link_to(User.where(id: local_assigns[:data].userid).first.name,
-                      profile_index_path(uid: get_uid(local_assigns[:data].userid)))) %>
+            name: link_to(User.where(id: local_assigns[:data].userid).first.name,
+              profile_index_path(uid: get_uid(local_assigns[:data].userid)))) %>
         <% end %>
-        </div>
-        </div>
+      </div>
+    </div>
 	</div>
 </div>

--- a/app/views/pages/_not_signed_in.html.erb
+++ b/app/views/pages/_not_signed_in.html.erb
@@ -1,70 +1,70 @@
 <div class="main_message">
-	<%= t('pages.home.not_signed_in.main_message_one') %>
+  <%= t('pages.home.not_signed_in.main_message_one') %>
 </div>
 <div class="message_text">
-	<%= t('pages.home.not_signed_in.message_text_one') %>
-	<div class="spacer"></div>
+  <%= t('pages.home.not_signed_in.message_text_one') %>
+  <div class="spacer"></div>
 </div>
 <div class="center">
-	<div class="message">
-		<div class="message_row">
-			<div class="message_cell">
-				<div id="book"></div>
-				<div class="icon_border"></div>
-				<%= t('pages.home.not_signed_in.message_one') %>
-			</div>
-			<div class="message_cell">
-				<div id="you"></div>
-				<div class="icon_border"></div>
-				<%= t('pages.home.not_signed_in.message_two') %>
-			</div>
-			<div class="message_cell no_margin_bottom">
-				<div id="time"></div>
-				<div class="icon_border"></div>
-				<%= t('pages.home.not_signed_in.message_three') %>
-			</div>
-		</div>
-	</div>
+  <div class="message">
+    <div class="message_row">
+      <div class="message_cell">
+        <div id="book"></div>
+        <div class="icon_border"></div>
+        <%= t('pages.home.not_signed_in.message_one') %>
+      </div>
+      <div class="message_cell">
+        <div id="you"></div>
+        <div class="icon_border"></div>
+        <%= t('pages.home.not_signed_in.message_two') %>
+      </div>
+      <div class="message_cell no_margin_bottom">
+        <div id="time"></div>
+        <div class="icon_border"></div>
+        <%= t('pages.home.not_signed_in.message_three') %>
+      </div>
+    </div>
+  </div>
 </div>
 <div class="spacer"></div>
 <div class="horizonal_divider"></div>
 <div class="main_message">
-	<div class="spacer"></div>
-	<%= t('pages.home.not_signed_in.main_message_two') %>
+  <div class="spacer"></div>
+  <%= t('pages.home.not_signed_in.main_message_two') %>
 </div>
 <div class="message_text">
-	<%= raw t('pages.home.not_signed_in.message_text_two', {
-			blog: link_to(t('navigation.blog').downcase, blog_path)
-		}) %>
+  <%= raw t('pages.home.not_signed_in.message_text_two', {
+    blog: link_to(t('navigation.blog').downcase, blog_path)
+  }) %>
   <div class="spacer"></div>
 </div>
 <div class="message" id="medium_posts">
-	<div class="message_row">
-		<% @posts.first(3).each do |post, index| %>
-		<div class="message_cell">
-			<%= link_to "#{post['link_name']}", post['link'], target: true %>
-			<div class="post_author"><%= post['author'] %></div>
-		</div>
-		<% end %>
-	</div>
+  <div class="message_row">
+    <% @posts.first(3).each do |post, index| %>
+      <div class="message_cell">
+        <%= link_to "#{post['link_name']}", post['link'], target: true %>
+        <div class="post_author"><%= post['author'] %></div>
+      </div>
+    <% end %>
+  </div>
 </div>
 <div class="spacer"></div>
 <div class="horizonal_divider"></div>
 <div class="main_message">
-	<div class="spacer"></div>
-	<%= t('pages.home.not_signed_in.main_message_three') %>
+  <div class="spacer"></div>
+  <%= t('pages.home.not_signed_in.main_message_three') %>
 </div>
 <div class="message_text">
-	<%= raw t('pages.home.not_signed_in.message_text_three', {
-			help: link_to(t('pages.home.not_signed_in.help'), contribute_path),
-			feedback: link_to(t('navigation.feedback'), 'http://goo.gl/forms/8EqoJDDiXY', target: 'blank')
-		}) %>
-    <div class="spacer"></div>
-    <div class="contributors_grid">
-      <% @blurbs.each do |blurb| %>
-        <div class="contributors_grid_child">
-          <%= ProfilePicture.fetch(blurb['image'], 'home_picture') %>
-        </div>
-      <% end %>
-    </div>
+  <%= raw t('pages.home.not_signed_in.message_text_three', {
+    help: link_to(t('pages.home.not_signed_in.help'), contribute_path),
+    feedback: link_to(t('navigation.feedback'), 'http://goo.gl/forms/8EqoJDDiXY', target: 'blank')
+  }) %>
+  <div class="spacer"></div>
+  <div class="contributors_grid">
+    <% @blurbs.each do |blurb| %>
+      <div class="contributors_grid_child">
+        <%= ProfilePicture.fetch(blurb['image'], 'home_picture') %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/pages/_signed_in_empty.html.erb
+++ b/app/views/pages/_signed_in_empty.html.erb
@@ -1,80 +1,80 @@
 <div class="main_message">
-	<%= t('pages.home.signed_in_empty.main_message_one', {
-		name: current_user.name
-		}) %>
+  <%= t('pages.home.signed_in_empty.main_message_one', {
+    name: current_user.name
+  }) %>
 </div>
 <div class="message_text">
-	<%= t('pages.home.signed_in_empty.message_text_one') %>
+  <%= t('pages.home.signed_in_empty.message_text_one') %>
 </div>
 
 <div class="horizonal_divider"></div>
 
 <div class="main_message">
-	<%= t('pages.home.signed_in_empty.main_message_two') %>
+  <%= t('pages.home.signed_in_empty.main_message_two') %>
 </div>
 <div class="table onboarding">
-	<div class="table_row">
-		<div class="table_cell message_cell center_div vertical_align_middle padding_bottom">
-			<div id="you"></div>
-		</div>
+  <div class="table_row">
+    <div class="table_cell message_cell center_div vertical_align_middle padding_bottom">
+      <div id="you"></div>
+    </div>
 
-		<div class="table_cell vertical_align_middle onboarding_message">
-			<%= raw t('pages.home.signed_in_empty.cell_one', {
-					profile: link_to(t('profile.index.title'), edit_user_registration_path),
-					moods: link_to(t('moods.plural'), moods_path),
-					allies: link_to(t('allies.index.title'), allies_path)
-				}) %>
-		</div>
-	</div>
+    <div class="table_cell vertical_align_middle onboarding_message">
+      <%= raw t('pages.home.signed_in_empty.cell_one', {
+        profile: link_to(t('profile.index.title'), edit_user_registration_path),
+        moods: link_to(t('moods.plural'), moods_path),
+        allies: link_to(t('allies.index.title'), allies_path)
+      }) %>
+    </div>
+  </div>
 </div>
 
 <div class="main_message">
-	<div class="spacer"></div>
-	<%= t('pages.home.signed_in_empty.main_message_three') %>
+  <div class="spacer"></div>
+  <%= t('pages.home.signed_in_empty.main_message_three') %>
 </div>
 <div class="table onboarding">
-	<div class="table_row">
-		<div class="table_cell message_cell center_div vertical_align_middle padding_bottom">
-			<div id="book"></div>
-		</div>
+  <div class="table_row">
+    <div class="table_cell message_cell center_div vertical_align_middle padding_bottom">
+      <div id="book"></div>
+    </div>
 
-		<div class="table_cell vertical_align_middle onboarding_message">
-			<%= raw t('pages.home.signed_in_empty.cell_two', {
-					categories: link_to(t('categories.plural'), categories_path),
-					moments: link_to(t('moments.plural'), moments_path)
-				}) %>
-		</div>
-	</div>
+    <div class="table_cell vertical_align_middle onboarding_message">
+      <%= raw t('pages.home.signed_in_empty.cell_two', {
+        categories: link_to(t('categories.plural'), categories_path),
+        moments: link_to(t('moments.plural'), moments_path)
+      }) %>
+    </div>
+  </div>
 </div>
 
 <div class="main_message">
-	<div class="spacer"></div>
-	<%= t('pages.home.signed_in_empty.main_message_four') %>
+  <div class="spacer"></div>
+  <%= t('pages.home.signed_in_empty.main_message_four') %>
 </div>
 <div class="table onboarding">
-	<div class="table_row">
-		<div class="table_cell message_cell center_div vertical_align_middle padding_bottom">
-			<div id="time"></div>
-		</div>
+  <div class="table_row">
+    <div class="table_cell message_cell center_div vertical_align_middle padding_bottom">
+      <div id="time"></div>
+    </div>
 
-		<div class="table_cell vertical_align_middle onboarding_message">
-			<%= raw t('pages.home.signed_in_empty.cell_three', {
-					strategize: link_to(t('pages.home.signed_in_empty.strategize'), strategies_path),
-					medications: link_to(t('medications.index.title'), medications_path),
-					group: link_to(t('groups.singular'), groups_path)
-				}) %>
-		</div>
-	</div>
+    <div class="table_cell vertical_align_middle onboarding_message">
+      <%= raw t('pages.home.signed_in_empty.cell_three', {
+        strategize: link_to(t('pages.home.signed_in_empty.strategize'), strategies_path),
+        medications: link_to(t('medications.index.title'), medications_path),
+        group: link_to(t('groups.singular'), groups_path)
+      }) %>
+    </div>
+  </div>
 </div>
 
 <div class="horizonal_divider"></div>
 
 <div class="main_message">
-	<%= t('pages.home.signed_in_empty.main_message_five') %>
+  <%= t('pages.home.signed_in_empty.main_message_five') %>
 </div>
 <div class="message_text">
-	<%= raw t('pages.home.signed_in_empty.message_text_three', {
-			faq: link_to(t('navigation.faq'), faq_path),
-			email_link: link_to(t('common.write_to_us'), "mailto:#{t('email')}")
-		}) %>
+  <%= raw t('pages.home.signed_in_empty.message_text_three', {
+    faq: link_to(t('navigation.faq'), faq_path),
+    email_link: link_to(t('common.write_to_us'), "mailto:#{t('email')}")
+  }) %>
 </div>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,46 +1,46 @@
 <% title t('navigation.about') %>
 
 <div class="main_message">
-	<%= raw t('pages.about.main_message_one', {
-			app_name: t('app_name')
-		}) %>
+  <%= raw t('pages.about.main_message_one', {
+    app_name: t('app_name')
+  }) %>
 </div>
 
 <div class="message_text">
-	<%= t('pages.about.message_text_one') %>
-	<div class="spacer"></div>
+  <%= t('pages.about.message_text_one') %>
+  <div class="spacer"></div>
 </div>
 
 <div class="horizonal_divider"></div>
 
 <div class="main_message">
-	<div class="spacer"></div>
-	<%= t('pages.about.main_message_two') %>
+  <div class="spacer"></div>
+  <%= t('pages.about.main_message_two') %>
 </div>
 
 <div class="message_text">
-	<%= raw t('pages.about.message_text_two') %>
-	<div class="spacer"></div>
+  <%= raw t('pages.about.message_text_two') %>
+  <div class="spacer"></div>
 </div>
 
 <div class="horizonal_divider"></div>
 
 <div class="main_message">
-	<div class="spacer"></div>
-	<%= t('pages.about.main_message_three') %>
+  <div class="spacer"></div>
+  <%= t('pages.about.main_message_three') %>
 </div>
 
 <div class="message_text">
-	<%= raw t('pages.about.message_text_three', {
-			linebreak_link: link_to(t('pages.about.linebreak'), 'https://linebreak.co', target: 'blank'),
-			fund_club_link: link_to(t('pages.about.fund_club'), 'http://joinfundclub.com', target: 'blank'),
-			patreon_link: link_to(t('navigation.patreon'), 'http://patreon.com/ifme', target: 'blank'),
-			opencollective_link: link_to(t('navigation.opencollective'), 'https://opencollective.com/ifme', target: 'blank')
-		}) %>
+  <%= raw t('pages.about.message_text_three', {
+    linebreak_link: link_to(t('pages.about.linebreak'), 'https://linebreak.co', target: 'blank'),
+    fund_club_link: link_to(t('pages.about.fund_club'), 'http://joinfundclub.com', target: 'blank'),
+    patreon_link: link_to(t('navigation.patreon'), 'http://patreon.com/ifme', target: 'blank'),
+    opencollective_link: link_to(t('navigation.opencollective'), 'https://opencollective.com/ifme', target: 'blank')
+  }) %>
 
-	<p class="no_margin_bottom">
-		<%= raw t('pages.about.email_us', {
-			email_link: link_to(t('pages.about.send_us'), "mailto:#{t('email')}")
-		}) %>
-	</p>
+  <p class="no_margin_bottom">
+    <%= raw t('pages.about.email_us', {
+      email_link: link_to(t('pages.about.send_us'), "mailto:#{t('email')}")
+    }) %>
+  </p>
 </div>

--- a/app/views/pages/blog.html.erb
+++ b/app/views/pages/blog.html.erb
@@ -1,17 +1,17 @@
 <% title t('navigation.blog') %>
 <%= raw t('pages.blog.description', {
-		email: link_to(t('email'), "mailto:#{t('email')}")
-	}) %>
+  email: link_to(t('email'), "mailto:#{t('email')}")
+}) %>
 <div class="spacer"></div>
 
 
 <% @posts.each_with_index do |p, index| %>
-	<% if index + 1 == @posts.length %>
-		<div class="blog_post no_margin_bottom">
-	<% else %>
-		<div class="blog_post">
-	<% end %>
-			<h1 class="blog_name"><%= link_to p["link_name"], p["link"], target: 'blank' %></h1>
-  			<%= p["author"] %>
-  		</div>
+  <% if index + 1 == @posts.length %>
+    <div class="blog_post no_margin_bottom">
+  <% else %>
+    <div class="blog_post">
+  <% end %>
+  <h1 class="blog_name"><%= link_to p["link_name"], p["link"], target: 'blank' %></h1>
+    <%= p["author"] %>
+  </div>
 <% end %>

--- a/app/views/pages/contribute.html.erb
+++ b/app/views/pages/contribute.html.erb
@@ -1,7 +1,7 @@
 <% title t('navigation.contribute') %>
 
 <div class="main_message">
-	<%= t('pages.contribute.main_message_one') %>
+  <%= t('pages.contribute.main_message_one') %>
 </div>
 
 <div class="message_text">
@@ -11,7 +11,7 @@
     github_link: link_to(t('navigation.github'), 'https://github.com/ifmeorg/ifme', target: 'blank')
     })
   %>
-	<div class="spacer"></div>
+  <div class="spacer"></div>
 </div>
 
 <div class="contributors">

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -1,48 +1,48 @@
 <% title t('pages.faq.title') %>
 <h1 class="faq_heading"><%= t('pages.faq.data_access_question') %></h1>
 <p>
- 	<%= raw t('pages.faq.data_access_answer') %>
+  <%= raw t('pages.faq.data_access_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.moment_question') %></h1>
 <p>
-	<%= raw t('pages.faq.moment_answer') %>
+  <%= raw t('pages.faq.moment_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.strategy_question') %></h1>
 <p>
-	<%= raw t('pages.faq.strategy_answer') %>
+  <%= raw t('pages.faq.strategy_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.category_question') %></h1>
 <p>
-	<%= raw t('pages.faq.category_answer') %>
+  <%= raw t('pages.faq.category_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.mood_question') %></h1>
 <p>
-	<%= raw t('pages.faq.mood_answer') %>
+  <%= raw t('pages.faq.mood_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.group_question') %></h1>
 <p>
-	<%= raw t('pages.faq.group_answer') %>
+  <%= raw t('pages.faq.group_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.medications_question') %></h1>
 <p>
-	<%= raw t('pages.faq.medications_answer') %>
+  <%= raw t('pages.faq.medications_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.invite_question') %></h1>
 <p>
-	<%= raw t('pages.faq.invite_answer') %>
+  <%= raw t('pages.faq.invite_answer') %>
 </p>
 
 <h1 class="faq_heading"><%= t('pages.faq.email_notifications_question') %></h1>
 <p class="no_margin_bottom">
-	<%= raw t('pages.faq.email_notifications_answer', {
-			desktop_icon: '<i class="fa fa-sort-up smaller_margin_left"></i>',
-			mobile_icon: '<i class="expand fa fa-bars smaller_margin_left"></i>'
-		}) %>
+  <%= raw t('pages.faq.email_notifications_answer', {
+    desktop_icon: '<i class="fa fa-sort-up smaller_margin_left"></i>',
+    mobile_icon: '<i class="expand fa fa-bars smaller_margin_left"></i>'
+  }) %>
 </p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,8 +1,8 @@
 <% title user_signed_in? && @stories.any? ? t('pages.home.stories') : t('pages.home.welcome') %>
 <% if !user_signed_in? %>
-	<%= render :partial => 'not_signed_in' %>
+	<%= render partial: 'not_signed_in' %>
 <% elsif @stories.count > 0 %>
-	<%= render :partial => '/moments/quick_moment', locals: { moment: @moment, categories: @categories, moods: @moods } %>
+	<%= render partial: '/moments/quick_moment', locals: { moment: @moment, categories: @categories, moods: @moods } %>
 
 	<div id="pages">
 		<div class="page">
@@ -11,7 +11,7 @@
 					<div class="story">
 		      	<div class="align_left">
 						  <h1 class="story_name">
-						    <%= render :partial => '/shared/viewers_hover', locals: { data: story } %>
+						    <%= render partial: '/shared/viewers_hover', locals: { data: story } %>
 						    <%= link_to story.name, story %>
 						  </h1>
 						</div>
@@ -26,7 +26,7 @@
 		     		</div>
 		     		<div class="clear"></div>
 
-		     		<%= render :partial => '/moments/info', locals: { data: story, show_strategies: true, home: true, class_name: true } %>
+		     		<%= render partial: '/moments/info', locals: { data: story, show_strategies: true, home: true, class_name: true } %>
 					</div>
 				<% end %>
 			<% end %>
@@ -35,5 +35,5 @@
 
 	<%= paginate @stories %>
 <% else %>
-	<%= render :partial => 'signed_in_empty' %>
+	<%= render partial: 'signed_in_empty' %>
 <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,39 +1,39 @@
 <% title user_signed_in? && @stories.any? ? t('pages.home.stories') : t('pages.home.welcome') %>
 <% if !user_signed_in? %>
-	<%= render partial: 'not_signed_in' %>
-<% elsif @stories.count > 0 %>
-	<%= render partial: '/moments/quick_moment', locals: { moment: @moment, categories: @categories, moods: @moods } %>
+  <%= render partial: 'not_signed_in' %>
+<% elsif @stories.any? %>
+  <%= render partial: '/moments/quick_moment', locals: { moment: @moment, categories: @categories, moods: @moods } %>
 
-	<div id="pages">
-		<div class="page">
-			<% @stories.each do |story| %>
-				<% if current_user.id == story.userid || (is_viewer(story.viewers) && are_allies?(current_user.id, story.userid)) %>
-					<div class="story">
-		      	<div class="align_left">
-						  <h1 class="story_name">
-						    <%= render partial: '/shared/viewers_hover', locals: { data: story } %>
-						    <%= link_to story.name, story %>
-						  </h1>
-						</div>
-						<div class="align_right">
-        			<h1 class="ally_name">
-        				<% if current_user.id == story.userid %>
-        					<%= link_to t('common.you'), profile_index_path(uid: current_user.uid) %>
-        				<% else %>
-        					<%= link_to User.where(:id => story.userid).first.name, profile_index_path(uid: get_uid(story.userid)) %>
-        				<% end %>
-        			</h1>
-		     		</div>
-		     		<div class="clear"></div>
+  <div id="pages">
+    <div class="page">
+      <% @stories.each do |story| %>
+        <% if current_user.id == story.userid || (is_viewer(story.viewers) && are_allies?(current_user.id, story.userid)) %>
+          <div class="story">
+            <div class="align_left">
+              <h1 class="story_name">
+                <%= render partial: '/shared/viewers_hover', locals: { data: story } %>
+                <%= link_to story.name, story %>
+              </h1>
+            </div>
+            <div class="align_right">
+              <h1 class="ally_name">
+                <% if current_user.id == story.userid %>
+                  <%= link_to t('common.you'), profile_index_path(uid: current_user.uid) %>
+                <% else %>
+                  <%= link_to User.where(id: story.userid).first.name, profile_index_path(uid: get_uid(story.userid)) %>
+                <% end %>
+              </h1>
+            </div>
+            <div class="clear"></div>
 
-		     		<%= render partial: '/moments/info', locals: { data: story, show_strategies: true, home: true, class_name: true } %>
-					</div>
-				<% end %>
-			<% end %>
-		</div>
-	</div>
+            <%= render partial: '/moments/info', locals: { data: story, show_strategies: true, home: true, class_name: true } %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 
-	<%= paginate @stories %>
+  <%= paginate @stories %>
 <% else %>
-	<%= render partial: 'signed_in_empty' %>
+  <%= render partial: 'signed_in_empty' %>
 <% end %>

--- a/app/views/pages/partners.html.erb
+++ b/app/views/pages/partners.html.erb
@@ -1,6 +1,6 @@
 <% title t('navigation.partners') %>
 <%= raw t('pages.partners.description', {
-    email: link_to(t('email'), "mailto:#{t('email')}")
-  }) %>
+  email: link_to(t('email'), "mailto:#{t('email')}")
+}) %>
 <div class="spacer"></div>
 <%= print_partners(@organizations) %>

--- a/app/views/pages/press.html.erb
+++ b/app/views/pages/press.html.erb
@@ -1,12 +1,12 @@
 <% title t('navigation.press') %>
 
 <% @press.each_with_index do |p, index| %>
-	<% if index + 1 == @press.length %>
-		<div class="blog_post no_margin_bottom">
-	<% else %>
-		<div class="blog_post">
-	<% end %>
-			<h1 class="blog_name"><%= link_to p["link_name"], p["link"], target: 'blank' %></h1>
-  			<%= p["author"] %>
-  		</div>
+  <% if index + 1 == @press.length %>
+    <div class="blog_post no_margin_bottom">
+  <% else %>
+    <div class="blog_post">
+  <% end %>
+    <h1 class="blog_name"><%= link_to p["link_name"], p["link"], target: 'blank' %></h1>
+    <%= p["author"] %>
+  </div>
 <% end %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -7,14 +7,14 @@
 
 <h1 class="privacy_heading"><%= t('pages.privacy.cookies') %></h1>
 <%= raw t('pages.privacy.cookies_description', {
-		google_privacy_policy: link_to(t('navigation.privacy').downcase, 'http://www.google.com/privacy.html', target: 'blank')
-	}) %>
+  google_privacy_policy: link_to(t('navigation.privacy').downcase, 'http://www.google.com/privacy.html', target: 'blank')
+}) %>
 
 <h1 class="privacy_heading"><%= t('pages.privacy.social_media') %></h1>
 <%= raw t('pages.privacy.social_media_description') %>
 
 <h1 class="privacy_heading"><%= t('pages.privacy.contact') %></h1>
 <%= raw t('pages.privacy.contact_description', {
-		email_link: link_to(t('common.write_to_us'), "mailto:#{t('email')}"),
-		jamie_king_media: link_to('Jamie King Media', 'http://jamieking.co.uk/resources/download-free-sample-privacy-policy.html', target: 'blank')
-	}) %>
+  email_link: link_to(t('common.write_to_us'), "mailto:#{t('email')}"),
+  jamie_king_media: link_to('Jamie King Media', 'http://jamieking.co.uk/resources/download-free-sample-privacy-policy.html', target: 'blank')
+}) %>

--- a/app/views/pages/resources.html.erb
+++ b/app/views/pages/resources.html.erb
@@ -1,10 +1,10 @@
 <% title t('navigation.resources') %>
 <%= raw t('pages.resources.description', {
-    communities: link_to(t('pages.resources.communities'), resources_path(resource: "communities")),
-    education: link_to(t('pages.resources.education'), resources_path(resource: "education")),
-    hotlines: link_to(t('pages.resources.hotlines'), resources_path(resource: "hotlines")),
-    services: link_to(t('pages.resources.services'), resources_path(resource: "services"))
-  }) %>
+  communities: link_to(t('pages.resources.communities'), resources_path(resource: "communities")),
+  education: link_to(t('pages.resources.education'), resources_path(resource: "education")),
+  hotlines: link_to(t('pages.resources.hotlines'), resources_path(resource: "hotlines")),
+  services: link_to(t('pages.resources.services'), resources_path(resource: "services"))
+}) %>
 <div class="spacer"></div>
 <%= print_resources("communities", @communities) %>
 <%= render partial: "shared/back_to_top" %>

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -34,9 +34,9 @@
   <div class="horizonal_divider"></div>
 <% end %>
 
-<%= render :partial => '/shared/stats', locals: { data_type: 'category', profile: @profile.id } %>
-<%= render :partial => '/shared/stats', locals: { data_type: 'mood', profile: @profile.id } %>
-<%= render :partial => '/shared/stats', locals: { data_type: 'strategy', profile: @profile.id } %>
+<%= render partial: '/shared/stats', locals: { data_type: 'category', profile: @profile.id } %>
+<%= render partial: '/shared/stats', locals: { data_type: 'mood', profile: @profile.id } %>
+<%= render partial: '/shared/stats', locals: { data_type: 'strategy', profile: @profile.id } %>
 
 <% if !@stories.nil? && !@stories.empty? %>
   <div class="main_message">
@@ -48,10 +48,10 @@
     <% @stories.each do |story| %>
       <div class="story">
         <h1 class="story_name">
-          <%= render :partial => '/shared/viewers_hover', locals: { data: story } %>
+          <%= render partial: '/shared/viewers_hover', locals: { data: story } %>
           <%= link_to story.name, story %>
         </h1>
-        <%= render :partial => '/moments/info', locals: { data: story, show_strategies: true, home: true, class_name: true } %>
+        <%= render partial: '/moments/info', locals: { data: story, show_strategies: true, home: true, class_name: true } %>
       </div>
     <% end %>
     </div>

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -12,25 +12,25 @@
       <%= link_to t('profile.index.edit_user'), edit_user_registration_path %>
       <div class="spacer"></div>
     <% end %>
-    <% if !User.where(:id => @profile.id).first.location.blank? %>
-      <i class="fa fa-location-arrow fa-inline"></i><%= User.where(:id => @profile.id).first.location %>
+    <% if User.where(id: @profile.id).first.location.present? %>
+      <i class="fa fa-location-arrow fa-inline"></i><%= User.where(id: @profile.id).first.location %>
       <br>
     <% end %>
     <% if @profile.id != current_user.id %>
       <% if current_user.allies_by_status(:pending_from_ally).include? @profile %>
-        <br><%= link_to t('allies.cancel_ally_request'), remove_allies_path(ally_id: @profile.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+        <br><%= link_to t('allies.cancel_ally_request'), remove_allies_path(ally_id: @profile.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
       <% elsif current_user.allies_by_status(:accepted).include? @profile %>
-        <br><%= link_to t('common.actions.remove'), remove_allies_path(ally_id: @profile.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+        <br><%= link_to t('common.actions.remove'), remove_allies_path(ally_id: @profile.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
       <% elsif current_user.allies_by_status(:pending_from_user).include? @profile %>
-        <br><%= link_to t('allies.accept'), add_allies_path(ally_id: @profile.id), :method => :post %> | <%= link_to t('allies.reject'), remove_allies_path(:ally_id => @profile.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+        <br><%= link_to t('allies.accept'), add_allies_path(ally_id: @profile.id), method: :post %> | <%= link_to t('allies.reject'), remove_allies_path(ally_id: @profile.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
       <% else %>
-        <br><%= link_to t('allies.add_ally'), add_allies_path(ally_id: @profile.id), :method => :post %>
+        <br><%= link_to t('allies.add_ally'), add_allies_path(ally_id: @profile.id), method: :post %>
       <% end %>
     <% end %>
   </div>
 </div>
 
-<% if !@stories.nil? && !@stories.empty? %>
+<% if !@stories.nil? && @stories.any? %>
   <div class="horizonal_divider"></div>
 <% end %>
 
@@ -38,7 +38,7 @@
 <%= render partial: '/shared/stats', locals: { data_type: 'mood', profile: @profile.id } %>
 <%= render partial: '/shared/stats', locals: { data_type: 'strategy', profile: @profile.id } %>
 
-<% if !@stories.nil? && !@stories.empty? %>
+<% if !@stories.nil? && @stories.any? %>
   <div class="main_message">
     Stories
   </div>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -1,9 +1,9 @@
-<%= form_for(:search, :url => search_index_path, :html => { :method => :get }) do |f| %>
-    <% if @email.nil? %>
- 		<%= f.text_field :email, :placeholder => t('search.form.search_by_email') %>
- 	<% else %>
- 		<%= f.text_field :email, :placeholder => t('search.form.search_by_email'), :value => @email %>
- 	<% end %>
+<%= form_for(:search, url: search_index_path, html: { method: :get }) do |f| %>
+  <% if @email.nil? %>
+    <%= f.text_field :email, placeholder: t('search.form.search_by_email') %>
+  <% else %>
+    <%= f.text_field :email, placeholder: t('search.form.search_by_email'), value: @email %>
+  <% end %>
 
-    <%= f.submit t('search.search'), class: 'no_margin_right' %>
+  <%= f.submit t('search.search'), class: 'no_margin_right' %>
 <% end %>

--- a/app/views/search/_posts.html.erb
+++ b/app/views/search/_posts.html.erb
@@ -1,9 +1,7 @@
 <div class="center margin_bottom">
-<%= form_for(:search, :url => posts_search_index_path, :html => { :method => :get }) do |f| %>
-
- 	<%= f.text_field :name, placeholder: t('search.search_by_name') %>
-
- 	<%= f.hidden_field :data_type, :value => local_assigns[:data_type] %>
+  <%= form_for(:search, url: posts_search_index_path, html: { method: :get }) do |f| %>
+    <%= f.text_field :name, placeholder: t('search.search_by_name') %>
+    <%= f.hidden_field :data_type, value: local_assigns[:data_type] %>
     <%= f.submit t('search.search'), class: 'no_margin_right' %>
-<% end %>
+  <% end %>
 </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -18,13 +18,13 @@
           <div class="location"><%= user.location %></div>
 
           <% if current_user.allies_by_status(:pending_from_ally).include?(user) %>
-            <%= link_to t('allies.cancel_ally_request'), remove_allies_path(ally_id: user.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+            <%= link_to t('allies.cancel_ally_request'), remove_allies_path(ally_id: user.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
           <% elsif current_user.allies_by_status(:pending_from_user).include?(user) %>
-            <%= link_to t('allies.accept'), add_allies_path(ally_id: user.id), :method => :post %>
+            <%= link_to t('allies.accept'), add_allies_path(ally_id: user.id), method: :post %>
           <% elsif current_user.allies_by_status(:accepted).include?(user) %>
-            <%= link_to t('common.actions.remove'), remove_allies_path(ally_id: user.id), :method => :post, data: { confirm: t('common.actions.confirm') } %>
+            <%= link_to t('common.actions.remove'), remove_allies_path(ally_id: user.id), method: :post, data: { confirm: t('common.actions.confirm') } %>
           <% else %>
-            <%= link_to t('allies.add_ally'), add_allies_path(ally_id: user.id), :method => :post %>
+            <%= link_to t('allies.add_ally'), add_allies_path(ally_id: user.id), method: :post %>
           <% end %>
         </div>
     <% end %>

--- a/app/views/shared/_character_count.html.erb
+++ b/app/views/shared/_character_count.html.erb
@@ -1,5 +1,5 @@
 <div class="character_count subtle">
-	<%= raw t('shared.character_count', {
-			number: content_tag(:span, '2000', id: local_assigns[:data].to_s + '_count')
-		}) %>
+  <%= raw t('shared.character_count', {
+    number: content_tag(:span, '2000', id: local_assigns[:data].to_s + '_count')
+  }) %>
 </div>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -13,7 +13,7 @@
 
     <div class="field no_margin_bottom">
       <%= f.text_area :comment, class: 'comment_textarea' %>
-      <%= render :partial => '/shared/character_count', locals: { data: 'comment_comment' } %>
+      <%= render partial: '/shared/character_count', locals: { data: 'comment_comment' } %>
     </div>
 
     <% if local_assigns[:comments].length == 0 %>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,85 +1,111 @@
-<% if ((local_assigns[:commentable_type] == 'moment' || local_assigns[:commentable_type] == 'strategy') && local_assigns[:data].comment && (current_user.id == local_assigns[:data].userid || local_assigns[:no_hide_page])) ||
-  (local_assigns[:commentable_type] == 'meeting' && local_assigns[:is_member]) %>
+<% if (
+  (
+    (
+      local_assigns[:commentable_type] == 'moment' ||
+      local_assigns[:commentable_type] == 'strategy'
+    ) &&
+    local_assigns[:data].comment &&
+    (
+      current_user.id == local_assigns[:data].userid ||
+      local_assigns[:no_hide_page]
+    )
+  ) ||
+  (
+    local_assigns[:commentable_type] == 'meeting' &&
+    local_assigns[:is_member]
+  )
+) %>
 
   <div class="horizonal_divider"></div>
 
   <div class="small_margin_top">
-  <%= form_for local_assigns[:comment], :url => { :action => "comment" }, :html => { :method => "post" } do |f| %>
-    <% if local_assigns[:comment].errors.any? %>
+    <%= form_for local_assigns[:comment], url: { action: "comment" }, html: { method: "post" } do |f| %>
+      <% if local_assigns[:comment].errors.any? %>
         <div class="error_explanation">
           <%= t('common.form.error_explanation') %>
         </div>
-    <% end %>
-
-    <div class="field no_margin_bottom">
-      <%= f.text_area :comment, class: 'comment_textarea' %>
-      <%= render partial: '/shared/character_count', locals: { data: 'comment_comment' } %>
-    </div>
-
-    <% if local_assigns[:comments].length == 0 %>
-    <div class="actions align_right no_margin_bottom">
-    <% else %>
-    <div class="actions align_right">
-    <% end %>
-      <%= f.hidden_field :commentable_type, :value => local_assigns[:commentable_type] %>
-      <%= f.hidden_field :comment_by, :value => current_user.id %>
-      <%= f.hidden_field :commentable_id, :value => local_assigns[:data].id %>
-      <% if (local_assigns[:commentable_type] == 'moment' || local_assigns[:commentable_type] == 'strategy') && local_assigns[:data].userid != current_user.id %>
-        <%= f.select :visibility, [
-          [t('shared.comments.share_everyone'), 'all'],
-          [t('shared.comments.share_with', name: User.where(:id => local_assigns[:data].userid).first.name), 'private']
-        ] %>
-      <% else %>
-        <%= f.hidden_field :visibility, :value => 'all' %>
-        <% if (local_assigns[:commentable_type] == 'moment' || local_assigns[:commentable_type] == 'strategy') && !local_assigns[:data].viewers.blank? && local_assigns[:data].viewers.length > 0 %>
-         <%= f.select :viewers, local_assigns[:data].viewers.collect { |v|
-              [ t('shared.comments.share_with', name: User.where(id: v).first.name), v ]
-             }, include_blank: t('shared.comments.share_everyone') %>
-        <% end %>
       <% end %>
-      <%= f.submit t('comment.singular'), class: 'no_margin_right small_margin_top', id: 'add_comment_button' %>
-    </div>
 
-    <div class="clear"></div>
-  <% end %>
+      <div class="field no_margin_bottom">
+        <%= f.text_area :comment, class: 'comment_textarea' %>
+        <%= render partial: '/shared/character_count', locals: { data: 'comment_comment' } %>
+      </div>
 
-  <div id="comments">
-  <% local_assigns[:comments].each do |comment| %>
-    <% if comment.visibility == 'all' ||
-      (comment.visibility == 'private' && User.where(id: comment.comment_by).exists? &&
-        (comment.comment_by == current_user.id ||
-        local_assigns[:is_member] ||
-        current_user.id == local_assigns[:data].userid ||
-        (!comment.viewers.blank? && comment.viewers.include?(current_user.id))
-        )) %>
-        <% result = generate_comment(comment, comment.commentable_type) %>
-        <% if local_assigns[:comments].first == comment %>
-        <div class="comment no_margin_top" id=<%= 'comment_' + comment.id.to_s %>>
+      <% if local_assigns[:comments].length == 0 %>
+        <div class="actions align_right no_margin_bottom">
+      <% else %>
+        <div class="actions align_right">
+      <% end %>
+
+        <%= f.hidden_field :commentable_type, value: local_assigns[:commentable_type] %>
+        <%= f.hidden_field :comment_by, value: current_user.id %>
+        <%= f.hidden_field :commentable_id, value: local_assigns[:data].id %>
+
+        <% if (local_assigns[:commentable_type] == 'moment' || local_assigns[:commentable_type] == 'strategy') && local_assigns[:data].userid != current_user.id %>
+          <%= f.select :visibility, [
+            [t('shared.comments.share_everyone'), 'all'],
+            [t('shared.comments.share_with', name: User.where(id: local_assigns[:data].userid).first.name), 'private']
+          ] %>
         <% else %>
-        <div class="comment" id=<%= 'comment_' + comment.id.to_s %>>
+          <%= f.hidden_field :visibility, value: 'all' %>
+          <% if (local_assigns[:commentable_type] == 'moment' || local_assigns[:commentable_type] == 'strategy') && !local_assigns[:data].viewers.blank? && local_assigns[:data].viewers.length > 0 %>
+            <%= f.select :viewers, local_assigns[:data].viewers.collect { |v|
+              [ t('shared.comments.share_with', name: User.where(id: v).first.name), v ]
+            }, include_blank: t('shared.comments.share_everyone') %>
+          <% end %>
         <% end %>
-          <div class="table">
-            <div class="table_row">
-              <div class="table_cell small_profile_picture_div vertical_align_middle padding_right">
-                <%= raw result[:profile_picture] %>
+
+        <%= f.submit t('comment.singular'), class: 'no_margin_right small_margin_top', id: 'add_comment_button' %>
+      </div>
+
+      <div class="clear"></div>
+    <% end %>
+
+    <div id="comments">
+      <% local_assigns[:comments].each do |comment| %>
+        <% if comment.visibility == 'all' ||
+          (
+            comment.visibility == 'private' &&
+            User.where(id: comment.comment_by).exists? &&
+            (
+              comment.comment_by == current_user.id ||
+              local_assigns[:is_member] ||
+              current_user.id == local_assigns[:data].userid ||
+              (
+                !comment.viewers.blank? &&
+                comment.viewers.include?(current_user.id)
+              )
+            )
+          )
+        %>
+          <% result = generate_comment(comment, comment.commentable_type) %>
+          <% if local_assigns[:comments].first == comment %>
+            <div class="comment no_margin_top" id=<%= 'comment_' + comment.id.to_s %>>
+          <% else %>
+            <div class="comment" id=<%= 'comment_' + comment.id.to_s %>>
+          <% end %>
+            <div class="table">
+              <div class="table_row">
+                <div class="table_cell small_profile_picture_div vertical_align_middle padding_right">
+                  <%= raw result[:profile_picture] %>
+                </div>
+                <div class="table_cell">
+                  <div class="comment_info">
+                    <%= raw result[:comment_info] %>
+                  </div>
+                  <div class="comment_text">
+                    <%= raw result[:comment_text] %>
+                  </div>
+                  <div class="subtle">
+                    <%= raw result[:visibility] %>
+                  </div>
+                </div>
+                <%= raw result[:delete_comment] %>
               </div>
-              <div class="table_cell">
-                <div class="comment_info">
-                  <%= raw result[:comment_info] %>
-                </div>
-                <div class="comment_text">
-                  <%= raw result[:comment_text] %>
-                </div>
-                <div class="subtle">
-                  <%= raw result[:visibility] %>
-                </div>
-              </div>
-              <%= raw result[:delete_comment] %>
             </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
-  <% end %>
-  </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,54 +1,54 @@
 <div id="footer">
-		<div id="footer_content">
-			<div class="table">
-				<div class="row">
-					<div class="table_cell large_padding_right">
-						<span class="footer_heading" id="if_me_links"><%= t('app_name') %></span>
-						<%= link_to(t('navigation.about'), about_path) %>
-						<%= link_to(t('navigation.blog'), blog_path) %>
-						<%= link_to(t('navigation.contribute'), contribute_path) %>
-						<%= link_to(t('navigation.faq'), faq_path) %>
-						<%= link_to(t('navigation.partners'), partners_path) %>
-						<%= link_to(t('navigation.press'), press_path) %>
-						<%= link_to(t('navigation.privacy'), privacy_path) %>
-					</div>
-					<div class="table_cell large_padding_right">
-						<span class="footer_heading" id="connect_links"><%= t('shared.footer.connect') %></span>
-						<%= link_to(get_icon_text('envelope', t('common.form.email')), 'mailto:join.ifme@gmail.com') %>
-						<%= link_to(get_icon_text('facebook', t('navigation.facebook')), "http://facebook.com/ifmeorg", target: "blank") %>
-						<%= link_to(get_icon_text('github', t('navigation.github')), "https://github.com/ifmeorg/ifme", target: "blank") %>
-						<%= link_to(get_icon_text('instagram', t('navigation.instagram')), 'https://www.instagram.com/ifmeorg', target: "blank") %>
-						<%= link_to(get_icon_text('medium', t('navigation.medium')), 'https://medium.com/ifme', target: "blank") %>
-						<%= link_to(get_icon_text('gift', t('navigation.opencollective')), 'https://opencollective.com/ifme', target: "blank") %>
-						<%= link_to(get_icon_text('money-bill-alt', t('navigation.patreon')), 'http://patreon.com/ifme', target: "blank") %>
-						<%= link_to(get_icon_text('rss', t('navigation.rss')), "https://medium.com/feed/ifme", target: "blank") %>
-						<%= link_to(get_icon_text('twitter', t('navigation.twitter')), "http://twitter.com/ifmeorg", target: "blank") %>
-					</div>
-					<div class="table_cell large_padding_right">
-						<span class="footer_heading" id="resources_links"><%= t('navigation.resources') %></span>
-						<%= link_to(t('pages.resources.communities'), resources_path(resource: "communities")) %>
-						<%= link_to(t('pages.resources.education'), resources_path(resource: "education")) %>
-						<%= link_to(t('pages.resources.hotlines'), resources_path(resource: "hotlines")) %>
-						<%= link_to(t('pages.resources.services'), resources_path(resource: "services")) %>
-					</div>
-					<div id="locale_toggle" class="table_cell">
-						<span class="footer_heading" id="language_links"><%= t('language') %></span>
-						<%= render partial: "shared/locale" %>
-					</div>
-				</div>
-			</div>
-			<div class="spacer"></div>
-			<div class="align_left">
-				<%= link_to(t('navigation.give_feedback').titleize, "http://goo.gl/forms/8EqoJDDiXY", class: "highlight", target: "blank", id: "feedback") %>
-			</div>
-			<div class="align_right license">
-				<%= content_tag(:span, raw(t('shared.footer.license')), class: 'yes_title', title: t('shared.footer.foss')) %>
-				<div class="footer_subtitle">
-					<%= raw t('shared.footer.license_subtitle',
-						license: link_to(t('shared.footer.licence_name'), "https://github.com/ifmeorg/ifme/blob/master/LICENSE.txt", target: "blank"))
-					%>
-				</div>
-			</div>
-			<div class="clear"></div>
-		</div>
-	</div>
+  <div id="footer_content">
+    <div class="table">
+      <div class="row">
+        <div class="table_cell large_padding_right">
+          <span class="footer_heading" id="if_me_links"><%= t('app_name') %></span>
+          <%= link_to(t('navigation.about'), about_path) %>
+          <%= link_to(t('navigation.blog'), blog_path) %>
+          <%= link_to(t('navigation.contribute'), contribute_path) %>
+          <%= link_to(t('navigation.faq'), faq_path) %>
+          <%= link_to(t('navigation.partners'), partners_path) %>
+          <%= link_to(t('navigation.press'), press_path) %>
+          <%= link_to(t('navigation.privacy'), privacy_path) %>
+        </div>
+        <div class="table_cell large_padding_right">
+          <span class="footer_heading" id="connect_links"><%= t('shared.footer.connect') %></span>
+          <%= link_to(get_icon_text('envelope', t('common.form.email')), 'mailto:join.ifme@gmail.com') %>
+          <%= link_to(get_icon_text('facebook', t('navigation.facebook')), "http://facebook.com/ifmeorg", target: "blank") %>
+          <%= link_to(get_icon_text('github', t('navigation.github')), "https://github.com/ifmeorg/ifme", target: "blank") %>
+          <%= link_to(get_icon_text('instagram', t('navigation.instagram')), 'https://www.instagram.com/ifmeorg', target: "blank") %>
+          <%= link_to(get_icon_text('medium', t('navigation.medium')), 'https://medium.com/ifme', target: "blank") %>
+          <%= link_to(get_icon_text('gift', t('navigation.opencollective')), 'https://opencollective.com/ifme', target: "blank") %>
+          <%= link_to(get_icon_text('money-bill-alt', t('navigation.patreon')), 'http://patreon.com/ifme', target: "blank") %>
+          <%= link_to(get_icon_text('rss', t('navigation.rss')), "https://medium.com/feed/ifme", target: "blank") %>
+          <%= link_to(get_icon_text('twitter', t('navigation.twitter')), "http://twitter.com/ifmeorg", target: "blank") %>
+        </div>
+        <div class="table_cell large_padding_right">
+          <span class="footer_heading" id="resources_links"><%= t('navigation.resources') %></span>
+          <%= link_to(t('pages.resources.communities'), resources_path(resource: "communities")) %>
+          <%= link_to(t('pages.resources.education'), resources_path(resource: "education")) %>
+          <%= link_to(t('pages.resources.hotlines'), resources_path(resource: "hotlines")) %>
+          <%= link_to(t('pages.resources.services'), resources_path(resource: "services")) %>
+        </div>
+        <div id="locale_toggle" class="table_cell">
+          <span class="footer_heading" id="language_links"><%= t('language') %></span>
+          <%= render partial: "shared/locale" %>
+        </div>
+      </div>
+    </div>
+    <div class="spacer"></div>
+    <div class="align_left">
+      <%= link_to(t('navigation.give_feedback').titleize, "http://goo.gl/forms/8EqoJDDiXY", class: "highlight", target: "blank", id: "feedback") %>
+    </div>
+    <div class="align_right license">
+      <%= content_tag(:span, raw(t('shared.footer.license')), class: 'yes_title', title: t('shared.footer.foss')) %>
+      <div class="footer_subtitle">
+        <%= raw t('shared.footer.license_subtitle',
+          license: link_to(t('shared.footer.licence_name'), "https://github.com/ifmeorg/ifme/blob/master/LICENSE.txt", target: "blank"))
+        %>
+      </div>
+    </div>
+    <div class="clear"></div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,66 +9,66 @@
 
       <ul id="small_nav" class="display_none">
       <% if user_signed_in? %>
-          <%= nav_link_to(t('moments.plural'), moments_path) %>
-          <%= nav_link_to(t('categories.plural'), categories_path) %>
-          <%= nav_link_to(t('moods.plural'), moods_path) %>
-          <%= nav_link_to(t('strategies.plural'), strategies_path) %>
-          <%= nav_link_to(t('medications.index.title'), medications_path) %>
-          <%= nav_link_to(t('groups.plural'), groups_path) %>
-          <%= nav_link_to(t('allies.index.title'), allies_path) %>
-          <div class="horizonal_divider"></div>
-          <%= nav_link_to(t('notifications.plural'), "", class: 'notifications_button') %>
-          <%= nav_link_to(t('profile.index.title'), profile_index_path(uid: current_user.uid)) %>
-          <%= nav_link_to(t('account.singular'), edit_user_registration_path) %>
-          <%= nav_link_to(t('navigation.resources'), resources_path) %>
-          <%= nav_link_to(t('shared.header.signout'), destroy_user_session_path, :method => :delete) %>
-        <% else %>
-          <%= nav_link_to(t('account.sign_in'), new_user_session_path) %>
-          <%= nav_link_to(t('common.actions.join'), new_user_registration_path) %>
-          <div class="horizonal_divider"></div>
-          <%= nav_link_to(t('navigation.about'), about_path) %>
-          <%= nav_link_to(t('navigation.blog'), blog_path) %>
-          <%= nav_link_to(t('navigation.resources'), resources_path) %>
-        <% end %>
-      </ul>
-    </div>
-
-    <div class="ifme-logo large-screen">
-      <%= render "shared/menu_logo" %>
-
-      <ul class="top-nav primary-nav">
-        <% if user_signed_in? %>
-          <%= nav_link_to(t('shared.header.home'), root_path)  %>
-          <%= nav_link_to(t('moments.plural'), moments_path, class: "expand_moment_button") %>
-          <%= nav_link_to(t('strategies.plural'), strategies_path) %>
-          <%= nav_link_to(t('medications.index.title'), medications_path) %>
-          <%= nav_link_to(t('groups.plural'), groups_path) %>
-          <%= nav_link_to(t('allies.index.title'), allies_path) %>
-        <% else %>
-          <%= nav_link_to(t('account.sign_in'), new_user_session_path) %>
-          <%= nav_link_to(t('common.actions.join'), new_user_registration_path) %>
-          <li><div class="vertical_divider"></div></li>
-          <%= nav_link_to(t('navigation.about'), about_path) %>
-          <%= nav_link_to(t('navigation.blog'), blog_path) %>
-          <%= nav_link_to(t('navigation.resources'), resources_path) %>
-        <% end %>
-        <div class="clear"></div>
-      </ul>
-
-      <% if user_signed_in? %>
-        <ul id="expand_moment" class="top-nav display_none">
-          <%= nav_link_to(t('categories.plural'), categories_path) %>
-          <%= nav_link_to(t('moods.plural'), moods_path) %>
-        </ul>
-
-        <ul id="expand_me" class="top-nav large-screen display_none">
-          <%= nav_link_to(t('notifications.plural'), "", class: 'notifications_button') %>
-          <%= nav_link_to(t('profile.index.title'), profile_index_path(uid: current_user.uid)) %>
-          <%= nav_link_to(t('account.singular'), edit_user_registration_path) %>
-          <%= nav_link_to(t('navigation.resources'), resources_path) %>
-          <%= nav_link_to(t('shared.header.signout'), destroy_user_session_path, :method => :delete) %>
-        </ul>
+        <%= nav_link_to(t('moments.plural'), moments_path) %>
+        <%= nav_link_to(t('categories.plural'), categories_path) %>
+        <%= nav_link_to(t('moods.plural'), moods_path) %>
+        <%= nav_link_to(t('strategies.plural'), strategies_path) %>
+        <%= nav_link_to(t('medications.index.title'), medications_path) %>
+        <%= nav_link_to(t('groups.plural'), groups_path) %>
+        <%= nav_link_to(t('allies.index.title'), allies_path) %>
+        <div class="horizonal_divider"></div>
+        <%= nav_link_to(t('notifications.plural'), "", class: 'notifications_button') %>
+        <%= nav_link_to(t('profile.index.title'), profile_index_path(uid: current_user.uid)) %>
+        <%= nav_link_to(t('account.singular'), edit_user_registration_path) %>
+        <%= nav_link_to(t('navigation.resources'), resources_path) %>
+        <%= nav_link_to(t('shared.header.signout'), destroy_user_session_path, method: :delete) %>
+      <% else %>
+        <%= nav_link_to(t('account.sign_in'), new_user_session_path) %>
+        <%= nav_link_to(t('common.actions.join'), new_user_registration_path) %>
+        <div class="horizonal_divider"></div>
+        <%= nav_link_to(t('navigation.about'), about_path) %>
+        <%= nav_link_to(t('navigation.blog'), blog_path) %>
+        <%= nav_link_to(t('navigation.resources'), resources_path) %>
       <% end %>
+    </ul>
+  </div>
+
+  <div class="ifme-logo large-screen">
+    <%= render "shared/menu_logo" %>
+
+    <ul class="top-nav primary-nav">
+      <% if user_signed_in? %>
+        <%= nav_link_to(t('shared.header.home'), root_path)  %>
+        <%= nav_link_to(t('moments.plural'), moments_path, class: "expand_moment_button") %>
+        <%= nav_link_to(t('strategies.plural'), strategies_path) %>
+        <%= nav_link_to(t('medications.index.title'), medications_path) %>
+        <%= nav_link_to(t('groups.plural'), groups_path) %>
+        <%= nav_link_to(t('allies.index.title'), allies_path) %>
+      <% else %>
+        <%= nav_link_to(t('account.sign_in'), new_user_session_path) %>
+        <%= nav_link_to(t('common.actions.join'), new_user_registration_path) %>
+        <li><div class="vertical_divider"></div></li>
+        <%= nav_link_to(t('navigation.about'), about_path) %>
+        <%= nav_link_to(t('navigation.blog'), blog_path) %>
+        <%= nav_link_to(t('navigation.resources'), resources_path) %>
+      <% end %>
+      <div class="clear"></div>
+    </ul>
+
+    <% if user_signed_in? %>
+      <ul id="expand_moment" class="top-nav display_none">
+        <%= nav_link_to(t('categories.plural'), categories_path) %>
+        <%= nav_link_to(t('moods.plural'), moods_path) %>
+      </ul>
+
+      <ul id="expand_me" class="top-nav large-screen display_none">
+        <%= nav_link_to(t('notifications.plural'), "", class: 'notifications_button') %>
+        <%= nav_link_to(t('profile.index.title'), profile_index_path(uid: current_user.uid)) %>
+        <%= nav_link_to(t('account.singular'), edit_user_registration_path) %>
+        <%= nav_link_to(t('navigation.resources'), resources_path) %>
+        <%= nav_link_to(t('shared.header.signout'), destroy_user_session_path, method: :delete) %>
+      </ul>
+    <% end %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -39,7 +39,7 @@
       <ul class="top-nav primary-nav">
         <% if user_signed_in? %>
           <%= nav_link_to(t('shared.header.home'), root_path)  %>
-          <%= nav_link_to(t('moments.plural'), moments_path, :class => "expand_moment_button") %>
+          <%= nav_link_to(t('moments.plural'), moments_path, class: "expand_moment_button") %>
           <%= nav_link_to(t('strategies.plural'), strategies_path) %>
           <%= nav_link_to(t('medications.index.title'), medications_path) %>
           <%= nav_link_to(t('groups.plural'), groups_path) %>

--- a/app/views/shared/_locale.html.erb
+++ b/app/views/shared/_locale.html.erb
@@ -1,1 +1,1 @@
-<%= select_tag "locale", options_for_select(@locales.collect{ |l| [l[:name], l[:locale]] }, @locale) %>
+<%= select_tag 'locale', options_for_select(@locales.collect{ |l| [l[:name], l[:locale]] }, @locale) %>

--- a/app/views/shared/_menu_logo.html.erb
+++ b/app/views/shared/_menu_logo.html.erb
@@ -1,10 +1,10 @@
 <% if user_signed_in? %>
-<span id="title_expand" class="expand_button header-logo">
-  <span class="logo-text">If <span id="me" class="me">Me</span></span>
-    <i class="expand fa fa-sort-down"></i>
-</span>
+  <span id="title_expand" class="expand_button header-logo">
+    <span class="logo-text">If <span id="me" class="me">Me</span></span>
+      <i class="expand fa fa-sort-down"></i>
+  </span>
 <% else %>
-<a id="title_expand" class="expand_button header-logo" href=<%= root_path %>>
-  <span class="logo-text">If <span id="me" class="me">Me</span></span>
-</a>
+  <a id="title_expand" class="expand_button header-logo" href=<%= root_path %>>
+    <span class="logo-text">If <span id="me" class="me">Me</span></span>
+  </a>
 <% end %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -4,12 +4,12 @@
   </div>
   <div class="align_right">
     <% if local_assigns[:modal_clear] %>
-      <% if Notification.all.size > 0 %>
+      <% if Notification.all.any? %>
         <h1 id="clear_notifications" class="align_left small_margin_right"><%= local_assigns[:modal_clear] %></h1>
       <% else %>
       <% end %>
       <h1 id="close_notifications" class="align_right"><i class="fa fa-times"></i></h1>
-    <div class="clear"></div>
+      <div class="clear"></div>
     <% elsif local_assigns[:modal_close_class] %>
       <h1 class=<%= "#{local_assigns[:modal_close_class].to_s} align_right" %>><i class="fa fa-times"></i></h1>
     <% elsif local_assigns[:modal_close_id] %>

--- a/app/views/shared/_moments_strategies.html.erb
+++ b/app/views/shared/_moments_strategies.html.erb
@@ -1,11 +1,11 @@
 <% if local_assigns[:data_type] == 'moment' || local_assigns[:data_type] == 'moment_tag_usage' %>
     <div class="moment">
       <h1 class="moment_name">
-        <%= render :partial => '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
+        <%= render partial: '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
         <%= link_to local_assigns[:item].name, local_assigns[:item] %>
       </h1>
 
-      <%= render :partial => '/moments/info', locals: { data: local_assigns[:item], show_strategies: true } %>
+      <%= render partial: '/moments/info', locals: { data: local_assigns[:item], show_strategies: true } %>
 
       <% if current_user.id == local_assigns[:item].userid %>
       <div class="small_margin_top">
@@ -19,7 +19,7 @@
 <% elsif local_assigns[:data_type] == 'strategy' || local_assigns[:data_type] == 'strategy_tag_usage' %>
       <div class="strategy">
       <h1 class="strategy_name">
-        <%= render :partial => '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
+        <%= render partial: '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
         <%= link_to local_assigns[:item].name, local_assigns[:item] %>
       </h1>
       <% if !local_assigns[:item].published? %>
@@ -38,7 +38,7 @@
           <% if Category.where(id: item, userid: current_user.id).exists? %>
           <span class="notification_wrapper">
             <span class="tip_notifications_button link_style"><%= Category.where(id: item).first.name %></span><% if local_assigns[:item].category.last != item %><%= ', ' %><% end %>
-            <%= render :partial => '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
+            <%= render partial: '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
           </span>
           <% end %>
         <% end %>

--- a/app/views/shared/_moments_strategies.html.erb
+++ b/app/views/shared/_moments_strategies.html.erb
@@ -1,55 +1,55 @@
 <% if local_assigns[:data_type] == 'moment' || local_assigns[:data_type] == 'moment_tag_usage' %>
-    <div class="moment">
-      <h1 class="moment_name">
-        <%= render partial: '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
-        <%= link_to local_assigns[:item].name, local_assigns[:item] %>
-      </h1>
+  <div class="moment">
+    <h1 class="moment_name">
+      <%= render partial: '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
+      <%= link_to local_assigns[:item].name, local_assigns[:item] %>
+    </h1>
 
-      <%= render partial: '/moments/info', locals: { data: local_assigns[:item], show_strategies: true } %>
+    <%= render partial: '/moments/info', locals: { data: local_assigns[:item], show_strategies: true } %>
 
-      <% if current_user.id == local_assigns[:item].userid %>
+    <% if current_user.id == local_assigns[:item].userid %>
       <div class="small_margin_top">
         <i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), edit_moment_path(local_assigns[:item]) %>
         <% if local_assigns[:data_type] == 'moment' %>
-        <i class="fa fa-trash-alt action small_margin_left"></i><%= link_to t('common.actions.delete'), local_assigns[:item], method: :delete, data: { confirm: t('common.actions.confirm') } %>
+          <i class="fa fa-trash-alt action small_margin_left"></i><%= link_to t('common.actions.delete'), local_assigns[:item], method: :delete, data: { confirm: t('common.actions.confirm') } %>
         <% end %>
       </div>
-      <% end %>
-    </div>
+    <% end %>
+  </div>
 <% elsif local_assigns[:data_type] == 'strategy' || local_assigns[:data_type] == 'strategy_tag_usage' %>
-      <div class="strategy">
-      <h1 class="strategy_name">
-        <%= render partial: '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
-        <%= link_to local_assigns[:item].name, local_assigns[:item] %>
-      </h1>
-      <% if !local_assigns[:item].published? %>
-        <span class="draft-badge">
-          <i class="fa fa-tag" aria-hidden="true"></i>
-          <%= I18n.t 'draft' %>
+  <div class="strategy">
+    <h1 class="strategy_name">
+      <%= render partial: '/shared/viewers_hover', locals: { data: local_assigns[:item] } %>
+      <%= link_to local_assigns[:item].name, local_assigns[:item] %>
+    </h1>
+    <% if !local_assigns[:item].published? %>
+      <span class="draft-badge">
+        <i class="fa fa-tag" aria-hidden="true"></i>
+        <%= I18n.t 'draft' %>
+      </span>
+    <% end %>
+    <%= ::TimeAgo.created_or_edited(local_assigns[:item]) %>
+    <% if local_assigns[:item].category.count > 0 %>
+      <br>
+      <strong>
+        <%= t('categories.label', count: local_assigns[:item].category.count) %>
+      </strong>
+      <% local_assigns[:item].category.each do |item| %>
+        <% if Category.where(id: item, userid: current_user.id).exists? %>
+        <span class="notification_wrapper">
+          <span class="tip_notifications_button link_style"><%= Category.where(id: item).first.name %></span><% if local_assigns[:item].category.last != item %><%= ', ' %><% end %>
+          <%= render partial: '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
         </span>
-      <% end %>
-      <%= ::TimeAgo.created_or_edited(local_assigns[:item]) %>
-      <% if local_assigns[:item].category.count > 0 %>
-        <br>
-        <strong>
-          <%= t('categories.label', count: local_assigns[:item].category.count) %>
-        </strong>
-        <% local_assigns[:item].category.each do |item| %>
-          <% if Category.where(id: item, userid: current_user.id).exists? %>
-          <span class="notification_wrapper">
-            <span class="tip_notifications_button link_style"><%= Category.where(id: item).first.name %></span><% if local_assigns[:item].category.last != item %><%= ', ' %><% end %>
-            <%= render partial: '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
-          </span>
-          <% end %>
         <% end %>
       <% end %>
-      <% if current_user.id == local_assigns[:item].userid %>
+    <% end %>
+    <% if current_user.id == local_assigns[:item].userid %>
       <div class="small_margin_top">
         <i class="fa fa-pencil-alt action"></i><%= link_to t('common.actions.edit'), edit_strategy_path(local_assigns[:item]) %>
         <% if local_assigns[:data_type] == 'strategy' %>
-        <i class="fa fa-trash-alt action small_margin_left"></i><%= link_to t('common.actions.delete'), local_assigns[:item], method: :delete, data: { confirm: t('common.actions.confirm') } %>
+          <i class="fa fa-trash-alt action small_margin_left"></i><%= link_to t('common.actions.delete'), local_assigns[:item], method: :delete, data: { confirm: t('common.actions.confirm') } %>
         <% end %>
       </div>
-      <% end %>
-    </div>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/shared/_quick_create.html.erb
+++ b/app/views/shared/_quick_create.html.erb
@@ -1,46 +1,46 @@
 <div class="quick_create display_none" id=<%= "#{local_assigns[:data_type].to_s}_quick_create" %> >
-	<div class="quick_create_text">
-		<%= render partial: '/shared/modal',
-			locals: {
-				modal_title: "#{t('shared.quick_create.new', name: local_assigns[:data_type].to_s.titleize)}",
-				modal_close_class: 'quick_create_close',
-			}
-		%>
+  <div class="quick_create_text">
+    <%= render partial: '/shared/modal',
+      locals: {
+        modal_title: "#{t('shared.quick_create.new', name: local_assigns[:data_type].to_s.titleize)}",
+        modal_close_class: 'quick_create_close',
+      }
+    %>
 
-		<div class="modal_text">
-		<%
-			if local_assigns[:data_type] == 'category'
-				url = quick_create_categories_path
-			elsif local_assigns[:data_type] == 'mood'
-				url = quick_create_moods_path
-			elsif local_assigns[:data_type] == 'strategy'
-				url = quick_create_strategies_path
-			end
-		%>
+    <div class="modal_text">
+      <%
+        if local_assigns[:data_type] == 'category'
+          url = quick_create_categories_path
+        elsif local_assigns[:data_type] == 'mood'
+          url = quick_create_moods_path
+        elsif local_assigns[:data_type] == 'strategy'
+          url = quick_create_strategies_path
+        end
+      %>
 
-		<%= form_for(local_assigns[:data], url: url) do |f| %>
-			<% if local_assigns[:data].errors.any? %>
-			  	<div class="error_explanation">
-			  	<% if local_assigns[:data_type] == 'category' %>
-					<%= t('common.form.error_explanation') %>
-			  	<% elsif local_assigns[:data_type] == 'mood' %>
-					<%= t('common.form.error_explanation') %>
-			  	<% elsif local_assigns[:data_type] == 'strategy' %>
-					<%= t('common.form.error_explanation') %>
-			  	<% end %>
-			  	</div>
-			<% end %>
+      <%= form_for(local_assigns[:data], url: url) do |f| %>
+        <% if local_assigns[:data].errors.any? %>
+          <div class="error_explanation">
+            <% if local_assigns[:data_type] == 'category' %>
+              <%= t('common.form.error_explanation') %>
+            <% elsif local_assigns[:data_type] == 'mood' %>
+              <%= t('common.form.error_explanation') %>
+            <% elsif local_assigns[:data_type] == 'strategy' %>
+              <%= t('common.form.error_explanation') %>
+            <% end %>
+          </div>
+        <% end %>
 
-			<%= render partial: '/shared/quick_create_fields', locals: { data_type: local_assigns[:data_type], f: f } %>
+        <%= render partial: '/shared/quick_create_fields', locals: { data_type: local_assigns[:data_type], f: f } %>
 
-			<div class="clear"></div>
+        <div class="clear"></div>
 
-			<div class="actions no_margin_bottom">
-				<%= f.hidden_field :tag, :value => local_assigns[:tag] %>
-				<%= f.hidden_field :data_type, :value => local_assigns[:data_type] %>
-				<%= f.submit t('common.actions.add') %>
-			</div>
-		<% end %>
-		</div>
-	</div>
+        <div class="actions no_margin_bottom">
+          <%= f.hidden_field :tag, value: local_assigns[:tag] %>
+          <%= f.hidden_field :data_type, value: local_assigns[:data_type] %>
+          <%= f.submit t('common.actions.add') %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/shared/_quick_create.html.erb
+++ b/app/views/shared/_quick_create.html.erb
@@ -1,6 +1,6 @@
 <div class="quick_create display_none" id=<%= "#{local_assigns[:data_type].to_s}_quick_create" %> >
 	<div class="quick_create_text">
-		<%= render :partial => '/shared/modal',
+		<%= render partial: '/shared/modal',
 			locals: {
 				modal_title: "#{t('shared.quick_create.new', name: local_assigns[:data_type].to_s.titleize)}",
 				modal_close_class: 'quick_create_close',
@@ -31,7 +31,7 @@
 			  	</div>
 			<% end %>
 
-			<%= render :partial => '/shared/quick_create_fields', locals: { data_type: local_assigns[:data_type], f: f } %>
+			<%= render partial: '/shared/quick_create_fields', locals: { data_type: local_assigns[:data_type], f: f } %>
 
 			<div class="clear"></div>
 

--- a/app/views/shared/_quick_create_fields.html.erb
+++ b/app/views/shared/_quick_create_fields.html.erb
@@ -64,7 +64,7 @@
 		<div class="clear"></div>
 	</div>
 	<%= local_assigns[:f].text_area :description, class: 'no_title' %>
-	<%= render :partial => '/shared/character_count', locals: { data: 'strategy_description' } %>
+	<%= render partial: '/shared/character_count', locals: { data: 'strategy_description' } %>
 </div>
 
 <% end %>

--- a/app/views/shared/_quick_create_fields.html.erb
+++ b/app/views/shared/_quick_create_fields.html.erb
@@ -6,7 +6,7 @@
 		<i class="fa fa-asterisk align_right"></i>
 		<div class="clear"></div>
 	</div>
-	<%= local_assigns[:f].text_field :name, :class => "name_field" %>
+	<%= local_assigns[:f].text_field :name, class: "name_field" %>
 </div>
 
 <div class="field">
@@ -24,7 +24,7 @@
 		<i class="fa fa-asterisk align_right"></i>
 		<div class="clear"></div>
 	</div>
-	<%= local_assigns[:f].text_field :name, :class => "name_field" %>
+	<%= local_assigns[:f].text_field :name, class: "name_field" %>
 </div>
 
 <div class="field">
@@ -42,7 +42,7 @@
 		<i class="fa fa-asterisk align_right"></i>
 		<div class="clear"></div>
 	</div>
-	<%= local_assigns[:f].text_field :name, :class => "name_field" %>
+	<%= local_assigns[:f].text_field :name, class: "name_field" %>
 </div>
 
 <% categories = Category.where(userid: current_user.id).all %>

--- a/app/views/shared/_quick_create_fields.html.erb
+++ b/app/views/shared/_quick_create_fields.html.erb
@@ -1,70 +1,70 @@
 <% if local_assigns[:data_type] == 'category' %>
 
-<div class="field">
-	<div class="label">
-		<%= local_assigns[:f].label t('common.name') %>
-		<i class="fa fa-asterisk align_right"></i>
-		<div class="clear"></div>
-	</div>
-	<%= local_assigns[:f].text_field :name, class: "name_field" %>
-</div>
+  <div class="field">
+    <div class="label">
+      <%= local_assigns[:f].label t('common.name') %>
+      <i class="fa fa-asterisk align_right"></i>
+      <div class="clear"></div>
+    </div>
+    <%= local_assigns[:f].text_field :name, class: "name_field" %>
+  </div>
 
-<div class="field">
-	<div class="label">
-		<%= local_assigns[:f].label t('common.form.description') %>
-	</div>
-	<%= local_assigns[:f].text_area :description, class: 'no_title' %>
-</div>
+  <div class="field">
+    <div class="label">
+      <%= local_assigns[:f].label t('common.form.description') %>
+    </div>
+    <%= local_assigns[:f].text_area :description, class: 'no_title' %>
+  </div>
 
-<% elsif local_assigns[:data_type] == 'mood' %>
+  <% elsif local_assigns[:data_type] == 'mood' %>
 
-<div class="field">
-	<div class="label">
-		<%= local_assigns[:f].label t('common.name') %>
-		<i class="fa fa-asterisk align_right"></i>
-		<div class="clear"></div>
-	</div>
-	<%= local_assigns[:f].text_field :name, class: "name_field" %>
-</div>
+  <div class="field">
+    <div class="label">
+      <%= local_assigns[:f].label t('common.name') %>
+      <i class="fa fa-asterisk align_right"></i>
+      <div class="clear"></div>
+    </div>
+    <%= local_assigns[:f].text_field :name, class: "name_field" %>
+  </div>
 
-<div class="field">
-	<div class="label">
-		<%= local_assigns[:f].label t('common.form.description') %>
-	</div>
-	<%= local_assigns[:f].text_area :description, class: 'no_title' %>
-</div>
+  <div class="field">
+    <div class="label">
+      <%= local_assigns[:f].label t('common.form.description') %>
+    </div>
+    <%= local_assigns[:f].text_area :description, class: 'no_title' %>
+  </div>
 
-<% elsif local_assigns[:data_type] == 'strategy' %>
+  <% elsif local_assigns[:data_type] == 'strategy' %>
 
-<div class="field">
-	<div class="label">
-		<%= local_assigns[:f].label t('common.title') %>
-		<i class="fa fa-asterisk align_right"></i>
-		<div class="clear"></div>
-	</div>
-	<%= local_assigns[:f].text_field :name, class: "name_field" %>
-</div>
+  <div class="field">
+    <div class="label">
+      <%= local_assigns[:f].label t('common.title') %>
+      <i class="fa fa-asterisk align_right"></i>
+      <div class="clear"></div>
+    </div>
+    <%= local_assigns[:f].text_field :name, class: "name_field" %>
+  </div>
 
-<% categories = Category.where(userid: current_user.id).all %>
-<% if !categories.nil? && categories.length > 0 %>
-<div class="field">
-	<div class="label">
-		<%= local_assigns[:f].label t('categories.plural') %>
-	</div>
-	<% categories.each do |item| %>
-		<%= local_assigns[:f].check_box(:category, {:multiple => true, :checked => @strategy.category.include?(item.id)}, item.id, nil) %><%= item.name %><br>
-	<% end %>
-</div>
-<% end %>
+  <% categories = Category.where(userid: current_user.id).all %>
+  <% if !categories.nil? && categories.length > 0 %>
+    <div class="field">
+      <div class="label">
+        <%= local_assigns[:f].label t('categories.plural') %>
+      </div>
+      <% categories.each do |item| %>
+        <%= local_assigns[:f].check_box(:category, { multiple: true, checked: @strategy.category.include?(item.id)}, item.id, nil) %><%= item.name %><br>
+      <% end %>
+    </div>
+  <% end %>
 
-<div class="field">
-	<div class="label">
-		<%= local_assigns[:f].label t('strategies.form.describe') %>
-		<i class="fa fa-asterisk align_right"></i>
-		<div class="clear"></div>
-	</div>
-	<%= local_assigns[:f].text_area :description, class: 'no_title' %>
-	<%= render partial: '/shared/character_count', locals: { data: 'strategy_description' } %>
-</div>
+  <div class="field">
+    <div class="label">
+      <%= local_assigns[:f].label t('strategies.form.describe') %>
+      <i class="fa fa-asterisk align_right"></i>
+      <div class="clear"></div>
+    </div>
+    <%= local_assigns[:f].text_area :description, class: 'no_title' %>
+    <%= render partial: '/shared/character_count', locals: { data: 'strategy_description' } %>
+  </div>
 
 <% end %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -2,50 +2,50 @@
 	<% most_focus = most_focus(local_assigns[:data_type], local_assigns[:profile]) %>
 	<% if most_focus.length > 0 %>
 
-		<% if !local_assigns[:profile] %>
-			<div class="stats_divider"></div>
-		<% end %>
+    <% if !local_assigns[:profile] %>
+      <div class="stats_divider"></div>
+    <% end %>
 
-	<div class="center" id="stats">
-		<% if local_assigns[:profile] %>
-		<div class="main_message no_margin_top">
-			<%= local_assigns[:data_type].pluralize.titleize %>
-		</div>
-		<% end %>
-		<div class="small_margin_bottom">
-			<% if !local_assigns[:profile] || local_assigns[:profile] == current_user.id %>
-				<%= t('shared.stats.you_are_focusing') %>
-			<% elsif local_assigns[:profile] %>
-				<%= t('shared.stats.user_is_focusing', name: User.where(id: local_assigns[:profile]).first.name) %>
-			<% end %>
-		</div>
+    <div class="center" id="stats">
+      <% if local_assigns[:profile] %>
+        <div class="main_message no_margin_top">
+          <%= local_assigns[:data_type].pluralize.titleize %>
+        </div>
+      <% end %>
+      <div class="small_margin_bottom">
+        <% if !local_assigns[:profile] || local_assigns[:profile] == current_user.id %>
+          <%= t('shared.stats.you_are_focusing') %>
+        <% elsif local_assigns[:profile] %>
+          <%= t('shared.stats.user_is_focusing', name: User.where(id: local_assigns[:profile]).first.name) %>
+        <% end %>
+      </div>
 
-		<div id="most_focus">
-			<% most_focus.each do |key, value| %>
-				
-				<div class="some_focus">
-				
-					<div class="some_focus_text">
-					<% if local_assigns[:data_type] == 'category' && (!local_assigns[:profile] || local_assigns[:profile] == current_user.id) %>
-						<%= viewers_hover(get_viewers_for(Category.where(id: key).first, 'category'), Category.where(id: key).first) %>
-					<% elsif local_assigns[:data_type] == 'category' && local_assigns[:profile] %>
-						<%= Category.where(id: key).first.name %>
-					<% elsif local_assigns[:data_type] == 'mood' && (!local_assigns[:profile] || local_assigns[:profile] == current_user.id) %>
-						<%= viewers_hover(get_viewers_for(Mood.where(id: key).first, 'mood'), Mood.where(id: key).first) %>
-					<% elsif local_assigns[:data_type] == 'mood' && local_assigns[:profile] %>
-						<%= Mood.where(id: key).first.name %>
-					<% elsif local_assigns[:data_type] == 'strategy' && (!local_assigns[:profile] || local_assigns[:profile] == current_user.id) %>
-						<%= viewers_hover(get_viewers_for(Strategy.where(id: key).first, 'strategy'), Strategy.where(id: key).first) %>
-					<% elsif local_assigns[:data_type] == 'strategy' && local_assigns[:profile] %>
-						<%= Strategy.where(id: key).first.name %>
-					<% end %>
-					</div>
-				</div>
-			<% end %>
-		</div>
+      <div id="most_focus">
+        <% most_focus.each do |key, value| %>
+          
+          <div class="some_focus">
+          
+            <div class="some_focus_text">
+              <% if local_assigns[:data_type] == 'category' && (!local_assigns[:profile] || local_assigns[:profile] == current_user.id) %>
+                <%= viewers_hover(get_viewers_for(Category.where(id: key).first, 'category'), Category.where(id: key).first) %>
+              <% elsif local_assigns[:data_type] == 'category' && local_assigns[:profile] %>
+                <%= Category.where(id: key).first.name %>
+              <% elsif local_assigns[:data_type] == 'mood' && (!local_assigns[:profile] || local_assigns[:profile] == current_user.id) %>
+                <%= viewers_hover(get_viewers_for(Mood.where(id: key).first, 'mood'), Mood.where(id: key).first) %>
+              <% elsif local_assigns[:data_type] == 'mood' && local_assigns[:profile] %>
+                <%= Mood.where(id: key).first.name %>
+              <% elsif local_assigns[:data_type] == 'strategy' && (!local_assigns[:profile] || local_assigns[:profile] == current_user.id) %>
+                <%= viewers_hover(get_viewers_for(Strategy.where(id: key).first, 'strategy'), Strategy.where(id: key).first) %>
+              <% elsif local_assigns[:data_type] == 'strategy' && local_assigns[:profile] %>
+                <%= Strategy.where(id: key).first.name %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
 
-		<div class="clear"></div>
-	</div>
+      <div class="clear"></div>
+    </div>
 	<% end %>
 <% elsif local_assigns[:data_type] == 'moment' %>
 	<%= raw(moments_stats) %>

--- a/app/views/shared/_tag_usage.html.erb
+++ b/app/views/shared/_tag_usage.html.erb
@@ -16,7 +16,7 @@
         <% moments.each do |moment_id| %>
             <% moment = Moment.where(id: moment_id).first %>
             <% if moment.userid == current_user.id || (moment.viewers.include?(current_user.id) && moment.published?) %>
-            <%= render :partial => '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
+            <%= render partial: '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
             <% end %>
         <% end %>
         </div>
@@ -31,7 +31,7 @@
         <% strategies.each do |strategy_id| %>
             <% strategy = Strategy.where(id: strategy_id).first %>
             <% if strategy.userid == current_user.id || (strategy.viewers.include?(current_user.id) && strategy.published?) %>
-            <%= render :partial => '/shared/moments_strategies', locals: { items: strategies, item: strategy, data_type: 'strategy_tag_usage' } %>
+            <%= render partial: '/shared/moments_strategies', locals: { items: strategies, item: strategy, data_type: 'strategy_tag_usage' } %>
             <% end %>
         <% end %>
         </div>
@@ -59,7 +59,7 @@
             <% moments.each do |moment_id| %>
                 <% moment = Moment.where(id: moment_id).first %>
                 <% if moment.userid == current_user.id || moment.viewers.include?(current_user.id) %>
-                <%= render :partial => '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
+                <%= render partial: '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
                 <% end %>
             <% end %>
             </div>

--- a/app/views/shared/_tag_usage.html.erb
+++ b/app/views/shared/_tag_usage.html.erb
@@ -2,69 +2,69 @@
 
     <div id="tag_usage" class="small_margin_top">
 
-    <% usage = tag_usage(local_assigns[:data], local_assigns[:data_type], local_assigns[:userid]) %>
+      <% usage = tag_usage(local_assigns[:data], local_assigns[:data_type], local_assigns[:userid]) %>
 
-    <% if local_assigns[:data_type] == 'category' %>
+      <% if local_assigns[:data_type] == 'category' %>
         <% moments = usage[0] %>
         <% strategies = usage[1] %>
 
         <% if moments.length > 0 %>
-        <h1 class="tag_type"><%= t('moments.tagged') %></h1>
+          <h1 class="tag_type"><%= t('moments.tagged') %></h1>
 
-        <div id="moment_tag_usage">
-      <div class="tag_usage">
-        <% moments.each do |moment_id| %>
-            <% moment = Moment.where(id: moment_id).first %>
-            <% if moment.userid == current_user.id || (moment.viewers.include?(current_user.id) && moment.published?) %>
-            <%= render partial: '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
-            <% end %>
+          <div id="moment_tag_usage">
+            <div class="tag_usage">
+              <% moments.each do |moment_id| %>
+                <% moment = Moment.where(id: moment_id).first %>
+                <% if moment.userid == current_user.id || (moment.viewers.include?(current_user.id) && moment.published?) %>
+                  <%= render partial: '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         <% end %>
-        </div>
-    </div>
-    <% end %>
 
-    <% if strategies.length > 0 %>
-        <h1 class="tag_type margin_top"><%= t('strategies.plural') %></h1>
+        <% if strategies.any? %>
+          <h1 class="tag_type margin_top"><%= t('strategies.plural') %></h1>
 
-        <div id="strategy_tag_usage">
-      <div class="tag_usage">
-        <% strategies.each do |strategy_id| %>
-            <% strategy = Strategy.where(id: strategy_id).first %>
-            <% if strategy.userid == current_user.id || (strategy.viewers.include?(current_user.id) && strategy.published?) %>
-            <%= render partial: '/shared/moments_strategies', locals: { items: strategies, item: strategy, data_type: 'strategy_tag_usage' } %>
-            <% end %>
+          <div id="strategy_tag_usage">
+            <div class="tag_usage">
+              <% strategies.each do |strategy_id| %>
+                <% strategy = Strategy.where(id: strategy_id).first %>
+                <% if strategy.userid == current_user.id || (strategy.viewers.include?(current_user.id) && strategy.published?) %>
+                  <%= render partial: '/shared/moments_strategies', locals: { items: strategies, item: strategy, data_type: 'strategy_tag_usage' } %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         <% end %>
-        </div>
-    </div>
-    <% end %>
-    <% else %>
+      <% else %>
         <% moments = usage %>
 
-        <% if moments.length > 0 %>
-            <% if local_assigns[:data_type] == 'strategy' %>
-                <h1 class="tag_type">
-                    <%= t('moments.tagged') %>
-                    <span id="showTaggedMoments" class="align_right display_inline_block"><i class="fa fa-caret-down"></i></span>
-                    <span id="hideTaggedMoments" class="align_right display_none"><i class="fa fa-caret-up"></i></span>
-                </h1>
+        <% if moments.any? %>
+          <% if local_assigns[:data_type] == 'strategy' %>
+            <h1 class="tag_type">
+              <%= t('moments.tagged') %>
+              <span id="showTaggedMoments" class="align_right display_inline_block"><i class="fa fa-caret-down"></i></span>
+              <span id="hideTaggedMoments" class="align_right display_none"><i class="fa fa-caret-up"></i></span>
+            </h1>
 
-                <div id="moment_tag_usage" class="display_none">
-        <div class="tag_usage">
-            <% else %>
-                <h1 class="tag_type"><%= t('moments.tagged') %></h1>
-                <div id="moment_tag_usage">
-        <div class="tag_usage">
-            <% end %>
+            <div id="moment_tag_usage" class="display_none">
+              <div class="tag_usage">
+          <% else %>
+            <h1 class="tag_type"><%= t('moments.tagged') %></h1>
+            <div id="moment_tag_usage">
+              <div class="tag_usage">
+          <% end %>
 
             <% moments.each do |moment_id| %>
-                <% moment = Moment.where(id: moment_id).first %>
-                <% if moment.userid == current_user.id || moment.viewers.include?(current_user.id) %>
-                <%= render partial: '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
-                <% end %>
+            <% moment = Moment.where(id: moment_id).first %>
+            <% if moment.userid == current_user.id || moment.viewers.include?(current_user.id) %>
+              <%= render partial: '/shared/moments_strategies', locals: { items: moments, item: moment, data_type: 'moment_tag_usage' } %>
             <% end %>
-            </div>
+          <% end %>
+        </div>
       </div>
-        <% end %>
     <% end %>
+  <% end %>
 </div>
 <% end %>

--- a/app/views/strategies/_form.html.erb
+++ b/app/views/strategies/_form.html.erb
@@ -85,13 +85,13 @@
       </div>
       <%= f.cktext_area :description, class: 'no_title special_textarea ckeditor' %>
 
-      <%= render :partial => '/shared/character_count', locals: { data: 'strategy_description' } %>
+      <%= render partial: '/shared/character_count', locals: { data: 'strategy_description' } %>
     </div>
     <div class="field slider-container">
       <div class="label draft_label">
         <%= f.label t('strategies.form.draft_question') %>
       </div>
-      <%= render :partial => '/shared/draft_slider', locals: {published: @strategy.published? } %>
+      <%= render partial: '/shared/draft_slider', locals: { published: @strategy.published? } %>
     </div>
   </div>
 </div>
@@ -106,4 +106,4 @@
 
 <% end %>
 
-<%= render :partial => '/shared/quick_create', locals: { data_type: 'category', data: @category, tag: 'strategy' } %>
+<%= render partial: '/shared/quick_create', locals: { data_type: 'category', data: @category, tag: 'strategy' } %>

--- a/app/views/strategies/_form.html.erb
+++ b/app/views/strategies/_form.html.erb
@@ -14,7 +14,7 @@
       </div>
       <div class="clear"></div>
       </div>
-      <%= f.text_field :name, :class => "name_field" %>
+      <%= f.text_field :name, class: "name_field" %>
     </div>
 
     <%= render partial: '/shared/autocomplete_checkboxes', locals: {

--- a/app/views/strategies/_form.html.erb
+++ b/app/views/strategies/_form.html.erb
@@ -14,43 +14,43 @@
       </div>
       <div class="clear"></div>
       </div>
-      <%= f.text_field :name, class: "name_field" %>
+      <%= f.text_field :name, class: 'name_field' %>
     </div>
 
     <%= render partial: '/shared/autocomplete_checkboxes', locals: {
-        f: f,
-        all_data: @categories,
-        this_data: @strategy.category,
-        data_type: 'category',
-        data_type_plural: 'categories'
-      } %>
+      f: f,
+      all_data: @categories,
+      this_data: @strategy.category,
+      data_type: 'category',
+      data_type_plural: 'categories'
+    } %>
 
-    <% if !@viewers.nil? && @viewers.length > 0 %>
-    <div class="sidebar_field">
-      <div class="sidebar_label expand_toggle" data-toggle="#viewers">
-        <a href="#" class="toggle_button">
-          <i class="fa fa-caret-down"></i>
-        </a>
-        <%= f.label t('shared.viewers.plural') %>
-        <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title smaller_margin_left', title: t('strategies.form.viewers_hint')) %>
+    <% if !@viewers.nil? && @viewers.any? %>
+      <div class="sidebar_field">
+        <div class="sidebar_label expand_toggle" data-toggle="#viewers">
+          <a href="#" class="toggle_button">
+            <i class="fa fa-caret-down"></i>
+          </a>
+          <%= f.label t('shared.viewers.plural') %>
+          <%= content_tag(:span, '<i class="fa fa-question-circle"></i>'.html_safe, class: 'yes_title smaller_margin_left', title: t('strategies.form.viewers_hint')) %>
+        </div>
       </div>
-    </div>
 
-    <div id="viewers" class="display_none">
-      <div id="viewers_list">
-      <label>
-        <input type="checkbox" id="viewers_all" />
-        <span id="viewers_label"><%= t('common.actions.select_all') %></span>
-      </label>
-
-      <% @viewers.each do |item| %>
+      <div id="viewers" class="display_none">
+        <div id="viewers_list">
         <label>
-          <%= f.check_box(:viewers, {:multiple => true, :checked => @strategy.viewers.include?(item.id)}, item.id, nil) %>
-          <%= User.where(:id => item.id).first.name %>
+          <input type="checkbox" id="viewers_all" />
+          <span id="viewers_label"><%= t('common.actions.select_all') %></span>
         </label>
-      <% end %>
+
+        <% @viewers.each do |item| %>
+          <label>
+            <%= f.check_box(:viewers, { multiple: true, checked: @strategy.viewers.include?(item.id)}, item.id, nil) %>
+            <%= User.where(id: item.id).first.name %>
+          </label>
+        <% end %>
+        </div>
       </div>
-    </div>
     <% end %>
 
     <div class="sidebar_field">

--- a/app/views/strategies/_strategy.html.erb
+++ b/app/views/strategies/_strategy.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => '/shared/moments_strategies', locals: { items: @strategies, item: strategy, data_type: 'strategy' } %>
+<%= render partial: '/shared/moments_strategies', locals: { items: @strategies, item: strategy, data_type: 'strategy' } %>

--- a/app/views/strategies/index.html.erb
+++ b/app/views/strategies/index.html.erb
@@ -7,7 +7,7 @@
 
 <div class="spacer"></div>
 
-<% if @strategies.length > 0 %>
+<% if @strategies.any? %>
   <%= render partial: '/search/posts', locals: { data_type: 'strategy' } %>
 
   <%= render partial: '/shared/stats', locals: { data_type: 'strategy' } %>

--- a/app/views/strategies/index.html.erb
+++ b/app/views/strategies/index.html.erb
@@ -8,9 +8,9 @@
 <div class="spacer"></div>
 
 <% if @strategies.length > 0 %>
-  <%= render :partial => '/search/posts', locals: { data_type: 'strategy' } %>
+  <%= render partial: '/search/posts', locals: { data_type: 'strategy' } %>
 
-  <%= render :partial => '/shared/stats', locals: { data_type: 'strategy' } %>
+  <%= render partial: '/shared/stats', locals: { data_type: 'strategy' } %>
 
   <div id="pages">
     <div class="page">

--- a/app/views/strategies/show.html.erb
+++ b/app/views/strategies/show.html.erb
@@ -1,5 +1,5 @@
 <% title @strategy.name %>
-<%= render :partial => 'shared/draft_badge', locals: {published: @strategy.published? } %>
+<%= render partial: 'shared/draft_badge', locals: {published: @strategy.published? } %>
 <%= ::TimeAgo.created_or_edited(@strategy) %>
 <% if @strategy.category.count > 0 %>
   <br>
@@ -9,7 +9,7 @@
     <% @strategy.category.each do |item| %>
       <span class="notification_wrapper">
         <span class="tip_notifications_button link_style"><%= Category.where(id: item).first.name %></span><% if @strategy.category.last != item %><%= ', ' %><% end %>
-        <%= render :partial => '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
+        <%= render partial: '/notifications/preview', locals: { data: Category.where(id: item).first, edit: edit_category_path(item) } %>
        </span>
     <% end %>
 <% end %>
@@ -21,8 +21,8 @@
   </p>
 <% end %>
 
-<%= render :partial => '/shared/viewers_indicator', locals: { data: @strategy } %>
+<%= render partial: '/shared/viewers_indicator', locals: { data: @strategy } %>
 
-<%= render :partial => '/shared/comments', locals: { data: @strategy, comments: @comments, comment: @comment, no_hide_page: @no_hide_page, commentable_type: 'strategy' } %>
+<%= render partial: '/shared/comments', locals: { data: @strategy, comments: @comments, comment: @comment, no_hide_page: @no_hide_page, commentable_type: 'strategy' } %>
 
-<%= render :partial => '/shared/tag_usage', locals: { data: @strategy.id, data_type: 'strategy', userid: @strategy.userid } %>
+<%= render partial: '/shared/tag_usage', locals: { data: @strategy.id, data_type: 'strategy', userid: @strategy.userid } %>

--- a/app/views/strategies/show.html.erb
+++ b/app/views/strategies/show.html.erb
@@ -1,7 +1,7 @@
 <% title @strategy.name %>
-<%= render partial: 'shared/draft_badge', locals: {published: @strategy.published? } %>
+<%= render partial: 'shared/draft_badge', locals: { published: @strategy.published? } %>
 <%= ::TimeAgo.created_or_edited(@strategy) %>
-<% if @strategy.category.count > 0 %>
+<% if @strategy.present? %>
   <br>
     <strong>
       <%= t('categories.label', count: @strategy.category.count) %>
@@ -14,7 +14,7 @@
     <% end %>
 <% end %>
 
-<% if !@strategy.description.blank? %>
+<% if @strategy.description.present? %>
   <p>
     <%= raw(@strategy.description) %>
     <%= print_reminders(@strategy) %>

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -1,30 +1,28 @@
-<%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f| %>
+<%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f| %>
   <%= devise_error_messages! %>
   <%= f.hidden_field :invitation_token %>
 
   <% if f.object.class.require_password_on_accepting %>
-
-  <div class="field">
-    <div class="label">
-      <%= f.label t('common.name') %>
+    <div class="field">
+      <div class="label">
+        <%= f.label t('common.name') %>
+      </div>
+      <%= f.text_field :name %>
     </div>
-    <%= f.text_field :name %>
-  </div>
 
-  <div class="field">
-    <div class="label">
-      <%= f.label t('devise.password') %>
+    <div class="field">
+      <div class="label">
+        <%= f.label t('devise.password') %>
+      </div>
+      <%= f.password_field :password %>
     </div>
-    <%= f.password_field :password %>
-  </div>
 
-  <div class="field">
-  	<div class="label">
-  		<%= f.label t('devise.registrations.placeholders.repeat_password') %>
-  	</div>
-  	<%= f.password_field :password_confirmation %>
-  </div>
-
+    <div class="field">
+      <div class="label">
+        <%= f.label t('devise.registrations.placeholders.repeat_password') %>
+      </div>
+      <%= f.password_field :password_confirmation %>
+    </div>
   <% end %>
 
   <div class="actions no_margin_bottom">

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -1,16 +1,16 @@
-<%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :id => 'invitations', :method => :post } do |f| %>
+<%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { id: 'invitations', method: :post } do |f| %>
   <%= devise_error_messages! %>
 
   <% resource.class.invite_key_fields.each do |field| -%>
     <div class="field">
-    <div class="label">
-      <% if field.to_s == 'email' %>
-        <%= f.label t('common.form.email') %>
-      <% else %>
-        <%= f.label field %>
-      <% end %>
-    </div>
-    <%= f.text_field field, :placeholder => t('allies.form.placeholder') %>
+      <div class="label">
+        <% if field.to_s == 'email' %>
+          <%= f.label t('common.form.email') %>
+        <% else %>
+          <%= f.label field %>
+        <% end %>
+      </div>
+      <%= f.text_field field, placeholder: t('allies.form.placeholder') %>
     </div>
   <% end -%>
 

--- a/app/views/users/mailer/invitation_instructions.html.erb
+++ b/app/views/users/mailer/invitation_instructions.html.erb
@@ -7,9 +7,9 @@
 <%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token) %>
 
 <% if @resource.invitation_due_at %>
-<br>
-<br>
-<%= t("devise.mailer.invitation_instructions.accept_until", due_date: @resource.invitation_due_at.strftime('%A %B %d, %Y at %I:%M %p')) %>
+  <br>
+  <br>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: @resource.invitation_due_at.strftime('%A %B %d, %Y at %I:%M %p')) %>
 <% end %>
 
 <br>

--- a/spec/features/user_creates_moment_spec.rb
+++ b/spec/features/user_creates_moment_spec.rb
@@ -52,7 +52,7 @@ describe 'UserCreatesAMoment', js: true do
       end
 
       within '#categories_list' do
-        page.all('input[name="moment[category][]"]')[2].click
+        page.all('input[name="moment[category][]"]').last.click
       end
 
       page.find('[data-toggle="#categories"]').click
@@ -124,7 +124,7 @@ describe 'UserCreatesAMoment', js: true do
       expect(page).to have_content 'Created:'
       expect(page).to have_content 'Categories: Another New Category, ' \
                                    'Some New Category'
-      expect(page).to have_content 'Moods: Another New Mood, Test Mood'
+      expect(page).to have_content 'Moods: Another New Mood, Some New Mood'
       expect(page).to have_content 'What happened and how do you feel?'
       expect(page).to have_content 'my moment why description'
       expect(page).to have_content 'What thoughts would you like to have?'

--- a/spec/features/user_creates_moment_spec.rb
+++ b/spec/features/user_creates_moment_spec.rb
@@ -124,7 +124,7 @@ describe 'UserCreatesAMoment', js: true do
       expect(page).to have_content 'Created:'
       expect(page).to have_content 'Categories: Another New Category, ' \
                                    'Some New Category'
-      expect(page).to have_content 'Moods: Another New Mood, Some New Mood'
+      expect(page).to have_content 'Moods: Another New Mood, Test Mood'
       expect(page).to have_content 'What happened and how do you feel?'
       expect(page).to have_content 'my moment why description'
       expect(page).to have_content 'What thoughts would you like to have?'

--- a/spec/features/user_creates_strategy_spec.rb
+++ b/spec/features/user_creates_strategy_spec.rb
@@ -47,7 +47,7 @@ describe 'UserCreatesAStrategy', js: true do
         page.find('#new_category input[type="submit"]').click
       end
       within '#categories_list' do
-        page.all('input[name="strategy[category][]"]')[2].click
+        page.all('input[name="strategy[category][]"]').last.click
       end
       page.find('[data-toggle="#categories"]').click
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper do
   describe '#nav_link_to' do
-    let(:is_active) { true }
+    let(:active)    { true }
     let(:label)     { 'foo' }
     let(:path)      { 'bar' }
     let(:options)   { {} }
@@ -8,11 +8,11 @@ describe ApplicationHelper do
     subject { nav_link_to(label, path, options) }
 
     before(:each) do
-      allow(self).to receive('is_active?').and_return(is_active)
+      allow(self).to receive('active?').and_return(active)
     end
 
     context 'when active' do
-      let(:is_active) { true }
+      let(:active) { true }
 
       it { is_expected.to have_selector 'li a' }
       it { is_expected.to include label }
@@ -20,7 +20,7 @@ describe ApplicationHelper do
     end
 
     context 'when not active' do
-      let(:is_active) { false }
+      let(:active) { false }
 
       it { is_expected.to have_selector 'li a' }
       it { is_expected.to include label }
@@ -31,20 +31,20 @@ describe ApplicationHelper do
       let(:options) { { :method => :delete } }
 
       it 'passes method in environment' do
-        expect(self).to receive(:is_active?).with(path, options)
+        expect(self).to receive(:active?).with(path, options)
         nav_link_to(label, path, options)
       end
     end
   end
 
-  describe '#is_active?' do
+  describe '#active?' do
     let(:is_current_page)    { false }
     let(:current_controller) { '' }
     let(:action_name)        { '' }
     let(:path)               { root_path }
     let(:environment)        { {} }
 
-    subject { is_active?(path, environment) }
+    subject { active?(path, environment) }
 
     before(:each) do
       params[:controller] = current_controller

--- a/spec/models/allyship_spec.rb
+++ b/spec/models/allyship_spec.rb
@@ -125,11 +125,11 @@ describe Allyship do
       it 'deletes viewer' do
         allyship_expected = Allyship.where(user_id: user.id,
                                            ally_id: ally.id)[0]
-        moment_expected = Moment.where(userid: user.id)[0]
+        moment_expected = user.moments.first
         strategy_expected = Strategy.where(userid: user.id)[0]
 
         expect { allyship_expected.destroy }
-          .to change { Moment.where(userid: user.id)[0].viewers.count }.from(1).to(0)
+          .to change { user.moments.first.viewers.count }.from(1).to(0)
           .and change { Strategy.where(userid: user.id)[0].viewers.count }.from(1).to(0)
       end
     end

--- a/spec/models/allyship_spec.rb
+++ b/spec/models/allyship_spec.rb
@@ -126,11 +126,11 @@ describe Allyship do
         allyship_expected = Allyship.where(user_id: user.id,
                                            ally_id: ally.id)[0]
         moment_expected = user.moments.first
-        strategy_expected = Strategy.where(userid: user.id)[0]
+        strategy_expected = user.strategies.first
 
         expect { allyship_expected.destroy }
           .to change { user.moments.first.viewers.count }.from(1).to(0)
-          .and change { Strategy.where(userid: user.id)[0].viewers.count }.from(1).to(0)
+          .and change { user.strategies.first.viewers.count }.from(1).to(0)
       end
     end
   end


### PR DESCRIPTION
This PR is to partly address #772. The primary goal is to clean up formatting, appease Rubocop, and standardize various nuggets of code used throughout the codebase.

## High-level overview of changes

- Replace `.where()` queries with association calls where applicable (e.g. `Moment.where(userid: user.id)` => `user.moments`)
- Replace double-negated `.empty?` calls with `.any?`
- Replace double-negated `.blank?` calls with `.present?`
- Make hash formatting uniform (e.g. `render :partial =>` => `render partial:`)
- Fix all Rubocop errors (a few errors were ignored in `.rubocop.yml` and disable comments were sprinkled)
- Fix indentation in models, controllers, views, scripts, and stylesheets (also replaced all tabs with 2 spaces)

## Additional improvements for future PRs

- Rename foreign keys (e.g. `userid` => `user_id`)
- Review database indexes
- Extract as many queries from views as possible
- Refactor methods that were wrapped with `# rubocop:disable MethodLength` comments
- Refactor classes that were wrapped with `# rubocop:disable ClassLength` comments