### PR TITLE
Update bad link for PostgreSQL instructions

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -15,7 +15,7 @@ Commons errors faced during installation are documented in this
 ## Postgres
 
 After installing Postgres, if you are asked to create a new user, please follow
-these [instructions](https://github.com/ifmeorg/ifme/blob/master/documentation/COMMON_ERRORS.md#postgresql-bad-connection).
+these [instructions](https://github.com/ifmeorg/ifme/wiki/Common-Dev-Environment-Errors#postgresql-bad-connection).
 
 ### A. macOS
 


### PR DESCRIPTION
There was a bad link in PostrgreSQL section in INSTALLATION.md. I have changed the link according to instructions from issue #899 