### PR TITLE
Fix coverage report prefix bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: Run React Jest Tests
           command: |
             cd client && RAILS_ENV=test bundle exec rake react_on_rails:locale && yarn lint:setup && yarn lint:build && yarn build:test && yarn test --coverage
-            cd ~/ifmeorg/ifme/tmp && ./cc-test-reporter format-coverage -t lcov -o codeclimate.frontend.json ../client/coverage/lcov.info
+            cd ~/ifmeorg/ifme/tmp && ./cc-test-reporter format-coverage --prefix /ifmeorg/ifme -t lcov -o codeclimate.frontend.json ../client/coverage/lcov.info
       - persist_to_workspace:
           root: tmp
           paths:
@@ -88,7 +88,7 @@ jobs:
           name: Run Rails Rspec Tests
           command: |
             bundle exec rspec --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec.xml
-            cd ~/ifmeorg/ifme/tmp && ./cc-test-reporter format-coverage -t simplecov -o codeclimate.backend.json ../coverage/.resultset.json
+            cd ~/ifmeorg/ifme/tmp && ./cc-test-reporter format-coverage --prefix /ifmeorg/ifme -t simplecov -o codeclimate.backend.json ../coverage/.resultset.json
       - persist_to_workspace:
           root: tmp
           paths:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

<!--[A few sentences describing your changes]-->
Fix coverage report prefix bug

Set prefix because test report points to ubuntu VM from Circle build:
```
{
  "message": "Invalid path part \"\"",
  "file_document": "{\"_id\"=>BSON::ObjectId('5ba75b0edc9acf46e00004dc'), \"type\"=>\"test_file_reports\", \"blob_id\"=>\"890a1e2809821d222ee36683f3a3c91d461be4b3\", \"coverage\"=>\"[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,1,1,1,1,null,1,1,15,null,8,null,1,null]\", \"covered_percent\"=>100, \"covered_strength\"=>3.3333333333333335, \"line_counts\"=>{\"missed\"=>0, \"covered\"=>9, \"total\"=>9}, \"path\"=>\"/home/ubuntu/ifmeorg/ifme/app/models/meeting.rb\", \"test_report_id\"=>BSON::ObjectId('5ba75b0e77d1bd3ae7000232')}"
}
```

# Test Coverage

🚫 <!--[NO, remove line if not applicable]--> N/A

<!--[Must be YES, if NO explain why]-->
