### PR TITLE
Cache bundle install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
           paths:
           - ~/.cache/yarn
           - ./node_modules
+          - ./vendor/bundle
       - run: |-
           mkdir -p config && echo 'test:
             min_messages: error


### PR DESCRIPTION
Should shave ~4 minutes off of CI run time.