### PR TITLE
Add set -e to Circle config to fail build on failing tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
       - run:
           name: Run React Jest Tests
           command: |
+            set -e
             cd client && RAILS_ENV=test bundle exec rake react_on_rails:locale && yarn lint:setup && yarn lint:build && yarn build:test && yarn test --coverage
             cd ~/ifmeorg/ifme/tmp && ./cc-test-reporter format-coverage -t lcov -o codeclimate.frontend.json ../client/coverage/lcov.info
       - persist_to_workspace:
@@ -87,6 +88,7 @@ jobs:
       - run:
           name: Run Rails Rspec Tests
           command: |
+            set -e
             bundle exec rspec --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec.xml
             cd ~/ifmeorg/ifme/tmp && ./cc-test-reporter format-coverage -t simplecov -o codeclimate.backend.json ../coverage/.resultset.json
       - persist_to_workspace:
@@ -96,6 +98,7 @@ jobs:
       - run:
           name: Run Rails Jasmine Tests
           command: |
+            set -e
             RAILS_ENV=test bundle exec rake jasmine:ci
       - run: bundle exec bundle-audit check --update
       - store_test_results:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

<!--[A few sentences describing your changes]-->
Failing test suites do not fail the CircleCI build, this started happening after I re-wrote the config to support sending code coverage to Code Climate. 

The cause of the issue is because I'm using multi-line commands to execute tests now. To fix this issue I just include `set -e` before the commands (see: https://support.circleci.com/hc/en-us/articles/115015733328-Tests-fail-but-job-finishes-successfully)

# Test Coverage

🚫 <!--[NO, remove line if not applicable]--> N/A

<!--[Must be YES, if NO explain why]-->

I realized I never added you @greysteil as a member of the Github org so I can't add you as a reviewer. Just sent you an invite! Could you review this?
