### PR TITLE
Use Nodejs LTS 8.11.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   ruby:
     version: 2.3.4
   node:
-    version: 6
+    version: 8.11.1
 
 dependencies:
   cache_directories:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "foreman start -f Procfile.dev"
   },
   "engines": {
-    "node": ">=6.x"
+    "node": "8.11.1"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
v9.11.1 is EoL June 2018. 
v10.0.0 LTS breaks our modules sadly.

So the best choice of a version lock is v8.11.1 which comes with new features such as Async/Await and has security support until Dec. 2019.

## Testing:
- [x] Verified that it builds on my personal Heroku fork