### PR TITLE
fix: mock right Time accessor in MedicationRemindersSpec

### DIFF
--- a/spec/services/medication_reminders_spec.rb
+++ b/spec/services/medication_reminders_spec.rb
@@ -69,7 +69,7 @@ describe MedicationReminders do
       let!(:reminder) { medication.refill_reminder }
 
       before 'pretend its a week before the refill is happening' do
-        allow(Time).to receive(:now).and_return(Time.strptime(refill_date, '%m/%d/%Y') - 1.week)
+        allow(Time).to receive(:current).and_return(Time.strptime(refill_date, '%m/%d/%Y') - 1.week)
       end
 
       context 'refill reminder is active ' do


### PR DESCRIPTION
# Description 

In commit 17c50631 the Service MedicationReminders was changed in a way that it uses `Time.current` instead of `Time.now`. The MedicationRemindersSpec still mocked `Time.now`, which resulted in an empty ActiveRecord Relation, and as such in no send message. 

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

# Screenshots

before
```
$ bundle exec rspec spec/services/medication_reminders_spec.rb 

Randomized with seed 37193
.F......

Failures:

  1) MedicationReminders#send_refill_reminder_emails reminders exist and it is one week before the refill refill reminder is active  sends an email
     Failure/Error: expect(deliveries.count).to eq(1)
     
       expected: 1
            got: 0
     
       (compared using ==)
     # ./spec/services/medication_reminders_spec.rb:78:in `block (5 levels) in <top (required)>'

Finished in 1.24 seconds (files took 6.9 seconds to load)
8 examples, 1 failure

Failed examples:

rspec ./spec/services/medication_reminders_spec.rb:76 # MedicationReminders#send_refill_reminder_emails reminders exist and it is one week before the refill refill reminder is active  sends an email

Randomized with seed 37193
```

after
```
$ bundle exec rspec spec/services/medication_reminders_spec.rb 

Randomized with seed 25510
........

Finished in 1.31 seconds (files took 10.21 seconds to load)
8 examples, 0 failures

Randomized with seed 25510
```
# Test Coverage
✅

