### PR TITLE
Changed the wrapper divs to Fragments

### DIFF
--- a/client/app/components/Chart/ChartControl.jsx
+++ b/client/app/components/Chart/ChartControl.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Chart } from './index';
 
 type chartControlState = {
@@ -57,7 +57,7 @@ export class ChartControl extends React.Component<
     const { types } = this.props;
     const { data, type } = this.state;
     return (
-      <div>
+      <Fragment>
         {types.map((value: string) => (
           <ChartControlButton
             key={value}
@@ -71,7 +71,7 @@ export class ChartControl extends React.Component<
           data={data[type]}
           chartType="Area"
         />
-      </div>
+      </Fragment>
     );
   }
 }

--- a/client/app/components/Input/index.jsx
+++ b/client/app/components/Input/index.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Fragment } from 'react';
 import css from './Input.scss';
 
 type Props = {
@@ -56,7 +56,7 @@ export class Input extends React.Component<Props, State> {
 
   render() {
     return (
-      <div>
+      <Fragment>
         <div className={this.labelClassNames()}>{this.props.label}</div>
         <input
           className={this.inputClassNames()}
@@ -74,7 +74,7 @@ export class Input extends React.Component<Props, State> {
           onFocus={this.onFocus}
           onBlur={this.onBlur}
         />
-      </div>
+      </Fragment>
     );
   }
 }

--- a/client/app/components/Textarea/index.jsx
+++ b/client/app/components/Textarea/index.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Fragment } from 'react';
 import css from './Textarea.scss';
 
 type Props = {
@@ -48,7 +48,7 @@ export class Textarea extends React.Component<Props, State> {
 
   render() {
     return (
-      <div>
+      <Fragment>
         <div className={this.labelClassNames()}>{this.props.label}</div>
         <textarea
           className={css.textarea}
@@ -68,7 +68,7 @@ export class Textarea extends React.Component<Props, State> {
           onFocus={this.onFocus}
           onBlur={this.onBlur}
         />
-      </div>
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
# Description 

In the React components, changed the wrapper divs to Fragments instead.

## More Details

In the future it will be easier to debug without a bunch of empty divs to dig through, so I thought this would be nice.
