### PR TITLE
Fix broken webpack bundle test

### DIFF
--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -20,12 +20,16 @@ module AssetsHelper
 
   def inline_file(path, css = false)
     if css && path == 'webpack_bundle.css'
-      File.read(Rails.root.join('public', 'webpack', path))
+      File.read(Rails.root.join('public', webpack_folder, path))
     elsif Rails.application.assets
       get_application_asset(path)
     else
       File.read(Rails.root.join('public', asset_path(path)))
     end
+  end
+
+  def webpack_folder
+    Rails.env.test? ? 'webpack-test' : 'webpack'
   end
 
   def get_application_asset(path)

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -18,7 +18,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const baseConfig = require('./webpack.config.base');
 
 const configPath = resolve('..', 'config');
-const devMode = process.env.NODE_ENV !== 'production';
+const devMode = process.env.NODE_ENV === 'development';
 const { output } = webpackConfigLoader(configPath);
 const outputFilename = `[name]${devMode ? '-[hash]' : ''}`;
 


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

<!--[A few sentences describing your changes]-->
Address 
```
Failure/Error: File.read(Rails.root.join('public', 'webpack', path))

Errno::ENOENT:
  No such file or directory @ rb_sysopen - /home/ubuntu/ifmeorg/ifme/public/webpack/webpack_bundle.css
./app/helpers/assets_helper.rb:23:in `read'
./app/helpers/assets_helper.rb:23:in `inline_file'
./app/helpers/assets_helper.rb:13:in `inline_css'
./spec/helpers/assets_helper_spec.rb:33:in `block (4 levels) in <top (required)>'
```

This is happening because `yarn build:test` generates `webpack-bundle-[hash].css` instead of `webpack-bundle.css` in the folder `webpack-test` instead of `webpack`

# Test Coverage

✅ <!--[YES, remove line if not applicable]-->

<!--[Must be YES, if NO explain why]-->
