### PR TITLE
Fix production issue with build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,12 @@ jobs:
             RAILS_ENV: test
             RACK_ENV: test
       - run: RAILS_ENV=test bundle exec rake db:create db:schema:load
+      - run: RAILS_ENV=test bundle exec rake react_on_rails:locale
       - run:
           name: Run React Jest Tests
           command: |
             set -e
-            cd client && yarn lint:flow && yarn lint:eslint && yarn test --coverage
+            cd client && yarn lint:flow && yarn lint:eslint && yarn test:circleci
             cd ~/ifmeorg/ifme/tmp && ./cc-test-reporter format-coverage -t lcov -o codeclimate.frontend.json ../client/coverage/lcov.info
       - persist_to_workspace:
           root: tmp

--- a/client/package.json
+++ b/client/package.json
@@ -2,18 +2,19 @@
   "name": "ifme",
   "private": true,
   "scripts": {
-    "build:i18n": "cd .. && RAILS_ENV=test bundle exec rake react_on_rails:locale",
-    "build:test": "yarn build:i18n && NODE_ENV=test webpack --config webpack.config.js --display-error-details",
+    "build:i18n": "rake react_on_rails:locale",
+    "build:test": "NODE_ENV=test webpack --config webpack.config.js --display-error-details",
     "build:production": "yarn build:i18n && NODE_ENV=production webpack --config webpack.config.js",
     "build:development": "yarn build:i18n && NODE_ENV=development webpack -w --config webpack.config.js",
     "build:production:debug": "yarn build:production --display-modules --sort-modules-by size",
-    "lint:flow": "yarn build:i18n && flow",
+    "lint:flow": "flow",
     "lint:eslint": "eslint 'app/**/*.js' 'app/**/*.jsx'",
     "lint:prettier": "./node_modules/.bin/prettier \"app/**/*.{js,jsx}\" --write --single-quote  --trailing-comma all",
     "lint": "yarn lint:flow && yarn lint:prettier && yarn lint:eslint --fix",
     "storybook": "yarn build:i18n && start-storybook -p 6006",
-    "test": "yarn build:test && NODE_PATH=./app jest",
-    "test:debug": "yarn build:test && NODE_PATH=./app node --inspect-brk jest --runInBand"
+    "test": "yarn build:i18n && yarn build:test && NODE_PATH=./app jest",
+    "test:debug": "yarn build:i18n && yarn build:test && NODE_PATH=./app node --inspect-brk jest --runInBand",
+    "test:circleci": "yarn build:test && NODE_PATH=./app jest --coverage"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

<!--[A few sentences describing your changes]-->

Fix production issue with build, remove bundle exec

```
remote:        Testing binary        
remote:        Binary is fine        
remote:        node-sass@4.9.2 /tmp/build_229f71b6e06f6ace810cf137a07d3eed/client/node_modules/node-sass        
remote:        yarn run v1.12.0        
remote:        $ yarn build:i18n && NODE_ENV=production webpack --config webpack.config.js        
remote:        $ cd .. && RAILS_ENV=test bundle exec rake react_on_rails:locale        
remote:        rake aborted!        
remote:        Unable to find a spec satisfying bundler-audit in the set. Perhaps the lockfile is corrupted?  
```

# Test Coverage

🚫 <!--[NO, remove line if not applicable]-->N/A

<!--[Must be YES, if NO explain why]-->
