### PR TITLE
1066-add-membership-bot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -25,3 +25,7 @@ newPRWelcomeComment: >
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
   Thank you for merging this pull request with us! If you haven't already, in another pull request, please [add yourself](https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb) to our [Contribute](https://www.if-me.org/contribute) page.
+
+# Link for member-bot to use for joining us
+howToJoinLink: >
+  https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack


### PR DESCRIPTION

# Description 

Adds a config var so member-bot can use a custom link to a join us page

## Corresponding Issue

#1066 

# Screenshots
this is not of the PR work but of the functionality of the bot
 https://screencast.com/t/qcfy3yPFG


# Test Coverage

🚫 <!--[NO, remove line if not applicable]-->

there is only a config var added. The testing really needs to be added to the member-bot it self. Ill work on that at some point