### PR TITLE
Fix flakey group spec

### DIFF
--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe GroupsController, type: :controller do
       put :update, params: { id: group.id, group: { leader: [user.id] } }
 
       non_leader.reload
-      expect(non_leader.leader).to be true
+      expect(non_leader.leader).to be_truthy
     end
   end
 end

--- a/spec/features/user_creates_a_medication_spec.rb
+++ b/spec/features/user_creates_a_medication_spec.rb
@@ -38,8 +38,8 @@ describe 'UserCreatesAMedication', js: true do
       end
 
       expect(medication.name).to eq(name)
-      expect(medication.take_medication_reminder.active?).to be false
-      expect(medication.refill_reminder.active?).to be false
+      expect(medication.take_medication_reminder.active?).to be_falsey
+      expect(medication.refill_reminder.active?).to be_falsey
     end
 
     context 'with reminders checked' do
@@ -49,8 +49,8 @@ describe 'UserCreatesAMedication', js: true do
         expect(CalendarUploader).to_not receive(:new)
         find('#submit').click
         expect(find('.pageTitle')).to have_content(name)
-        expect(medication.take_medication_reminder.active?).to be true
-        expect(medication.refill_reminder.active?).to be true
+        expect(medication.take_medication_reminder.active?).to be_truthy
+        expect(medication.refill_reminder.active?).to be_truthy
       end
     end
 
@@ -62,8 +62,8 @@ describe 'UserCreatesAMedication', js: true do
         expect(CalendarUploader).to receive_message_chain(:new, :upload_event)
         find('#submit').click
         expect(find('.pageTitle')).to have_content(name)
-        expect(medication.take_medication_reminder.active?).to be true
-        expect(medication.refill_reminder.active?).to be true
+        expect(medication.take_medication_reminder.active?).to be_truthy
+        expect(medication.refill_reminder.active?).to be_truthy
       end
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,28 +32,28 @@ describe ApplicationHelper do
 
     context 'current page' do
       let(:is_current_page) { true }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'current controller' do
       let(:current_controller) { 'moments' }
       let(:path)               { new_moment_path }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'current controller and profile' do
       let(:current_controller) { 'profile' }
       let(:path)               { 'profile?user_id=2' }
 
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
 
     context 'current controller and about' do
       let(:current_controller) { 'pages' }
       let(:path)               { 'about' }
 
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
 
     context 'new user session with devise' do
@@ -61,7 +61,7 @@ describe ApplicationHelper do
       let(:action_name)        { 'new' }
       let(:path)               { new_user_session_path }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'new user registration with devise' do
@@ -69,7 +69,7 @@ describe ApplicationHelper do
       let(:action_name)        { 'create' }
       let(:path)               { new_user_registration_path }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'sign out' do
@@ -77,7 +77,7 @@ describe ApplicationHelper do
       let(:path)               { destroy_user_session_path }
       let(:environment)        { { method: :delete } }
 
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -96,18 +96,18 @@ describe ApplicationHelper do
 
     context 'when the path matches' do
       let(:page) { new_user_session_path }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the controller and action match' do
       let(:current_controller) { 'sessions' }
       let(:action_name) { 'new' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -126,18 +126,18 @@ describe ApplicationHelper do
 
     context 'when the path matches' do
       let(:page) { new_user_registration_path }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the controller and action match the path' do
       let(:current_controller) { 'registrations' }
       let(:action_name) { 'create' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -156,18 +156,18 @@ describe ApplicationHelper do
 
     context 'when the path matches' do
       let(:page) { new_user_password_path }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the controller and action match the path' do
       let(:current_controller) { 'devise/passwords' }
       let(:action_name) { 'new' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -186,18 +186,18 @@ describe ApplicationHelper do
 
     context 'when the path matches' do
       let(:page) { edit_user_registration_path }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the controller and action match the path' do
       let(:current_controller) { 'registrations' }
       let(:action_name) { 'update' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -215,17 +215,17 @@ describe ApplicationHelper do
     context 'when the path matches and user is not signed in' do
       let(:page) { root_path }
       let(:user_signed_in) { false }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path matches and user is signed in' do
       let(:page) { root_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -244,24 +244,24 @@ describe ApplicationHelper do
 
     context 'when the path matches' do
       let(:page) { new_user_invitation_path }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the controller and action match the path' do
       let(:current_controller) { 'devise/invitations' }
       let(:action_name) { 'new' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when another controller and action match the path' do
       let(:current_controller) { 'users/invitations' }
       let(:action_name) { 'create' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -280,18 +280,18 @@ describe ApplicationHelper do
 
     context 'when the path matches' do
       let(:page) { accept_user_invitation_path }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the controller and action match the path' do
       let(:current_controller) { 'users/invitations' }
       let(:action_name) { 'update' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -310,18 +310,18 @@ describe ApplicationHelper do
 
     context 'when the path matches' do
       let(:page) { edit_user_password_path }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the controller and action match the path' do
       let(:current_controller) { 'devise/passwords' }
       let(:action_name) { 'edit' }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -343,12 +343,12 @@ describe ApplicationHelper do
       let(:current_controller) { 'secret_shares' }
       let(:action_name) { 'show' }
       let(:page) { secret_share_path(id: moment.id) }
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the path does not match' do
       let(:page) { about_path }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -363,24 +363,24 @@ describe ApplicationHelper do
     context 'non-devise is the active page' do
       context 'when it is a static page' do
         let(:page) { about_path }
-        it { is_expected.to be true }
+        it { is_expected.to be_truthy }
       end
 
       context 'when it is not a static page' do
         let(:page) { moments_path }
-        it { is_expected.to be false }
+        it { is_expected.to be_falsey }
       end
     end
 
     context 'devise path is the active page' do
       context 'when it is a static page' do
         let(:page) { accept_user_invitation_path }
-        it { is_expected.to be true }
+        it { is_expected.to be_truthy }
       end
 
       context 'when it is not a static page' do
         let(:page) { new_user_password_path }
-        it { is_expected.to be false }
+        it { is_expected.to be_falsey }
       end
     end
   end

--- a/spec/helpers/reminder_helper_spec.rb
+++ b/spec/helpers/reminder_helper_spec.rb
@@ -9,17 +9,17 @@ describe ReminderHelper do
 
   describe '#active_reminders?' do
     it 'returns false when data has no active_reminder method' do
-      expect(active_reminders?({})).to be false
+      expect(active_reminders?({})).to be_falsey
     end
 
-    it 'returns false when data has no active reminder' do      
-      medication = FactoryBot.create(:medication, user_id: user.id)      
-      expect(active_reminders?(medication)).to be false
+    it 'returns false when data has no active reminder' do
+      medication = FactoryBot.create(:medication, user_id: user.id)
+      expect(active_reminders?(medication)).to be_falsey
     end
 
     it 'returns true when data is good' do
-      medication = FactoryBot.create(:medication, :with_daily_reminder, user_id: user.id)      
-      expect(active_reminders?(medication)).to be true
+      medication = FactoryBot.create(:medication, :with_daily_reminder, user_id: user.id)
+      expect(active_reminders?(medication)).to be_truthy
     end
   end
 
@@ -44,7 +44,7 @@ describe ReminderHelper do
       reminders = print_reminders({})
       expect(reminders).to eq('')
     end
-  
+
     it 'returns correct html when data has reminders' do
       medication = FactoryBot.create(:medication, :with_daily_reminder, user_id: user.id)
       reminders = print_reminders(medication)

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -31,7 +31,7 @@ describe Group do
 
         result = group.led_by?(user)
 
-        expect(result).to be false
+        expect(result).to be_falsey
       end
     end
 
@@ -42,7 +42,7 @@ describe Group do
 
         result = group.led_by?(user)
 
-        expect(result).to be true
+        expect(result).to be_truthy
       end
     end
   end
@@ -56,7 +56,7 @@ describe Group do
 
         result = group.member?(non_member_user)
 
-        expect(result).to be false
+        expect(result).to be_falsey
       end
     end
 
@@ -67,7 +67,7 @@ describe Group do
 
         result = group.member?(user)
 
-        expect(result).to be true
+        expect(result).to be_truthy
       end
     end
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -50,10 +50,11 @@ describe Group do
   describe '#member?' do
     context 'when user is not a member of the group' do
       it 'returns false' do
-        user = create :user1
-        group = create :group_with_member
+        member_user = create :user
+        non_member_user = create :user1
+        group = create :group_with_member, user_id: member_user.id
 
-        result = group.member?(user)
+        result = group.member?(non_member_user)
 
         expect(result).to be false
       end

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -79,11 +79,11 @@ describe Medication do
     let(:daily_medication) { FactoryBot.create(:medication, user_id: user.id) }
 
     it 'is weekly medication' do
-      expect(weekly_medication.daily?).to be false
+      expect(weekly_medication.daily?).to be_falsey
     end
 
     it 'is daily medication' do
-      expect(daily_medication.daily?).to be true
+      expect(daily_medication.daily?).to be_truthy
     end
   end
 end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -71,7 +71,7 @@ describe Meeting do
 
         result = meeting.led_by?(user)
 
-        expect(result).to be false
+        expect(result).to be_falsey
       end
     end
 
@@ -84,7 +84,7 @@ describe Meeting do
 
         result = meeting.led_by?(user)
 
-        expect(result).to be true
+        expect(result).to be_truthy
       end
     end
   end
@@ -100,7 +100,7 @@ describe Meeting do
 
         result = meeting.member?(user)
 
-        expect(result).to be false
+        expect(result).to be_falsey
       end
     end
 
@@ -113,7 +113,7 @@ describe Meeting do
 
         result = meeting.member?(user)
 
-        expect(result).to be true
+        expect(result).to be_truthy
       end
     end
   end

--- a/spec/models/moment_spec.rb
+++ b/spec/models/moment_spec.rb
@@ -54,11 +54,11 @@ describe Moment do
     let(:user) { moment.user }
     let(:subject) { moment.owned_by?(user) }
 
-    it { is_expected.to be true }
+    it { is_expected.to be_truthy }
 
     context 'when the user does not own the moment' do
       let(:user) { create(:user) }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -67,12 +67,12 @@ describe Moment do
       let(:moment) { build(:moment, :with_user, :with_published_at) }
       let(:subject) { moment.published? }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
     context 'when it does not have a publication date' do
       let(:moment) { create(:moment, :with_user) }
       let(:subject) { moment.published? }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/models/strategy_spec.rb
+++ b/spec/models/strategy_spec.rb
@@ -64,12 +64,12 @@ describe Strategy do
       let(:strategy) { build(:strategy, :with_published_at) }
       let(:subject) { strategy.published? }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
     context 'when it does not have a publication date' do
       let(:strategy) { create(:strategy) }
       let(:subject) { strategy.published? }
-      it { is_expected.to be false }
+      it { is_expected.to be_falsey }
     end
   end
 end


### PR DESCRIPTION
# Description 

After looking `CircleCi` build to gather information to fix https://github.com/ifmeorg/ifme/pull/1145 I found that `spec/models/group_spec.rb` also had a flakey spec that failed due the same reason (hardcoded IDs and specs order). 

I think we should create an issue to review hardcoded IDs in fixtures to avoid flakey specs in the future.

## More Details

I took the opportunity to normalize the boolean assertions rspec format, I went for `be_truthy` and `be_falsey` but I can change it back if we think `be false` and `be true` is more expressive.

## Corresponding Issue

No issue but related to https://github.com/ifmeorg/ifme/issues/1144

# Test Coverage

Same
