### PR TITLE
Use `100%` for width over `100vw` to prevent horizontal scrollbar

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,12 +56,12 @@ body, html {
 
   > div:first-of-type {
     margin-bottom: auto;
-    width: 100vw;
+    width: 100%;
   }
 
   > div:last-of-type {
     margin-top: auto;
-    width: 100vw;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
# Description 

Fixes issue where an unwanted horizontal scrollbar is shown if page content is long enough to show a vertical scrollbar by changing `width: 100vw;` to `width: 100%;` on the header/footer elements.

## Corresponding Issue

Resolves  https://github.com/ifmeorg/ifme/issues/967
