### PR TITLE
Changed word without much sense in Spanish

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -36,8 +36,8 @@ es:
    rss: 'RSS'
    twitter: "Twitter"
    facebook: "Facebook"
-   feedback: "retroalimentación"
-   give_feedback: 'Retroalimentar'
+   feedback: "comentarios"
+   give_feedback: 'Enviar comentarios'
    press: 'Prensa'
    faq: 'Preguntas Frecuentes'
    resources: "Recursos"
@@ -174,7 +174,7 @@ es:
   mailer:
    html:
     app_description: "%{app_name} es una comunidad que anima a las personas a compartir sus experiencias de salud mental con sus seres queridos."
-    no_reply: "No puedes responder a este correo electrónico. Si tienes preguntas, dudas, o retroalimentación, por favor envía un mensaje a %{email}!"
+    no_reply: "No puedes responder a este correo electrónico. Si tienes preguntas, dudas, o comentarios, por favor envía un mensaje a %{email}!"
   title:
    reset_password: "Reestablece tu contraseña"
 


### PR DESCRIPTION
Retroalimentar/ción : didn't fit in this context

<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
## Description 

Previous ''Feedback' translation had not much sense. 'Retroalimentar' didn't fit in this context.  
It was literal translated.


## Test Coverage

🚫 <!--[NO, remove line if not applicable]-->

Just few words
