### PR TITLE
Create two separate workflows for circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
             git push https://heroku:$HEROKU_API_KEY@git.heroku.com/ifme.git master
 workflows:
   version: 2
-  build-deploy:
+  build-test:
     jobs:
       - setup-coverage
       - build:
@@ -139,9 +139,30 @@ workflows:
       - upload-coverage:
           requires:
             - build
+  build-test-deploy:
+    jobs:
+      - setup-coverage
+      - build:
+          requires:
+            - setup-coverage
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+      - upload-coverage:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
       - deploy:
           requires:
             - upload-coverage
           filters:
             branches:
-              only: master
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+/


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description

Workflow that deploys requires a git tag to run. Adding a tag filter
would require all other tasks to have a tag as well. Splitting into two
workflows, the build-test flow can work on all branches/commits
while build-test-deploy only works when a git tag matching vX.X.X is pushed.

<!--[A few sentences describing your changes]-->

## More Details
[Git Tag Documentation](https://circleci.com/docs/2.0/workflows/#git-tag-job-execution)

According to the documentation if using tag filters and a job requires any other job directly or indirectly, those jobs must also require regular expression filters for tags.

<!--[More details on your changes, remove if not applicable]-->

## Corresponding Issue

#1075 
<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

# Screenshots

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

# Test Coverage

🚫 <!--[NO, remove line if not applicable]-->

<!--[Must be YES, if NO explain why]-->
