### PR TITLE
#976 Missing HTTP security headers added

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -46,9 +46,9 @@ module Ifme
      'Referrer-Policy' => 'strict-origin-when-cross-origin',
      'Strict-Transport-Security' => 'max-age=31536000'
     }
-    
+
     # gzip the html/json responses
-    config.middleware.use Rack::Deflater, 
+    config.middleware.use Rack::Deflater,
       include: %w[text/html application/json image/svg+xml]
     # export translations for use in javascript
     config.middleware.use I18n::JS::Middleware

--- a/application.rb
+++ b/application.rb
@@ -37,20 +37,19 @@ module Ifme
       end
     }
 
-    
     config.action_dispatch.default_headers = {
-  'X-Frame-Options' => 'SAMEORIGIN',
-  'X-XSS-Protection' => '1; mode=block',
-  'X-Content-Type-Options' => 'nosniff',
-  'X-Download-Options' => 'noopen',
-  'X-Permitted-Cross-Domain-Policies' => 'none',
-  'Referrer-Policy' => 'strict-origin-when-cross-origin',
-  'Strict-Transport-Security' => 'max-age=31536000'
+     'X-Frame-Options' => 'SAMEORIGIN',
+     'X-XSS-Protection' => '1; mode=block',
+     'X-Content-Type-Options' => 'nosniff',
+     'X-Download-Options' => 'noopen',
+     'X-Permitted-Cross-Domain-Policies' => 'none',
+     'Referrer-Policy' => 'strict-origin-when-cross-origin',
+     'Strict-Transport-Security' => 'max-age=31536000'
     }
     
-
     # gzip the html/json responses
-    config.middleware.use Rack::Deflater, include: %w[text/html application/json image/svg+xml]
+    config.middleware.use Rack::Deflater, 
+      include: %w[text/html application/json image/svg+xml]
     # export translations for use in javascript
     config.middleware.use I18n::JS::Middleware
 

--- a/application.rb
+++ b/application.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative 'boot'
+require 'rails/all'
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module Ifme
+  class Application < Rails::Application
+    # Settings in config/environments/* take precedence over those here.
+    # Application configuration should go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded.
+
+    # Set Time.zone default to the specified zone and make Active Record
+    # auto-convert to this zone.
+    # Run "rake -D time" for a list of tasks for finding time zone names.
+    # Default is UTC.
+    # config.time_zone = 'Central Time (US & Canada)'
+
+    # The default locale is :en and all translations from
+    # config/locales/*.rb,yml are auto loaded.
+    # config.i18n.load_path += Dir[
+    #   Rails.root.join('my', 'locales', '*.{rb,yml}').to_s
+    # ]
+
+    config.exceptions_app = routes
+
+    config.autoload_paths << Rails.root.join('lib')
+
+    config.action_view.field_error_proc = proc { |html_tag|
+      if html_tag.to_s.include?('label')
+        %(<div class="errorField">#{html_tag}</div>).html_safe
+      else
+        html_tag.to_s.html_safe
+      end
+    }
+
+    
+    config.action_dispatch.default_headers = {
+  'X-Frame-Options' => 'SAMEORIGIN',
+  'X-XSS-Protection' => '1; mode=block',
+  'X-Content-Type-Options' => 'nosniff',
+  'X-Download-Options' => 'noopen',
+  'X-Permitted-Cross-Domain-Policies' => 'none',
+  'Referrer-Policy' => 'strict-origin-when-cross-origin',
+  'Strict-Transport-Security' => 'max-age=31536000'
+    }
+    
+
+    # gzip the html/json responses
+    config.middleware.use Rack::Deflater, include: %w[text/html application/json image/svg+xml]
+    # export translations for use in javascript
+    config.middleware.use I18n::JS::Middleware
+
+    config.i18n.available_locales = ['pt-BR'].concat %i[en es sv nl it nb vi]
+
+    config.i18n.default_locale = :en
+  end
+end


### PR DESCRIPTION
Added HTTP security headers to application.rb

<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 
Added the following headers to application.rb:
  'X-Frame-Options' => 'SAMEORIGIN',
  'X-XSS-Protection' => '1; mode=block',
  'X-Content-Type-Options' => 'nosniff',
  'X-Download-Options' => 'noopen',
  'X-Permitted-Cross-Domain-Policies' => 'none',
  'Referrer-Policy' => 'strict-origin-when-cross-origin',
  'Strict-Transport-Security' => 'max-age=31536000'
All of these headers are necessary to prevent cross site scripting, clickjacking, and a non default option (STS) that prevents man-in-the-middle attacks by stripping TLS. 
## More Details
While security headers are necessary, it does not make the website invulnerable. It's always a good idea to test for cross site scripting throughout the entire domain and patch it as soon as possible.
<!--[More details on your changes, remove if not applicable]-->
In addition, the missing Content-Security-Policy header requires the additional file content_security_policy.rb which is missing from config/initializers/.

## Corresponding Issue
https://github.com/ifmeorg/ifme/issues/976

# Screenshots


![image](https://user-images.githubusercontent.com/43491270/45923618-dfe1e100-be9f-11e8-8e4d-20855c87ffba.png)


# Test Coverage
In progress
<!--[✅ YES, remove line if not applicable]-->
<!--🚫 [NO, remove line if not applicable]-->

<!--[Must be YES, if NO explain why]-->
