### PR TITLE
Fix bug in Moments form for categories/moods/strategies

### DIFF
--- a/app/helpers/moments_helper.rb
+++ b/app/helpers/moments_helper.rb
@@ -134,19 +134,21 @@ module MomentsHelper
         id: item.slug,
         label: item.name,
         value: item.id,
-        checked: data_for_moment(data).include?(item.id)
+        checked: data_for(item)&.include?(item.id)
       )
     end
     checkboxes
   end
 
-  def data_for_moment(data)
-    if data == @categories
+  def data_for(item)
+    case item.class.name
+    when 'Category'
       @moment.category
-    elsif data == @moods
+    when 'Mood'
       @moment.mood
+    when 'Strategy'
+      @moment.strategy
     end
-    @moment.strategy
   end
 end
 # rubocop:enable ModuleLength

--- a/spec/features/user_creates_a_draft_moment_spec.rb
+++ b/spec/features/user_creates_a_draft_moment_spec.rb
@@ -112,6 +112,36 @@ describe 'UserCreatesADraftMoment', js: true do
       # EDITING
       find('.storyActionsEdit').click
       expect(find('.pageTitle')).to have_content 'Edit My New Moment'
+      expect(page).to have_field('moment_comment', checked: true)
+      expect(page).to have_field('moment_publishing', checked: true)
+
+      within('#moment_category_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Category'
+        expect(page).to have_content 'Some New Category'
+        find('.accordion').click
+      end
+
+      within('#moment_mood_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Mood'
+        expect(page).to have_content 'Some New Mood'
+        find('.accordion').click
+      end
+
+      within('#moment_strategy_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Strategy'
+        expect(page).to have_content 'Some New Strategy'
+        find('.accordion').click
+      end
+
+      within('#moment_viewers_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Ally 1'
+        find('.accordion').click
+      end
+
       moment_why_text = 'I am changing my moment why'
       fill_in_textarea(moment_why_text, '#moment_why')
 

--- a/spec/features/user_creates_a_draft_strategy_spec.rb
+++ b/spec/features/user_creates_a_draft_strategy_spec.rb
@@ -79,6 +79,22 @@ describe 'UserCreatesADraftStrategy', js: true do
       visit back
       find('.storyActionsEdit').click
       expect(find('.pageTitle')).to have_content 'Edit My New Strategy'
+      expect(page).to have_field('strategy_comment', checked: true)
+      expect(page).to have_field('strategy_publishing', checked: true)
+
+      within('#strategy_category_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Category'
+        expect(page).to have_content 'Some New Category'
+        find('.accordion').click
+      end
+
+      within('#strategy_viewers_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Ally 1'
+        find('.accordion').click
+      end
+
       strategy_description_text = 'I am changing my strategy description'
       fill_in_textarea(strategy_description_text, '#strategy_description')
 

--- a/spec/features/user_creates_a_published_moment_spec.rb
+++ b/spec/features/user_creates_a_published_moment_spec.rb
@@ -112,6 +112,38 @@ describe 'UserCreatesAPublishedMoment', js: true do
       # EDITING
       find('.storyActionsEdit').click
       expect(find('.pageTitle')).to have_content 'Edit My New Moment'
+      expect(page).to have_field('moment_comment', checked: true)
+      expect(page).to have_field('moment_publishing', checked: false)
+
+      within('#moment_category_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Category'
+        expect(page).to have_content 'Some New Category'
+        find('.accordion').click
+      end
+
+      within('#moment_mood_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Mood'
+        expect(page).to have_content 'Some New Mood'
+        find('.accordion').click
+      end
+
+      within('#moment_strategy_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Strategy'
+        expect(page).to have_content 'Some New Strategy'
+        find('.accordion').click
+      end
+
+      within('#moment_viewers_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Ally 0'
+        expect(page).to have_content 'Ally 1'
+        expect(page).to have_content 'Ally 2'
+        find('.accordion').click
+      end
+
       moment_why_text = 'I am changing my moment why'
       fill_in_textarea(moment_why_text, '#moment_why')
       find('#submit').click

--- a/spec/features/user_creates_a_published_strategy_spec.rb
+++ b/spec/features/user_creates_a_published_strategy_spec.rb
@@ -76,6 +76,24 @@ describe 'UserCreatesAPublishedStrategy', js: true do
       # EDITING
       find('.storyActionsEdit').click
       expect(find('.pageTitle')).to have_content 'Edit My New Strategy'
+      expect(page).to have_field('strategy_comment', checked: true)
+      expect(page).to have_field('strategy_publishing', checked: false)
+
+      within('#strategy_category_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Test Category'
+        expect(page).to have_content 'Some New Category'
+        find('.accordion').click
+      end
+
+      within('#strategy_viewers_accordion') do
+        find('.accordion').click
+        expect(page).to have_content 'Ally 0'
+        expect(page).to have_content 'Ally 1'
+        expect(page).to have_content 'Ally 2'
+        find('.accordion').click
+      end
+
       strategy_description_text = 'I am changing my strategy description'
       fill_in_textarea(strategy_description_text, '#strategy_description')
       find('#submit').click


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

<!--[A few sentences describing your changes]-->
There was a bug where if you had saved a Moment with categories, moods, and strategies and you went to the edit the form, those options you selected wouldn't appear.

# Test Coverage

✅ <!--[YES, remove line if not applicable]-->

<!--[Must be YES, if NO explain why]-->
