### PR TITLE
Secure Notifications Controller

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -62,6 +62,9 @@ class NotificationsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_notification
-    @notification = Notification.find_by(id: params[:id], user_id: current_user.id)
+    @notification = Notification.find_by(
+      id: params[:id],
+      user_id: current_user.id
+    )
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -7,12 +7,7 @@ class NotificationsController < ApplicationController
   # DELETE /notifications/1
   # DELETE /notifications/1.json
   def destroy
-    notification = Notification.find_by(
-      id: params[:id],
-      user_id: current_user.id
-    )
-
-    notification.destroy if notification.present?
+    @notification.destroy if @notification.present?
 
     respond_to do |format|
       format.html { redirect_back(fallback_location: notifications_path) }
@@ -66,14 +61,7 @@ class NotificationsController < ApplicationController
   # rubocop:enable MethodLength
 
   # Use callbacks to share common setup or constraints between actions.
-  # rubocop:disable RescueStandardError
   def set_notification
-    @notification = Notification.find(params[:id])
-  rescue
-    respond_to do |format|
-      format.html { redirect_back(fallback_location: notifications_path) }
-      format.json { head :no_content }
-    end
+    @notification = Notification.find_by(id: params[:id], user_id: current_user.id)
   end
-  # rubocop:enable RescueStandardError
 end


### PR DESCRIPTION
Additionally find_by will either return an ActiveRecord instance or
return nil so we can do away with the rescue and rubocop disable.

<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

Supercedes old pull request of #316 to secure notifications controller. Added additional Notification filter param of user_id in the before_action method `set_notification`. Using `Notification.find_by` returns nil if nothing is found so additionally allowed removal of the rescue in `set_notification` since it was doing the same return as in the `destroy` method anyway.
<!--[A few sentences describing your changes]-->


## Corresponding Issue
Fixes #1025.
<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

# Test Coverage

🚫 <!--[NO, remove line if not applicable]-->
Did not expand on test coverage with this commit, only ensured that current test suite still runs and passes
<!--[Must be YES, if NO explain why]-->
