### PR TITLE
Minor: Fixing main README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Information about installing and configuring if me is located in [INSTALLATION.m
 
 [How to add translations for new languages](https://github.com/ifmeorg/ifme/wiki/Translations)
 
-## Workflows and Conbtributions
+## Workflows and Contributions
 
 [Workflows and contributions](https://github.com/ifmeorg/ifme/wiki/Workflow)
 

--- a/client/package.json
+++ b/client/package.json
@@ -71,7 +71,7 @@
     "extract-text-webpack-plugin": "^2.1.2",
     "file-loader": "^1.1.6",
     "flow-bin": "^0.54.1",
-    "flow-typed": "^2.3.0",
+    "flow-typed": "^2.4.0",
     "glob": "^7.1.2",
     "imports-loader": "^0.7.1",
     "jasmine": "^2.7.0",


### PR DESCRIPTION
Dipping my toes in with the tiniest of PRs.  Hello all! 👋🏻

-------------------------------------------
Edit:
Circle ran into this issue during build & flow setup:
```
UNCAUGHT ERROR: Error: react-navigation_v1.x.x/CONTRIBUTING.md: Unexpected file name. This directory can only contain test files or a libdef file named `react-navigation_v1.x.x.js`.
```

Ties to this issue in the `flow-typed` pkg:
https://github.com/flowtype/flow-typed/issues/1926

Bumping the package version for `flow-typed` to apply their whitelist fix