### PR TITLE
Refactor application_controller_spec.rb

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -10,51 +10,49 @@ RSpec::Matchers.define :be_avatar_component do
 end
 
 describe ApplicationController do
+  let(:new_user1) { create(:user1) }
+  let(:new_user2) { create(:user2) }
   describe "most_focus" do
     describe "categories" do
       it "returns an empty hash because no categories exist" do
-        new_user = create(:user1)
-        sign_in new_user
-        new_moment = create(:moment, userid: new_user.id)
-        new_strategy = create(:strategy, userid: new_user.id)
+        sign_in new_user1
+        new_moment = create(:moment, userid: new_user1.id)
+        new_strategy = create(:strategy, userid: new_user1.id)
         expect(controller.most_focus('category', nil).length).to eq(0)
       end
 
       describe "returns a hash because categories exist" do
         it "returns a hash of size 1 when the same category is used twice" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_category = create(:category, userid: new_user.id)
-          new_moment = create(:moment, userid: new_user.id, category: Array.new(1, new_category.id))
-          new_strategy = create(:strategy, userid: new_user.id, category: Array.new(1, new_category.id))
-          result = controller.most_focus('category', new_user.id)
+          sign_in new_user1
+          new_category = create(:category, userid: new_user1.id)
+          new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category.id))
+          new_strategy = create(:strategy, userid: new_user1.id, category: Array.new(1, new_category.id))
+          result = controller.most_focus('category', new_user1.id)
           expect(result.length).to eq(1)
           expect(result[new_category.id]).to eq(2)
         end
 
         it "returns a hash of size 2" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_category1 = create(:category, userid: new_user.id)
-          new_category2 = create(:category, userid: new_user.id)
-          new_moment = create(:moment, userid: new_user.id, category: Array.new(1, new_category1.id))
-          new_strategy = create(:strategy, userid: new_user.id, category: Array.new(1, new_category2.id))
-          result = controller.most_focus('category', new_user.id)
+          sign_in new_user1
+          new_category1 = create(:category, userid: new_user1.id)
+          new_category2 = create(:category, userid: new_user1.id)
+          new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category1.id))
+          new_strategy = create(:strategy, userid: new_user1.id, category: Array.new(1, new_category2.id))
+          result = controller.most_focus('category', new_user1.id)
           expect(result.length).to eq(2)
           expect(result[new_category1.id]).to eq(1)
           expect(result[new_category2.id]).to eq(1)
         end
 
         it "returns a correct hash of size 3" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_category1 = create(:category, userid: new_user.id)
-          new_category2 = create(:category, userid: new_user.id)
-          new_category3 = create(:category, userid: new_user.id)
-          new_category4 = create(:category, userid: new_user.id)
-          new_moment = create(:moment, userid: new_user.id, category: Array.new(1, new_category2.id))
-          new_strategy = create(:strategy, userid: new_user.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id])
-          result = controller.most_focus('category', new_user.id)
+          sign_in new_user1
+          new_category1 = create(:category, userid: new_user1.id)
+          new_category2 = create(:category, userid: new_user1.id)
+          new_category3 = create(:category, userid: new_user1.id)
+          new_category4 = create(:category, userid: new_user1.id)
+          new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category2.id))
+          new_strategy = create(:strategy, userid: new_user1.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id])
+          result = controller.most_focus('category', new_user1.id)
           expect(result.length).to eq(3)
           expect(result[new_category1.id]).to eq(1)
           expect(result[new_category2.id]).to eq(2)
@@ -63,8 +61,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          new_user1 = create(:user1)
-          new_user2 = create(:user2)
           sign_in new_user1
           new_category1 = create(:category, userid: new_user2.id)
           new_category2 = create(:category, userid: new_user2.id)
@@ -81,8 +77,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when his/her posts are drafts" do
-          new_user1 = create(:user1)
-          new_user2 = create(:user2)
           sign_in new_user1
           new_category1 = create(:category, userid: new_user2.id)
           new_category2 = create(:category, userid: new_user2.id)
@@ -102,45 +96,41 @@ describe ApplicationController do
 
     describe "moods" do
       it "returns an empty hash because no moods exist" do
-        new_user = create(:user1)
-        sign_in new_user
-        new_moment = create(:moment, userid: new_user.id)
+        sign_in new_user1
+        new_moment = create(:moment, userid: new_user1.id)
         expect(controller.most_focus('mood', nil).length).to eq(0)
       end
 
       describe "returns a hash because moods exist" do
         it "returns a hash of size 1 when the same mood is used twice" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_mood = create(:mood, userid: new_user.id)
-          new_moment = create(:moment, userid: new_user.id, mood: Array.new(1, new_mood.id))
-          result = controller.most_focus('mood', new_user.id)
+          sign_in new_user1
+          new_mood = create(:mood, userid: new_user1.id)
+          new_moment = create(:moment, userid: new_user1.id, mood: Array.new(1, new_mood.id))
+          result = controller.most_focus('mood', new_user1.id)
           expect(result.length).to eq(1)
           expect(result[new_mood.id]).to eq(1)
         end
 
         it "returns a hash of size 2" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_mood1 = create(:mood, userid: new_user.id)
-          new_mood2 = create(:mood, userid: new_user.id)
-          new_moment = create(:moment, userid: new_user.id, mood: [new_mood1.id, new_mood2.id])
-          result = controller.most_focus('mood', new_user.id)
+          sign_in new_user1
+          new_mood1 = create(:mood, userid: new_user1.id)
+          new_mood2 = create(:mood, userid: new_user1.id)
+          new_moment = create(:moment, userid: new_user1.id, mood: [new_mood1.id, new_mood2.id])
+          result = controller.most_focus('mood', new_user1.id)
           expect(result.length).to eq(2)
           expect(result[new_mood1.id]).to eq(1)
           expect(result[new_mood2.id]).to eq(1)
         end
 
         it "returns a correct hash of size 3" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_mood1 = create(:mood, userid: new_user.id)
-          new_mood2 = create(:mood, userid: new_user.id)
-          new_mood3 = create(:mood, userid: new_user.id)
-          new_mood4 = create(:mood, userid: new_user.id)
-          new_moment1 = create(:moment, userid: new_user.id, mood: Array.new(1, new_mood2.id))
-          new_moment2 = create(:moment, userid: new_user.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id])
-          result = controller.most_focus('mood', new_user.id)
+          sign_in new_user1
+          new_mood1 = create(:mood, userid: new_user1.id)
+          new_mood2 = create(:mood, userid: new_user1.id)
+          new_mood3 = create(:mood, userid: new_user1.id)
+          new_mood4 = create(:mood, userid: new_user1.id)
+          new_moment1 = create(:moment, userid: new_user1.id, mood: Array.new(1, new_mood2.id))
+          new_moment2 = create(:moment, userid: new_user1.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id])
+          result = controller.most_focus('mood', new_user1.id)
           expect(result.length).to eq(3)
           expect(result[new_mood1.id]).to eq(1)
           expect(result[new_mood2.id]).to eq(2)
@@ -149,8 +139,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          new_user1 = create(:user1)
-          new_user2 = create(:user2)
           sign_in new_user1
           new_mood1 = create(:mood, userid: new_user2.id)
           new_mood2 = create(:mood, userid: new_user2.id)
@@ -167,8 +155,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when all his/her posts are drafts" do
-          new_user1 = create(:user1)
-          new_user2 = create(:user2)
           sign_in new_user1
           new_mood1 = create(:mood, userid: new_user2.id)
           new_mood2 = create(:mood, userid: new_user2.id)
@@ -188,45 +174,42 @@ describe ApplicationController do
 
     describe "strategy" do
       it "returns an empty hash because no strategies exist" do
-        new_user = create(:user1)
-        sign_in new_user
-        new_moment = create(:moment, userid: new_user.id)
+        sign_in new_user1
+        new_moment = create(:moment, userid: new_user1.id)
         expect(controller.most_focus('strategy', nil).length).to eq(0)
       end
 
       describe "returns a hash because strategies exist" do
         it "returns a hash of size 1 when the same strategy is used twice" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_strategy = create(:strategy, userid: new_user.id)
-          new_moment = create(:moment, userid: new_user.id, strategy: Array.new(1, new_strategy.id))
-          result = controller.most_focus('strategy', new_user.id)
+          sign_in new_user1
+          new_strategy = create(:strategy, userid: new_user1.id)
+          new_moment = create(:moment, userid: new_user1.id, strategy: Array.new(1, new_strategy.id))
+          result = controller.most_focus('strategy', new_user1.id)
           expect(result.length).to eq(1)
           expect(result[new_strategy.id]).to eq(1)
         end
 
         it "returns a hash of size 2" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_strategy1 = create(:strategy, userid: new_user.id)
-          new_strategy2 = create(:strategy, userid: new_user.id)
-          new_moment = create(:moment, userid: new_user.id, strategy: [new_strategy1.id, new_strategy2.id])
-          result = controller.most_focus('strategy', new_user.id)
+          sign_in new_user1
+          new_strategy1 = create(:strategy, userid: new_user1.id)
+          new_strategy2 = create(:strategy, userid: new_user1.id)
+          new_moment = create(:moment, userid: new_user1.id, strategy: [new_strategy1.id, new_strategy2.id])
+          result = controller.most_focus('strategy', new_user1.id)
           expect(result.length).to eq(2)
           expect(result[new_strategy1.id]).to eq(1)
           expect(result[new_strategy2.id]).to eq(1)
         end
 
         it "returns a correct hash of size 3" do
-          new_user = create(:user1)
-          sign_in new_user
-          new_strategy1 = create(:strategy, userid: new_user.id)
-          new_strategy2 = create(:strategy, userid: new_user.id)
-          new_strategy3 = create(:strategy, userid: new_user.id)
-          new_strategy4 = create(:strategy, userid: new_user.id)
-          new_moment1 = create(:moment, userid: new_user.id, strategy: Array.new(1, new_strategy2.id))
-          new_moment2 = create(:moment, userid: new_user.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id])
-          result = controller.most_focus('strategy', new_user.id)
+          
+          sign_in new_user1
+          new_strategy1 = create(:strategy, userid: new_user1.id)
+          new_strategy2 = create(:strategy, userid: new_user1.id)
+          new_strategy3 = create(:strategy, userid: new_user1.id)
+          new_strategy4 = create(:strategy, userid: new_user1.id)
+          new_moment1 = create(:moment, userid: new_user1.id, strategy: Array.new(1, new_strategy2.id))
+          new_moment2 = create(:moment, userid: new_user1.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id])
+          result = controller.most_focus('strategy', new_user1.id)
           expect(result.length).to eq(3)
           expect(result[new_strategy1.id]).to eq(1)
           expect(result[new_strategy2.id]).to eq(2)
@@ -235,8 +218,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          new_user1 = create(:user1)
-          new_user2 = create(:user2)
           sign_in new_user1
           new_strategy1 = create(:strategy, userid: new_user2.id)
           new_strategy2 = create(:strategy, userid: new_user2.id)
@@ -253,8 +234,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when all his/her posts are drafts" do
-          new_user1 = create(:user1)
-          new_user2 = create(:user2)
           sign_in new_user1
           new_strategy1 = create(:strategy, userid: new_user2.id)
           new_strategy2 = create(:strategy, userid: new_user2.id)
@@ -275,93 +254,79 @@ describe ApplicationController do
 
   describe "tag_usage" do
     it "is looking for categories tagged nowhere" do
-      new_user = create(:user1)
-      new_category = create(:category, userid: new_user.id)
-      result = controller.tag_usage(new_category.id, 'category', new_user.id)
+      new_category = create(:category, userid: new_user1.id)
+      result = controller.tag_usage(new_category.id, 'category', new_user1.id)
         expect(result[0].length + result[1].length).to eq(0)
     end
 
     it "is looking for categories tagged in moments and strategies" do
-      new_user = create(:user1)
-      new_category = create(:category, userid: new_user.id)
-        new_moment = create(:moment, userid: new_user.id, category: Array.new(1, new_category.id))
-        new_strategy = create(:strategy, userid: new_user.id, category: Array.new(1, new_category.id))
-        result = controller.tag_usage(new_category.id, 'category', new_user.id)
+      new_category = create(:category, userid: new_user1.id)
+        new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category.id))
+        new_strategy = create(:strategy, userid: new_user1.id, category: Array.new(1, new_category.id))
+        result = controller.tag_usage(new_category.id, 'category', new_user1.id)
         expect(result[0].length + result[1].length).to eq(2)
     end
 
     it "is looking for moods tagged nowhere" do
-      new_user = create(:user1)
-      new_mood = create(:mood, userid: new_user.id)
-      result = controller.tag_usage(new_mood.id, 'mood', new_user.id)
+      new_mood = create(:mood, userid: new_user1.id)
+      result = controller.tag_usage(new_mood.id, 'mood', new_user1.id)
         expect(result.length).to eq(0)
     end
 
     it "is looking for moods tagged in moments" do
-      new_user = create(:user1)
-      new_mood = create(:mood, userid: new_user.id)
-        new_moment = create(:moment, userid: new_user.id, mood: Array.new(1, new_mood.id))
-        result = controller.tag_usage(new_mood.id, 'mood', new_user.id)
+      new_mood = create(:mood, userid: new_user1.id)
+        new_moment = create(:moment, userid: new_user1.id, mood: Array.new(1, new_mood.id))
+        result = controller.tag_usage(new_mood.id, 'mood', new_user1.id)
         expect(result.length).to eq(1)
     end
 
     it "is looking for strategies tagged nowhere" do
-      new_user = create(:user1)
-      new_strategy = create(:strategy, userid: new_user.id)
-      result = controller.tag_usage(new_strategy.id, 'strategy', new_user.id)
+      new_strategy = create(:strategy, userid: new_user1.id)
+      result = controller.tag_usage(new_strategy.id, 'strategy', new_user1.id)
         expect(result.length).to eq(0)
     end
 
     it "is looking for strategies tagged in moments" do
-      new_user = create(:user1)
-      new_strategy = create(:strategy, userid: new_user.id)
-        new_moment = create(:moment, userid: new_user.id, strategy: Array.new(1, new_strategy.id))
-        result = controller.tag_usage(new_strategy.id, 'strategy', new_user.id)
+      new_strategy = create(:strategy, userid: new_user1.id)
+        new_moment = create(:moment, userid: new_user1.id, strategy: Array.new(1, new_strategy.id))
+        result = controller.tag_usage(new_strategy.id, 'strategy', new_user1.id)
         expect(result.length).to eq(1)
     end
   end
 
   describe "get_stories" do
     it "has no stories and does not include allies" do
-      new_user = create(:user1)
-      sign_in new_user
-        expect(controller.get_stories(new_user, false).length).to eq(0)
+      sign_in new_user1
+        expect(controller.get_stories(new_user1, false).length).to eq(0)
     end
 
     it "has only moments and does not include allies" do
-      new_user = create(:user1)
-      sign_in new_user
-      new_moment = create(:moment, userid: new_user.id)
-      expect(controller.get_stories(new_user, false).length).to eq(1)
+      sign_in new_user1
+      new_moment = create(:moment, userid: new_user1.id)
+      expect(controller.get_stories(new_user1, false).length).to eq(1)
     end
 
-    it "has only strategies and does not include allies" do
-      new_user = create(:user1)
-      sign_in new_user
-      new_strategy = create(:strategy, userid: new_user.id)
-      expect(controller.get_stories(new_user, false).length).to eq(1)
+    it "has only strategies and does not include allies" do 
+      sign_in new_user1
+      new_strategy = create(:strategy, userid: new_user1.id)
+      expect(controller.get_stories(new_user1, false).length).to eq(1)
     end
 
     it "has both moments and strategies, and does not include allies" do
-      new_user = create(:user1)
-      sign_in new_user
-      new_moment = create(:moment, userid: new_user.id)
-      new_strategy = create(:strategy, userid: new_user.id)
-      expect(controller.get_stories(new_user, false).length).to eq(2)
+      sign_in new_user1
+      new_moment = create(:moment, userid: new_user1.id)
+      new_strategy = create(:strategy, userid: new_user1.id)
+      expect(controller.get_stories(new_user1, false).length).to eq(2)
 
     end
 
     it "has no stories and does include allies" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
         expect(controller.get_stories(new_user1, true).length).to eq(0)
     end
 
     it "has only moments and does include allies" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_moment1 = create(:moment, userid: new_user1.id, published_at: Time.zone.now)
@@ -370,8 +335,6 @@ describe ApplicationController do
     end
 
     it "has only other users' draft moments and does include allies" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_moment2 = create(:moment, userid: new_user2.id, viewers: [new_user1.id])
@@ -379,8 +342,6 @@ describe ApplicationController do
     end
 
     it "has only strategies and does include allies" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_strategy1 = create(:strategy, userid: new_user1.id, published_at: Time.zone.now)
@@ -389,8 +350,6 @@ describe ApplicationController do
     end
 
     it "has only other users' draft strategies and does include allies" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id])
@@ -398,8 +357,6 @@ describe ApplicationController do
     end
 
     it "has both moments and strategies, and does include allies" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_moment1 = create(:moment, userid: new_user1.id, published_at: Time.zone.now)
@@ -408,8 +365,6 @@ describe ApplicationController do
     end
 
     it "has only users' draft moments and strategies, and does include allies" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_moment2 = create(:moment, userid: new_user2.id)
@@ -418,8 +373,6 @@ describe ApplicationController do
     end
 
     it "has no moments and strategies despite being allies with user" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_moment2 = create(:moment, userid: new_user2.id)
@@ -428,8 +381,6 @@ describe ApplicationController do
     end
 
     it "has both moments and strategies and is allies with user" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_moment1 = create(:moment, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
@@ -437,9 +388,7 @@ describe ApplicationController do
       expect(controller.get_stories(new_user2, false).length).to eq(2)
     end
 
-    it "has both moments and strategies and is allies with user, but her/his posts are all drafts" do
-      new_user1 = create(:user1)
-      new_user2 = create(:user2)
+    it "has both moments and strategies and is allies with user, but her/his posts are all drafts"  do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
       sign_in new_user1
       new_moment1 = create(:moment, userid: new_user2.id, viewers: [new_user1.id])
@@ -450,35 +399,31 @@ describe ApplicationController do
 
   describe "moments_stats" do
     it "has no moments" do
-      new_user = create(:user1)
-      sign_in new_user
+      sign_in new_user1
         expect(controller.moments_stats).to eq('')
     end
 
     it "has one moment" do
-      new_user = create(:user1)
-      sign_in new_user
-      new_moment = create(:moment, userid: new_user.id)
+      sign_in new_user1
+      new_moment = create(:moment, userid: new_user1.id)
       expect(controller.moments_stats).to eq('')
     end
 
     it "has more than one moment created this month" do
-      new_user = create(:user1)
-      sign_in new_user
-      new_moment1 = create(:moment, userid: new_user.id)
-      new_moment2 = create(:moment, userid: new_user.id)
+      sign_in new_user1
+      new_moment1 = create(:moment, userid: new_user1.id)
+      new_moment2 = create(:moment, userid: new_user1.id)
       expect(controller.moments_stats).to eq('<div class="center" id="stats">You have written a <strong>total</strong> of <strong>2</strong> moments.</div>')
     end
 
     it "has more than one moment created on different months" do
-      new_user = create(:user1)
-      sign_in new_user
-      new_moment1 = create(:moment, userid: new_user.id, created_at: '2014-01-01 00:00:00')
-      new_moment2 = create(:moment, userid: new_user.id)
+      sign_in new_user1
+      new_moment1 = create(:moment, userid: new_user1.id, created_at: '2014-01-01 00:00:00')
+      new_moment2 = create(:moment, userid: new_user1.id)
 
       expect(controller.moments_stats).to eq('<div class="center" id="stats">You have written a <strong>total</strong> of <strong>2</strong> moments. This <strong>month</strong> you wrote <strong>1</strong> moment.</div>')
 
-      new_moment3 = create(:moment, userid: new_user.id)
+      new_moment3 = create(:moment, userid: new_user1.id)
 
       expect(controller.moments_stats).to eq('<div class="center" id="stats">You have written a <strong>total</strong> of <strong>3</strong> moments. This <strong>month</strong> you wrote <strong>2</strong> moments.</div>')
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -408,8 +408,6 @@ describe ApplicationController do
   end
 
   describe 'generate_comment' do
-    let(:user1) { create(:user1) }
-    let(:user2) { create(:user2) }
     let(:user3) { create(:user3) }
     let(:comment) { 'Hello from the outside'}
 
@@ -422,24 +420,24 @@ describe ApplicationController do
     end
 
     before do
-      create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
-      create(:allyships_accepted, user_id: user1.id, ally_id: user3.id)
+      create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
+      create(:allyships_accepted, user_id: new_user1.id, ally_id: user3.id)
     end
 
     context 'Moments' do
-      let(:new_moment) { create(:moment, userid: user1.id, viewers: [user2.id, user3.id]) }
+      let(:new_moment) { create(:moment, userid: new_user1.id, viewers: [new_user2.id, user3.id]) }
 
       context 'Comment posted by Moment creator who is logged in' do
         before(:each) do
-          sign_in user1
+          sign_in new_user1
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user1.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user1.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user1),
+            comment_info: comment_info(new_user1),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -448,13 +446,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user1.id, visibility: 'private', viewers: [user2.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user1.id, visibility: 'private', viewers: [new_user2.id])
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user1),
+            comment_info: comment_info(new_user1),
             comment_text: comment,
-            visibility: "Visible only between you and #{user2.name}",
+            visibility: "Visible only between you and #{new_user2.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -463,15 +461,15 @@ describe ApplicationController do
 
       context 'Comment posted by Moment viewer who is logged in' do
         before(:each) do
-          sign_in user2
+          sign_in new_user2
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user2.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user2.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user2),
+            comment_info: comment_info(new_user2),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -480,13 +478,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user2.id, visibility: 'private', viewers: [user1.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user2.id, visibility: 'private', viewers: [new_user1.id])
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user2),
+            comment_info: comment_info(new_user2),
             comment_text: comment,
-            visibility: "Visible only between you and #{user1.name}",
+            visibility: "Visible only between you and #{new_user1.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -495,19 +493,19 @@ describe ApplicationController do
     end
 
     context 'Strategies' do
-      let(:new_strategy) { create(:strategy, userid: user1.id, viewers: [user2.id, user3.id]) }
+      let(:new_strategy) { create(:strategy, userid: new_user1.id, viewers: [new_user2.id, user3.id]) }
 
       context 'Comment posted by Strategy creator who is logged in' do
         before(:each) do
-          sign_in user1
+          sign_in new_user1
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user1.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user1.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user1),
+            comment_info: comment_info(new_user1),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -516,13 +514,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user1.id, visibility: 'private', viewers: [user2.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user1.id, visibility: 'private', viewers: [new_user2.id])
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user1),
+            comment_info: comment_info(new_user1),
             comment_text: comment,
-            visibility: "Visible only between you and #{user2.name}",
+            visibility: "Visible only between you and #{new_user2.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -531,15 +529,15 @@ describe ApplicationController do
 
       context 'Comment posted by Strategy viewer who is logged in' do
         before(:each) do
-          sign_in user2
+          sign_in new_user2
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user2.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user2.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user2),
+            comment_info: comment_info(new_user2),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -548,13 +546,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user2.id, visibility: 'private', viewers: [user1.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user2.id, visibility: 'private', viewers: [new_user1.id])
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user2),
+            comment_info: comment_info(new_user2),
             comment_text: comment,
-            visibility: "Visible only between you and #{user1.name}",
+            visibility: "Visible only between you and #{new_user1.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -566,18 +564,18 @@ describe ApplicationController do
       let(:new_meeting) { create :meeting }
 
       before do
-        create :meeting_member, userid: user1.id, leader: true, meetingid: new_meeting.id
-        create :meeting_member, userid: user2.id, leader: false, meetingid: new_meeting.id
+        create :meeting_member, userid: new_user1.id, leader: true, meetingid: new_meeting.id
+        create :meeting_member, userid: new_user2.id, leader: false, meetingid: new_meeting.id
       end
 
       context 'Comment posted by Meeting creator who is logged in' do
         it 'generates a valid comment object' do
-          sign_in user1
-          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: user1.id, visibility: 'all')
+          sign_in new_user1
+          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: new_user1.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'meeting')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user1),
+            comment_info: comment_info(new_user1),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -588,12 +586,12 @@ describe ApplicationController do
 
       context 'Comment posted by Meeting member who is logged in' do
         it 'generates a valid comment object' do
-          sign_in user2
-          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: user2.id, visibility: 'all')
+          sign_in new_user2
+          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: new_user2.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'meeting')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(user2),
+            comment_info: comment_info(new_user2),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -14,8 +14,10 @@ describe ApplicationController do
   let(:new_user2) { create(:user2) }
   describe "most_focus" do
     describe "categories" do
-      it "returns an empty hash because no categories exist" do
+      before(:example) do 
         sign_in new_user1
+      end 
+      it "returns an empty hash because no categories exist" do
         new_moment = create(:moment, userid: new_user1.id)
         new_strategy = create(:strategy, userid: new_user1.id)
         expect(controller.most_focus('category', nil).length).to eq(0)
@@ -23,7 +25,6 @@ describe ApplicationController do
 
       describe "returns a hash because categories exist" do
         it "returns a hash of size 1 when the same category is used twice" do
-          sign_in new_user1
           new_category = create(:category, userid: new_user1.id)
           new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category.id))
           new_strategy = create(:strategy, userid: new_user1.id, category: Array.new(1, new_category.id))
@@ -33,7 +34,6 @@ describe ApplicationController do
         end
 
         it "returns a hash of size 2" do
-          sign_in new_user1
           new_category1 = create(:category, userid: new_user1.id)
           new_category2 = create(:category, userid: new_user1.id)
           new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category1.id))
@@ -45,7 +45,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 3" do
-          sign_in new_user1
           new_category1 = create(:category, userid: new_user1.id)
           new_category2 = create(:category, userid: new_user1.id)
           new_category3 = create(:category, userid: new_user1.id)
@@ -61,7 +60,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          sign_in new_user1
           new_category1 = create(:category, userid: new_user2.id)
           new_category2 = create(:category, userid: new_user2.id)
           new_category3 = create(:category, userid: new_user2.id)
@@ -77,7 +75,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when his/her posts are drafts" do
-          sign_in new_user1
           new_category1 = create(:category, userid: new_user2.id)
           new_category2 = create(:category, userid: new_user2.id)
           new_category3 = create(:category, userid: new_user2.id)
@@ -95,15 +92,16 @@ describe ApplicationController do
     end
 
     describe "moods" do
-      it "returns an empty hash because no moods exist" do
+      before(:example) do 
         sign_in new_user1
+      end 
+      it "returns an empty hash because no moods exist" do
         new_moment = create(:moment, userid: new_user1.id)
         expect(controller.most_focus('mood', nil).length).to eq(0)
       end
 
       describe "returns a hash because moods exist" do
         it "returns a hash of size 1 when the same mood is used twice" do
-          sign_in new_user1
           new_mood = create(:mood, userid: new_user1.id)
           new_moment = create(:moment, userid: new_user1.id, mood: Array.new(1, new_mood.id))
           result = controller.most_focus('mood', new_user1.id)
@@ -112,7 +110,6 @@ describe ApplicationController do
         end
 
         it "returns a hash of size 2" do
-          sign_in new_user1
           new_mood1 = create(:mood, userid: new_user1.id)
           new_mood2 = create(:mood, userid: new_user1.id)
           new_moment = create(:moment, userid: new_user1.id, mood: [new_mood1.id, new_mood2.id])
@@ -123,7 +120,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 3" do
-          sign_in new_user1
           new_mood1 = create(:mood, userid: new_user1.id)
           new_mood2 = create(:mood, userid: new_user1.id)
           new_mood3 = create(:mood, userid: new_user1.id)
@@ -139,7 +135,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          sign_in new_user1
           new_mood1 = create(:mood, userid: new_user2.id)
           new_mood2 = create(:mood, userid: new_user2.id)
           new_mood3 = create(:mood, userid: new_user2.id)
@@ -155,7 +150,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when all his/her posts are drafts" do
-          sign_in new_user1
           new_mood1 = create(:mood, userid: new_user2.id)
           new_mood2 = create(:mood, userid: new_user2.id)
           new_mood3 = create(:mood, userid: new_user2.id)
@@ -173,15 +167,16 @@ describe ApplicationController do
     end
 
     describe "strategy" do
-      it "returns an empty hash because no strategies exist" do
+      before(:example) do 
         sign_in new_user1
+      end 
+      it "returns an empty hash because no strategies exist" do
         new_moment = create(:moment, userid: new_user1.id)
         expect(controller.most_focus('strategy', nil).length).to eq(0)
       end
 
       describe "returns a hash because strategies exist" do
         it "returns a hash of size 1 when the same strategy is used twice" do
-          sign_in new_user1
           new_strategy = create(:strategy, userid: new_user1.id)
           new_moment = create(:moment, userid: new_user1.id, strategy: Array.new(1, new_strategy.id))
           result = controller.most_focus('strategy', new_user1.id)
@@ -190,7 +185,6 @@ describe ApplicationController do
         end
 
         it "returns a hash of size 2" do
-          sign_in new_user1
           new_strategy1 = create(:strategy, userid: new_user1.id)
           new_strategy2 = create(:strategy, userid: new_user1.id)
           new_moment = create(:moment, userid: new_user1.id, strategy: [new_strategy1.id, new_strategy2.id])
@@ -201,8 +195,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 3" do
-          
-          sign_in new_user1
           new_strategy1 = create(:strategy, userid: new_user1.id)
           new_strategy2 = create(:strategy, userid: new_user1.id)
           new_strategy3 = create(:strategy, userid: new_user1.id)
@@ -218,7 +210,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          sign_in new_user1
           new_strategy1 = create(:strategy, userid: new_user2.id)
           new_strategy2 = create(:strategy, userid: new_user2.id)
           new_strategy3 = create(:strategy, userid: new_user2.id)
@@ -234,7 +225,6 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when all his/her posts are drafts" do
-          sign_in new_user1
           new_strategy1 = create(:strategy, userid: new_user2.id)
           new_strategy2 = create(:strategy, userid: new_user2.id)
           new_strategy3 = create(:strategy, userid: new_user2.id)
@@ -295,25 +285,24 @@ describe ApplicationController do
   end
 
   describe "get_stories" do
-    it "has no stories and does not include allies" do
+    before(:example) do 
       sign_in new_user1
+    end 
+    it "has no stories and does not include allies" do
         expect(controller.get_stories(new_user1, false).length).to eq(0)
     end
 
     it "has only moments and does not include allies" do
-      sign_in new_user1
       new_moment = create(:moment, userid: new_user1.id)
       expect(controller.get_stories(new_user1, false).length).to eq(1)
     end
 
     it "has only strategies and does not include allies" do 
-      sign_in new_user1
       new_strategy = create(:strategy, userid: new_user1.id)
       expect(controller.get_stories(new_user1, false).length).to eq(1)
     end
 
     it "has both moments and strategies, and does not include allies" do
-      sign_in new_user1
       new_moment = create(:moment, userid: new_user1.id)
       new_strategy = create(:strategy, userid: new_user1.id)
       expect(controller.get_stories(new_user1, false).length).to eq(2)
@@ -322,13 +311,11 @@ describe ApplicationController do
 
     it "has no stories and does include allies" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
         expect(controller.get_stories(new_user1, true).length).to eq(0)
     end
 
     it "has only moments and does include allies" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_moment1 = create(:moment, userid: new_user1.id, published_at: Time.zone.now)
       new_moment2 = create(:moment, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
       expect(controller.get_stories(new_user1, true).length).to eq(2)
@@ -336,14 +323,12 @@ describe ApplicationController do
 
     it "has only other users' draft moments and does include allies" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_moment2 = create(:moment, userid: new_user2.id, viewers: [new_user1.id])
       expect(controller.get_stories(new_user1, true).length).to eq(0)
     end
 
     it "has only strategies and does include allies" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_strategy1 = create(:strategy, userid: new_user1.id, published_at: Time.zone.now)
       new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
       expect(controller.get_stories(new_user1, true).length).to eq(2)
@@ -351,14 +336,12 @@ describe ApplicationController do
 
     it "has only other users' draft strategies and does include allies" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id])
       expect(controller.get_stories(new_user1, true).length).to eq(0)
     end
 
     it "has both moments and strategies, and does include allies" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_moment1 = create(:moment, userid: new_user1.id, published_at: Time.zone.now)
       new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
       expect(controller.get_stories(new_user1, true).length).to eq(2)
@@ -366,7 +349,6 @@ describe ApplicationController do
 
     it "has only users' draft moments and strategies, and does include allies" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_moment2 = create(:moment, userid: new_user2.id)
       new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id])
       expect(controller.get_stories(new_user1, true).length).to eq(0)
@@ -374,7 +356,6 @@ describe ApplicationController do
 
     it "has no moments and strategies despite being allies with user" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_moment2 = create(:moment, userid: new_user2.id)
       new_strategy2 = create(:strategy, userid: new_user2.id)
       expect(controller.get_stories(new_user2, false).length).to eq(0)
@@ -382,7 +363,6 @@ describe ApplicationController do
 
     it "has both moments and strategies and is allies with user" do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_moment1 = create(:moment, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
       new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
       expect(controller.get_stories(new_user2, false).length).to eq(2)
@@ -390,7 +370,6 @@ describe ApplicationController do
 
     it "has both moments and strategies and is allies with user, but her/his posts are all drafts"  do
       new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      sign_in new_user1
       new_moment1 = create(:moment, userid: new_user2.id, viewers: [new_user1.id])
       new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id])
       expect(controller.get_stories(new_user2, false).length).to eq(0)
@@ -398,26 +377,25 @@ describe ApplicationController do
   end
 
   describe "moments_stats" do
-    it "has no moments" do
+    before(:example) do 
       sign_in new_user1
+    end 
+    it "has no moments" do
         expect(controller.moments_stats).to eq('')
     end
 
     it "has one moment" do
-      sign_in new_user1
       new_moment = create(:moment, userid: new_user1.id)
       expect(controller.moments_stats).to eq('')
     end
 
     it "has more than one moment created this month" do
-      sign_in new_user1
       new_moment1 = create(:moment, userid: new_user1.id)
       new_moment2 = create(:moment, userid: new_user1.id)
       expect(controller.moments_stats).to eq('<div class="center" id="stats">You have written a <strong>total</strong> of <strong>2</strong> moments.</div>')
     end
 
     it "has more than one moment created on different months" do
-      sign_in new_user1
       new_moment1 = create(:moment, userid: new_user1.id, created_at: '2014-01-01 00:00:00')
       new_moment2 = create(:moment, userid: new_user1.id)
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -10,48 +10,48 @@ RSpec::Matchers.define :be_avatar_component do
 end
 
 describe ApplicationController do
-  let(:new_user1) { create(:user1) }
-  let(:new_user2) { create(:user2) }
+  let(:user1) { create(:user1) }
+  let(:user2) { create(:user2) }
   describe "most_focus" do
     describe "categories" do
       before(:example) do 
-        sign_in new_user1
+        sign_in user1
       end 
       it "returns an empty hash because no categories exist" do
-        new_moment = create(:moment, userid: new_user1.id)
-        new_strategy = create(:strategy, userid: new_user1.id)
+        new_moment = create(:moment, userid: user1.id)
+        new_strategy = create(:strategy, userid: user1.id)
         expect(controller.most_focus('category', nil).length).to eq(0)
       end
 
       describe "returns a hash because categories exist" do
         it "returns a hash of size 1 when the same category is used twice" do
-          new_category = create(:category, userid: new_user1.id)
-          new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category.id))
-          new_strategy = create(:strategy, userid: new_user1.id, category: Array.new(1, new_category.id))
-          result = controller.most_focus('category', new_user1.id)
+          new_category = create(:category, userid: user1.id)
+          new_moment = create(:moment, userid: user1.id, category: Array.new(1, new_category.id))
+          new_strategy = create(:strategy, userid: user1.id, category: Array.new(1, new_category.id))
+          result = controller.most_focus('category', user1.id)
           expect(result.length).to eq(1)
           expect(result[new_category.id]).to eq(2)
         end
 
         it "returns a hash of size 2" do
-          new_category1 = create(:category, userid: new_user1.id)
-          new_category2 = create(:category, userid: new_user1.id)
-          new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category1.id))
-          new_strategy = create(:strategy, userid: new_user1.id, category: Array.new(1, new_category2.id))
-          result = controller.most_focus('category', new_user1.id)
+          new_category1 = create(:category, userid: user1.id)
+          new_category2 = create(:category, userid: user1.id)
+          new_moment = create(:moment, userid: user1.id, category: Array.new(1, new_category1.id))
+          new_strategy = create(:strategy, userid: user1.id, category: Array.new(1, new_category2.id))
+          result = controller.most_focus('category', user1.id)
           expect(result.length).to eq(2)
           expect(result[new_category1.id]).to eq(1)
           expect(result[new_category2.id]).to eq(1)
         end
 
         it "returns a correct hash of size 3" do
-          new_category1 = create(:category, userid: new_user1.id)
-          new_category2 = create(:category, userid: new_user1.id)
-          new_category3 = create(:category, userid: new_user1.id)
-          new_category4 = create(:category, userid: new_user1.id)
-          new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category2.id))
-          new_strategy = create(:strategy, userid: new_user1.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id])
-          result = controller.most_focus('category', new_user1.id)
+          new_category1 = create(:category, userid: user1.id)
+          new_category2 = create(:category, userid: user1.id)
+          new_category3 = create(:category, userid: user1.id)
+          new_category4 = create(:category, userid: user1.id)
+          new_moment = create(:moment, userid: user1.id, category: Array.new(1, new_category2.id))
+          new_strategy = create(:strategy, userid: user1.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id])
+          result = controller.most_focus('category', user1.id)
           expect(result.length).to eq(3)
           expect(result[new_category1.id]).to eq(1)
           expect(result[new_category2.id]).to eq(2)
@@ -60,13 +60,13 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          new_category1 = create(:category, userid: new_user2.id)
-          new_category2 = create(:category, userid: new_user2.id)
-          new_category3 = create(:category, userid: new_user2.id)
-          new_category4 = create(:category, userid: new_user2.id)
-          new_moment = create(:moment, userid: new_user2.id, category: Array.new(1, new_category2.id), viewers: Array.new(1, new_user1.id), published_at: Time.zone.now)
-          new_strategy = create(:strategy, userid: new_user2.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id], published_at: Time.zone.now)
-          result = controller.most_focus('category', new_user2.id)
+          new_category1 = create(:category, userid: user2.id)
+          new_category2 = create(:category, userid: user2.id)
+          new_category3 = create(:category, userid: user2.id)
+          new_category4 = create(:category, userid: user2.id)
+          new_moment = create(:moment, userid: user2.id, category: Array.new(1, new_category2.id), viewers: Array.new(1, user1.id), published_at: Time.zone.now)
+          new_strategy = create(:strategy, userid: user2.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id], published_at: Time.zone.now)
+          result = controller.most_focus('category', user2.id)
           expect(result.length).to eq(1)
           expect(result[new_category1.id]).to eq(nil)
           expect(result[new_category2.id]).to eq(1)
@@ -75,13 +75,13 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when his/her posts are drafts" do
-          new_category1 = create(:category, userid: new_user2.id)
-          new_category2 = create(:category, userid: new_user2.id)
-          new_category3 = create(:category, userid: new_user2.id)
-          new_category4 = create(:category, userid: new_user2.id)
-          new_moment = create(:moment, userid: new_user2.id, category: Array.new(1, new_category2.id), viewers: Array.new(1, new_user1.id))
-          new_strategy = create(:strategy, userid: new_user2.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id])
-          result = controller.most_focus('category', new_user2.id)
+          new_category1 = create(:category, userid: user2.id)
+          new_category2 = create(:category, userid: user2.id)
+          new_category3 = create(:category, userid: user2.id)
+          new_category4 = create(:category, userid: user2.id)
+          new_moment = create(:moment, userid: user2.id, category: Array.new(1, new_category2.id), viewers: Array.new(1, user1.id))
+          new_strategy = create(:strategy, userid: user2.id, category: [new_category1.id, new_category2.id, new_category3.id, new_category4.id])
+          result = controller.most_focus('category', user2.id)
           expect(result.length).to eq(0)
           expect(result[new_category1.id]).to eq(nil)
           expect(result[new_category2.id]).to eq(nil)
@@ -93,40 +93,40 @@ describe ApplicationController do
 
     describe "moods" do
       before(:example) do 
-        sign_in new_user1
+        sign_in user1
       end 
       it "returns an empty hash because no moods exist" do
-        new_moment = create(:moment, userid: new_user1.id)
+        new_moment = create(:moment, userid: user1.id)
         expect(controller.most_focus('mood', nil).length).to eq(0)
       end
 
       describe "returns a hash because moods exist" do
         it "returns a hash of size 1 when the same mood is used twice" do
-          new_mood = create(:mood, userid: new_user1.id)
-          new_moment = create(:moment, userid: new_user1.id, mood: Array.new(1, new_mood.id))
-          result = controller.most_focus('mood', new_user1.id)
+          new_mood = create(:mood, userid: user1.id)
+          new_moment = create(:moment, userid: user1.id, mood: Array.new(1, new_mood.id))
+          result = controller.most_focus('mood', user1.id)
           expect(result.length).to eq(1)
           expect(result[new_mood.id]).to eq(1)
         end
 
         it "returns a hash of size 2" do
-          new_mood1 = create(:mood, userid: new_user1.id)
-          new_mood2 = create(:mood, userid: new_user1.id)
-          new_moment = create(:moment, userid: new_user1.id, mood: [new_mood1.id, new_mood2.id])
-          result = controller.most_focus('mood', new_user1.id)
+          new_mood1 = create(:mood, userid: user1.id)
+          new_mood2 = create(:mood, userid: user1.id)
+          new_moment = create(:moment, userid: user1.id, mood: [new_mood1.id, new_mood2.id])
+          result = controller.most_focus('mood', user1.id)
           expect(result.length).to eq(2)
           expect(result[new_mood1.id]).to eq(1)
           expect(result[new_mood2.id]).to eq(1)
         end
 
         it "returns a correct hash of size 3" do
-          new_mood1 = create(:mood, userid: new_user1.id)
-          new_mood2 = create(:mood, userid: new_user1.id)
-          new_mood3 = create(:mood, userid: new_user1.id)
-          new_mood4 = create(:mood, userid: new_user1.id)
-          new_moment1 = create(:moment, userid: new_user1.id, mood: Array.new(1, new_mood2.id))
-          new_moment2 = create(:moment, userid: new_user1.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id])
-          result = controller.most_focus('mood', new_user1.id)
+          new_mood1 = create(:mood, userid: user1.id)
+          new_mood2 = create(:mood, userid: user1.id)
+          new_mood3 = create(:mood, userid: user1.id)
+          new_mood4 = create(:mood, userid: user1.id)
+          new_moment1 = create(:moment, userid: user1.id, mood: Array.new(1, new_mood2.id))
+          new_moment2 = create(:moment, userid: user1.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id])
+          result = controller.most_focus('mood', user1.id)
           expect(result.length).to eq(3)
           expect(result[new_mood1.id]).to eq(1)
           expect(result[new_mood2.id]).to eq(2)
@@ -135,13 +135,13 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          new_mood1 = create(:mood, userid: new_user2.id)
-          new_mood2 = create(:mood, userid: new_user2.id)
-          new_mood3 = create(:mood, userid: new_user2.id)
-          new_mood4 = create(:mood, userid: new_user2.id)
-          new_moment1 = create(:moment, userid: new_user2.id, mood: Array.new(1, new_mood2.id), viewers: Array.new(1, new_user1.id), published_at: Time.zone.now)
-          new_moment2 = create(:moment, userid: new_user2.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id], published_at: Time.zone.now)
-          result = controller.most_focus('mood', new_user2.id)
+          new_mood1 = create(:mood, userid: user2.id)
+          new_mood2 = create(:mood, userid: user2.id)
+          new_mood3 = create(:mood, userid: user2.id)
+          new_mood4 = create(:mood, userid: user2.id)
+          new_moment1 = create(:moment, userid: user2.id, mood: Array.new(1, new_mood2.id), viewers: Array.new(1, user1.id), published_at: Time.zone.now)
+          new_moment2 = create(:moment, userid: user2.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id], published_at: Time.zone.now)
+          result = controller.most_focus('mood', user2.id)
           expect(result.length).to eq(1)
           expect(result[new_mood1.id]).to eq(nil)
           expect(result[new_mood2.id]).to eq(1)
@@ -150,13 +150,13 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when all his/her posts are drafts" do
-          new_mood1 = create(:mood, userid: new_user2.id)
-          new_mood2 = create(:mood, userid: new_user2.id)
-          new_mood3 = create(:mood, userid: new_user2.id)
-          new_mood4 = create(:mood, userid: new_user2.id)
-          new_moment1 = create(:moment, userid: new_user2.id, mood: Array.new(1, new_mood2.id), viewers: Array.new(1, new_user1.id))
-          new_moment2 = create(:moment, userid: new_user2.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id])
-          result = controller.most_focus('mood', new_user2.id)
+          new_mood1 = create(:mood, userid: user2.id)
+          new_mood2 = create(:mood, userid: user2.id)
+          new_mood3 = create(:mood, userid: user2.id)
+          new_mood4 = create(:mood, userid: user2.id)
+          new_moment1 = create(:moment, userid: user2.id, mood: Array.new(1, new_mood2.id), viewers: Array.new(1, user1.id))
+          new_moment2 = create(:moment, userid: user2.id, mood: [new_mood1.id, new_mood2.id, new_mood3.id, new_mood4.id])
+          result = controller.most_focus('mood', user2.id)
           expect(result.length).to eq(0)
           expect(result[new_mood1.id]).to eq(nil)
           expect(result[new_mood2.id]).to eq(nil)
@@ -168,40 +168,40 @@ describe ApplicationController do
 
     describe "strategy" do
       before(:example) do 
-        sign_in new_user1
+        sign_in user1
       end 
       it "returns an empty hash because no strategies exist" do
-        new_moment = create(:moment, userid: new_user1.id)
+        new_moment = create(:moment, userid: user1.id)
         expect(controller.most_focus('strategy', nil).length).to eq(0)
       end
 
       describe "returns a hash because strategies exist" do
         it "returns a hash of size 1 when the same strategy is used twice" do
-          new_strategy = create(:strategy, userid: new_user1.id)
-          new_moment = create(:moment, userid: new_user1.id, strategy: Array.new(1, new_strategy.id))
-          result = controller.most_focus('strategy', new_user1.id)
+          new_strategy = create(:strategy, userid: user1.id)
+          new_moment = create(:moment, userid: user1.id, strategy: Array.new(1, new_strategy.id))
+          result = controller.most_focus('strategy', user1.id)
           expect(result.length).to eq(1)
           expect(result[new_strategy.id]).to eq(1)
         end
 
         it "returns a hash of size 2" do
-          new_strategy1 = create(:strategy, userid: new_user1.id)
-          new_strategy2 = create(:strategy, userid: new_user1.id)
-          new_moment = create(:moment, userid: new_user1.id, strategy: [new_strategy1.id, new_strategy2.id])
-          result = controller.most_focus('strategy', new_user1.id)
+          new_strategy1 = create(:strategy, userid: user1.id)
+          new_strategy2 = create(:strategy, userid: user1.id)
+          new_moment = create(:moment, userid: user1.id, strategy: [new_strategy1.id, new_strategy2.id])
+          result = controller.most_focus('strategy', user1.id)
           expect(result.length).to eq(2)
           expect(result[new_strategy1.id]).to eq(1)
           expect(result[new_strategy2.id]).to eq(1)
         end
 
         it "returns a correct hash of size 3" do
-          new_strategy1 = create(:strategy, userid: new_user1.id)
-          new_strategy2 = create(:strategy, userid: new_user1.id)
-          new_strategy3 = create(:strategy, userid: new_user1.id)
-          new_strategy4 = create(:strategy, userid: new_user1.id)
-          new_moment1 = create(:moment, userid: new_user1.id, strategy: Array.new(1, new_strategy2.id))
-          new_moment2 = create(:moment, userid: new_user1.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id])
-          result = controller.most_focus('strategy', new_user1.id)
+          new_strategy1 = create(:strategy, userid: user1.id)
+          new_strategy2 = create(:strategy, userid: user1.id)
+          new_strategy3 = create(:strategy, userid: user1.id)
+          new_strategy4 = create(:strategy, userid: user1.id)
+          new_moment1 = create(:moment, userid: user1.id, strategy: Array.new(1, new_strategy2.id))
+          new_moment2 = create(:moment, userid: user1.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id])
+          result = controller.most_focus('strategy', user1.id)
           expect(result.length).to eq(3)
           expect(result[new_strategy1.id]).to eq(1)
           expect(result[new_strategy2.id]).to eq(2)
@@ -210,13 +210,13 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 1 belonging to another user" do
-          new_strategy1 = create(:strategy, userid: new_user2.id)
-          new_strategy2 = create(:strategy, userid: new_user2.id)
-          new_strategy3 = create(:strategy, userid: new_user2.id)
-          new_strategy4 = create(:strategy, userid: new_user2.id)
-          new_moment1 = create(:moment, userid: new_user2.id, strategy: Array.new(1, new_strategy2.id), viewers: Array.new(1, new_user1.id), published_at: Time.zone.now)
-          new_moment2 = create(:moment, userid: new_user2.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id], published_at: Time.zone.now)
-          result = controller.most_focus('strategy', new_user2.id)
+          new_strategy1 = create(:strategy, userid: user2.id)
+          new_strategy2 = create(:strategy, userid: user2.id)
+          new_strategy3 = create(:strategy, userid: user2.id)
+          new_strategy4 = create(:strategy, userid: user2.id)
+          new_moment1 = create(:moment, userid: user2.id, strategy: Array.new(1, new_strategy2.id), viewers: Array.new(1, user1.id), published_at: Time.zone.now)
+          new_moment2 = create(:moment, userid: user2.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id], published_at: Time.zone.now)
+          result = controller.most_focus('strategy', user2.id)
           expect(result.length).to eq(1)
           expect(result[new_strategy1.id]).to eq(nil)
           expect(result[new_strategy2.id]).to eq(1)
@@ -225,13 +225,13 @@ describe ApplicationController do
         end
 
         it "returns a correct hash of size 0 belonging to another user when all his/her posts are drafts" do
-          new_strategy1 = create(:strategy, userid: new_user2.id)
-          new_strategy2 = create(:strategy, userid: new_user2.id)
-          new_strategy3 = create(:strategy, userid: new_user2.id)
-          new_strategy4 = create(:strategy, userid: new_user2.id)
-          new_moment1 = create(:moment, userid: new_user2.id, strategy: Array.new(1, new_strategy2.id), viewers: Array.new(1, new_user1.id))
-          new_moment2 = create(:moment, userid: new_user2.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id])
-          result = controller.most_focus('strategy', new_user2.id)
+          new_strategy1 = create(:strategy, userid: user2.id)
+          new_strategy2 = create(:strategy, userid: user2.id)
+          new_strategy3 = create(:strategy, userid: user2.id)
+          new_strategy4 = create(:strategy, userid: user2.id)
+          new_moment1 = create(:moment, userid: user2.id, strategy: Array.new(1, new_strategy2.id), viewers: Array.new(1, user1.id))
+          new_moment2 = create(:moment, userid: user2.id, strategy: [new_strategy1.id, new_strategy2.id, new_strategy3.id, new_strategy4.id])
+          result = controller.most_focus('strategy', user2.id)
           expect(result.length).to eq(0)
           expect(result[new_strategy1.id]).to eq(nil)
           expect(result[new_strategy2.id]).to eq(nil)
@@ -244,164 +244,164 @@ describe ApplicationController do
 
   describe "tag_usage" do
     it "is looking for categories tagged nowhere" do
-      new_category = create(:category, userid: new_user1.id)
-      result = controller.tag_usage(new_category.id, 'category', new_user1.id)
+      new_category = create(:category, userid: user1.id)
+      result = controller.tag_usage(new_category.id, 'category', user1.id)
         expect(result[0].length + result[1].length).to eq(0)
     end
 
     it "is looking for categories tagged in moments and strategies" do
-      new_category = create(:category, userid: new_user1.id)
-        new_moment = create(:moment, userid: new_user1.id, category: Array.new(1, new_category.id))
-        new_strategy = create(:strategy, userid: new_user1.id, category: Array.new(1, new_category.id))
-        result = controller.tag_usage(new_category.id, 'category', new_user1.id)
+      new_category = create(:category, userid: user1.id)
+        new_moment = create(:moment, userid: user1.id, category: Array.new(1, new_category.id))
+        new_strategy = create(:strategy, userid: user1.id, category: Array.new(1, new_category.id))
+        result = controller.tag_usage(new_category.id, 'category', user1.id)
         expect(result[0].length + result[1].length).to eq(2)
     end
 
     it "is looking for moods tagged nowhere" do
-      new_mood = create(:mood, userid: new_user1.id)
-      result = controller.tag_usage(new_mood.id, 'mood', new_user1.id)
+      new_mood = create(:mood, userid: user1.id)
+      result = controller.tag_usage(new_mood.id, 'mood', user1.id)
         expect(result.length).to eq(0)
     end
 
     it "is looking for moods tagged in moments" do
-      new_mood = create(:mood, userid: new_user1.id)
-        new_moment = create(:moment, userid: new_user1.id, mood: Array.new(1, new_mood.id))
-        result = controller.tag_usage(new_mood.id, 'mood', new_user1.id)
+      new_mood = create(:mood, userid: user1.id)
+        new_moment = create(:moment, userid: user1.id, mood: Array.new(1, new_mood.id))
+        result = controller.tag_usage(new_mood.id, 'mood', user1.id)
         expect(result.length).to eq(1)
     end
 
     it "is looking for strategies tagged nowhere" do
-      new_strategy = create(:strategy, userid: new_user1.id)
-      result = controller.tag_usage(new_strategy.id, 'strategy', new_user1.id)
+      new_strategy = create(:strategy, userid: user1.id)
+      result = controller.tag_usage(new_strategy.id, 'strategy', user1.id)
         expect(result.length).to eq(0)
     end
 
     it "is looking for strategies tagged in moments" do
-      new_strategy = create(:strategy, userid: new_user1.id)
-        new_moment = create(:moment, userid: new_user1.id, strategy: Array.new(1, new_strategy.id))
-        result = controller.tag_usage(new_strategy.id, 'strategy', new_user1.id)
+      new_strategy = create(:strategy, userid: user1.id)
+        new_moment = create(:moment, userid: user1.id, strategy: Array.new(1, new_strategy.id))
+        result = controller.tag_usage(new_strategy.id, 'strategy', user1.id)
         expect(result.length).to eq(1)
     end
   end
 
   describe "get_stories" do
     before(:example) do 
-      sign_in new_user1
+      sign_in user1
     end 
     it "has no stories and does not include allies" do
-        expect(controller.get_stories(new_user1, false).length).to eq(0)
+        expect(controller.get_stories(user1, false).length).to eq(0)
     end
 
     it "has only moments and does not include allies" do
-      new_moment = create(:moment, userid: new_user1.id)
-      expect(controller.get_stories(new_user1, false).length).to eq(1)
+      new_moment = create(:moment, userid: user1.id)
+      expect(controller.get_stories(user1, false).length).to eq(1)
     end
 
     it "has only strategies and does not include allies" do 
-      new_strategy = create(:strategy, userid: new_user1.id)
-      expect(controller.get_stories(new_user1, false).length).to eq(1)
+      new_strategy = create(:strategy, userid: user1.id)
+      expect(controller.get_stories(user1, false).length).to eq(1)
     end
 
     it "has both moments and strategies, and does not include allies" do
-      new_moment = create(:moment, userid: new_user1.id)
-      new_strategy = create(:strategy, userid: new_user1.id)
-      expect(controller.get_stories(new_user1, false).length).to eq(2)
+      new_moment = create(:moment, userid: user1.id)
+      new_strategy = create(:strategy, userid: user1.id)
+      expect(controller.get_stories(user1, false).length).to eq(2)
 
     end
 
     it "has no stories and does include allies" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-        expect(controller.get_stories(new_user1, true).length).to eq(0)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+        expect(controller.get_stories(user1, true).length).to eq(0)
     end
 
     it "has only moments and does include allies" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_moment1 = create(:moment, userid: new_user1.id, published_at: Time.zone.now)
-      new_moment2 = create(:moment, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
-      expect(controller.get_stories(new_user1, true).length).to eq(2)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_moment1 = create(:moment, userid: user1.id, published_at: Time.zone.now)
+      new_moment2 = create(:moment, userid: user2.id, viewers: [user1.id], published_at: Time.zone.now)
+      expect(controller.get_stories(user1, true).length).to eq(2)
     end
 
     it "has only other users' draft moments and does include allies" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_moment2 = create(:moment, userid: new_user2.id, viewers: [new_user1.id])
-      expect(controller.get_stories(new_user1, true).length).to eq(0)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_moment2 = create(:moment, userid: user2.id, viewers: [user1.id])
+      expect(controller.get_stories(user1, true).length).to eq(0)
     end
 
     it "has only strategies and does include allies" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_strategy1 = create(:strategy, userid: new_user1.id, published_at: Time.zone.now)
-      new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
-      expect(controller.get_stories(new_user1, true).length).to eq(2)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_strategy1 = create(:strategy, userid: user1.id, published_at: Time.zone.now)
+      new_strategy2 = create(:strategy, userid: user2.id, viewers: [user1.id], published_at: Time.zone.now)
+      expect(controller.get_stories(user1, true).length).to eq(2)
     end
 
     it "has only other users' draft strategies and does include allies" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id])
-      expect(controller.get_stories(new_user1, true).length).to eq(0)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_strategy2 = create(:strategy, userid: user2.id, viewers: [user1.id])
+      expect(controller.get_stories(user1, true).length).to eq(0)
     end
 
     it "has both moments and strategies, and does include allies" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_moment1 = create(:moment, userid: new_user1.id, published_at: Time.zone.now)
-      new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
-      expect(controller.get_stories(new_user1, true).length).to eq(2)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_moment1 = create(:moment, userid: user1.id, published_at: Time.zone.now)
+      new_strategy2 = create(:strategy, userid: user2.id, viewers: [user1.id], published_at: Time.zone.now)
+      expect(controller.get_stories(user1, true).length).to eq(2)
     end
 
     it "has only users' draft moments and strategies, and does include allies" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_moment2 = create(:moment, userid: new_user2.id)
-      new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id])
-      expect(controller.get_stories(new_user1, true).length).to eq(0)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_moment2 = create(:moment, userid: user2.id)
+      new_strategy2 = create(:strategy, userid: user2.id, viewers: [user1.id])
+      expect(controller.get_stories(user1, true).length).to eq(0)
     end
 
     it "has no moments and strategies despite being allies with user" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_moment2 = create(:moment, userid: new_user2.id)
-      new_strategy2 = create(:strategy, userid: new_user2.id)
-      expect(controller.get_stories(new_user2, false).length).to eq(0)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_moment2 = create(:moment, userid: user2.id)
+      new_strategy2 = create(:strategy, userid: user2.id)
+      expect(controller.get_stories(user2, false).length).to eq(0)
     end
 
     it "has both moments and strategies and is allies with user" do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_moment1 = create(:moment, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
-      new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id], published_at: Time.zone.now)
-      expect(controller.get_stories(new_user2, false).length).to eq(2)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_moment1 = create(:moment, userid: user2.id, viewers: [user1.id], published_at: Time.zone.now)
+      new_strategy2 = create(:strategy, userid: user2.id, viewers: [user1.id], published_at: Time.zone.now)
+      expect(controller.get_stories(user2, false).length).to eq(2)
     end
 
     it "has both moments and strategies and is allies with user, but her/his posts are all drafts"  do
-      new_allies = create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      new_moment1 = create(:moment, userid: new_user2.id, viewers: [new_user1.id])
-      new_strategy2 = create(:strategy, userid: new_user2.id, viewers: [new_user1.id])
-      expect(controller.get_stories(new_user2, false).length).to eq(0)
+      new_allies = create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      new_moment1 = create(:moment, userid: user2.id, viewers: [user1.id])
+      new_strategy2 = create(:strategy, userid: user2.id, viewers: [user1.id])
+      expect(controller.get_stories(user2, false).length).to eq(0)
     end
   end
 
   describe "moments_stats" do
     before(:example) do 
-      sign_in new_user1
+      sign_in user1
     end 
     it "has no moments" do
         expect(controller.moments_stats).to eq('')
     end
 
     it "has one moment" do
-      new_moment = create(:moment, userid: new_user1.id)
+      new_moment = create(:moment, userid: user1.id)
       expect(controller.moments_stats).to eq('')
     end
 
     it "has more than one moment created this month" do
-      new_moment1 = create(:moment, userid: new_user1.id)
-      new_moment2 = create(:moment, userid: new_user1.id)
+      new_moment1 = create(:moment, userid: user1.id)
+      new_moment2 = create(:moment, userid: user1.id)
       expect(controller.moments_stats).to eq('<div class="center" id="stats">You have written a <strong>total</strong> of <strong>2</strong> moments.</div>')
     end
 
     it "has more than one moment created on different months" do
-      new_moment1 = create(:moment, userid: new_user1.id, created_at: '2014-01-01 00:00:00')
-      new_moment2 = create(:moment, userid: new_user1.id)
+      new_moment1 = create(:moment, userid: user1.id, created_at: '2014-01-01 00:00:00')
+      new_moment2 = create(:moment, userid: user1.id)
 
       expect(controller.moments_stats).to eq('<div class="center" id="stats">You have written a <strong>total</strong> of <strong>2</strong> moments. This <strong>month</strong> you wrote <strong>1</strong> moment.</div>')
 
-      new_moment3 = create(:moment, userid: new_user1.id)
+      new_moment3 = create(:moment, userid: user1.id)
 
       expect(controller.moments_stats).to eq('<div class="center" id="stats">You have written a <strong>total</strong> of <strong>3</strong> moments. This <strong>month</strong> you wrote <strong>2</strong> moments.</div>')
     end
@@ -420,24 +420,24 @@ describe ApplicationController do
     end
 
     before do
-      create(:allyships_accepted, user_id: new_user1.id, ally_id: new_user2.id)
-      create(:allyships_accepted, user_id: new_user1.id, ally_id: user3.id)
+      create(:allyships_accepted, user_id: user1.id, ally_id: user2.id)
+      create(:allyships_accepted, user_id: user1.id, ally_id: user3.id)
     end
 
     context 'Moments' do
-      let(:new_moment) { create(:moment, userid: new_user1.id, viewers: [new_user2.id, user3.id]) }
+      let(:new_moment) { create(:moment, userid: user1.id, viewers: [user2.id, user3.id]) }
 
       context 'Comment posted by Moment creator who is logged in' do
         before(:each) do
-          sign_in new_user1
+          sign_in user1
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user1.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user1.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user1),
+            comment_info: comment_info(user1),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -446,13 +446,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user1.id, visibility: 'private', viewers: [new_user2.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user1.id, visibility: 'private', viewers: [user2.id])
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user1),
+            comment_info: comment_info(user1),
             comment_text: comment,
-            visibility: "Visible only between you and #{new_user2.name}",
+            visibility: "Visible only between you and #{user2.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -461,15 +461,15 @@ describe ApplicationController do
 
       context 'Comment posted by Moment viewer who is logged in' do
         before(:each) do
-          sign_in new_user2
+          sign_in user2
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user2.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user2.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user2),
+            comment_info: comment_info(user2),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -478,13 +478,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: new_user2.id, visibility: 'private', viewers: [new_user1.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user2.id, visibility: 'private', viewers: [user1.id])
           expect(controller.generate_comment(new_comment, 'moment')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user2),
+            comment_info: comment_info(user2),
             comment_text: comment,
-            visibility: "Visible only between you and #{new_user1.name}",
+            visibility: "Visible only between you and #{user1.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -493,19 +493,19 @@ describe ApplicationController do
     end
 
     context 'Strategies' do
-      let(:new_strategy) { create(:strategy, userid: new_user1.id, viewers: [new_user2.id, user3.id]) }
+      let(:new_strategy) { create(:strategy, userid: user1.id, viewers: [user2.id, user3.id]) }
 
       context 'Comment posted by Strategy creator who is logged in' do
         before(:each) do
-          sign_in new_user1
+          sign_in user1
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user1.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user1.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user1),
+            comment_info: comment_info(user1),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -514,13 +514,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user1.id, visibility: 'private', viewers: [new_user2.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user1.id, visibility: 'private', viewers: [user2.id])
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user1),
+            comment_info: comment_info(user1),
             comment_text: comment,
-            visibility: "Visible only between you and #{new_user2.name}",
+            visibility: "Visible only between you and #{user2.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -529,15 +529,15 @@ describe ApplicationController do
 
       context 'Comment posted by Strategy viewer who is logged in' do
         before(:each) do
-          sign_in new_user2
+          sign_in user2
         end
 
         it 'generates a valid comment object when visbility is all' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user2.id, visibility: 'all')
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user2.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user2),
+            comment_info: comment_info(user2),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -546,13 +546,13 @@ describe ApplicationController do
         end
 
         it 'generates a valid comment object when visbility is private' do
-          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: new_user2.id, visibility: 'private', viewers: [new_user1.id])
+          new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user2.id, visibility: 'private', viewers: [user1.id])
           expect(controller.generate_comment(new_comment, 'strategy')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user2),
+            comment_info: comment_info(user2),
             comment_text: comment,
-            visibility: "Visible only between you and #{new_user1.name}",
+            visibility: "Visible only between you and #{user1.name}",
             delete_comment: delete_comment(new_comment.id),
             no_save: false
           )
@@ -564,18 +564,18 @@ describe ApplicationController do
       let(:new_meeting) { create :meeting }
 
       before do
-        create :meeting_member, userid: new_user1.id, leader: true, meetingid: new_meeting.id
-        create :meeting_member, userid: new_user2.id, leader: false, meetingid: new_meeting.id
+        create :meeting_member, userid: user1.id, leader: true, meetingid: new_meeting.id
+        create :meeting_member, userid: user2.id, leader: false, meetingid: new_meeting.id
       end
 
       context 'Comment posted by Meeting creator who is logged in' do
         it 'generates a valid comment object' do
-          sign_in new_user1
-          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: new_user1.id, visibility: 'all')
+          sign_in user1
+          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: user1.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'meeting')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user1),
+            comment_info: comment_info(user1),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),
@@ -586,12 +586,12 @@ describe ApplicationController do
 
       context 'Comment posted by Meeting member who is logged in' do
         it 'generates a valid comment object' do
-          sign_in new_user2
-          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: new_user2.id, visibility: 'all')
+          sign_in user2
+          new_comment = create(:comment, comment: comment, commentable_type: 'meeting', commentable_id: new_meeting.id, comment_by: user2.id, visibility: 'all')
           expect(controller.generate_comment(new_comment, 'meeting')).to include(
             commentid: new_comment.id,
             :profile_picture => be_avatar_component,
-            comment_info: comment_info(new_user2),
+            comment_info: comment_info(user2),
             comment_text: comment,
             visibility: nil,
             delete_comment: delete_comment(new_comment.id),


### PR DESCRIPTION
#811 This PR:
- Creates shared examples for the users
- Makes variable naming more consistent 
- Sign in user in a before block 

This dries up the code since the user was originally defined and signed in several times. There is still more work to do in the file, but hopefully, this is a good start.