### PR TITLE
fix(client): add an explicit requirement to rebuild node-sass due to …

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,8 @@
     "lint": "yarn lint:flow && yarn lint:eslint",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "start": "yarn storybook"
+    "start": "yarn storybook",
+    "postinstall": "npm rebuild node-sass"
   },
   "cacheDirectories": [
     "node_modules",

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "start": "yarn storybook",
-    "postinstall": "npm rebuild node-sass"
+    "heroku-postbuild": "npm rebuild node-sass"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
…the node-gyp compilation not building sass bindings properly through yarn

After scouring the internet, it looks like this is a safe solution to let our pipeline trigger the node-sass rebuild. If we run into more of these issues with other node packages, we can reopen this issue and take a look at a scaling solution.

