### PR TITLE
Wrap website description in quotes

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="manifest.json">
-    <meta name="Description" content=<%= t('app_description') %>>
+    <meta name="description" content="<%= t('app_description') %>">
     <meta name="theme-color" content="#6d0839">
     <%= csrf_meta_tags %>
     <% if (user_signed_in? && !static_page?) || secret_share_path? %>


### PR DESCRIPTION
### Description 

The website description is not properly interpolated and hence when sharing the website link, the description is just "A".

![share](https://user-images.githubusercontent.com/7039523/46702809-2f3b4780-cbea-11e8-8dda-d8b29adc6978.png)


This PR fixes the issue by wrapping the interpolated description within quotes.

### Screenshot showing fix

![fix](https://user-images.githubusercontent.com/7039523/46702739-e4213480-cbe9-11e8-9b48-a779e1de3584.png)
