### PR TITLE
Fix vulnerability CVE-2018-3760

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,7 @@ GEM
       tilt (~> 2.0)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.2)


### PR DESCRIPTION
Fix vulnerability by upgrading the gem using `bundle update sprockets`.

Although this project has in `production.rb`
`config.assets.compile = false`
CircleCI was still complaining about the sprockets version.