### PR TITLE
Update vn to be vi in translation files

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
    ptbr: Português
    sv: Svenska
    various: Various
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -20,7 +20,7 @@ es:
    ptbr: Português
    sv: Svenska
    various: Varios
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -20,7 +20,7 @@ it:
    ptbr: Português
    sv: Svenska
    various: Vari
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -20,7 +20,7 @@ nb:
    ptbr: Português
    sv: Svenska
    various: Various
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -20,7 +20,7 @@ nl:
    ptbr: Português
    sv: Svenska
    various: Verscheidende
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 

--- a/config/locales/ptbr.yml
+++ b/config/locales/ptbr.yml
@@ -20,7 +20,7 @@ ptbr:
    ptbr: Português
    sv: Svenska
    various: Outros
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -20,7 +20,7 @@ sv:
    ptbr: Português
    sv: Svenska
    various: Olika
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -20,7 +20,7 @@ vi:
    ptbr: Português
    sv: Svenska
    various: Various
-   vn: Tiếng Việt
+   vi: Tiếng Việt
    it: Italiano
    nb: Norsk
 
@@ -533,7 +533,7 @@ vi:
     license_we: 'We'
     license_foss: 'FOSS'
     foss: 'Free and open source software'
-    license_subtitle: 'Được cấp phép theo'
+    license_subtitle: 'Được cấp phép theo %{license}'
     connect: 'kết nối'
   comments:
     share_everyone: 'Chia sẻ với mọi người'


### PR DESCRIPTION
Forgot to update vn to vi in the actual main translation docs. Whoops!