### PR TITLE
Add about label to devise.registrations.edit.labels

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -41,7 +41,7 @@
     <% end %>
   <% end %>
 
-  <div class="label smallMarginTop"><%= t('navigation.about') %></div>
+  <div class="label smallMarginTop"><%= t('devise.registrations.edit.labels.about') %></div>
   <%= f.text_area :about, placeholder: t('devise.registrations.edit.placeholders.about'), 'aria-label': t('devise.registrations.edit.placeholders.about') %>
 
   <div class="label smallMarginTop">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -664,6 +664,7 @@ de:
         labels:
           profile_picture: Profilbild
           remove_picture: 'Bild entfernen'
+          about: 'Über uns'
           password_for: 'Passwort für dein <strong>if me</strong> Konto'
           update: Aktualisieren
         placeholders:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -655,6 +655,7 @@ en:
         labels:
           profile_picture: 'Profile picture'
           remove_picture: 'Remove picture'
+          about: About
           password_for: 'Password for <strong>if me</strong> account'
           update: Update
         placeholders:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -655,6 +655,7 @@ es:
         labels:
           profile_picture: 'Imagen de perfil'
           remove_picture: 'Remover imagen'
+          about: 'Acerca de '
           password_for: 'Contraseña para cuenta de <strong>if me</strong>'
           update: Actualizar
         placeholders:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -655,6 +655,7 @@ fr:
         labels:
           profile_picture: 'Photo de profile'
           remove_picture: 'Effacer la photo'
+          about: 'À notre propos'
           password_for: 'Mot de passe pour votre compte <strong>if me</strong>'
           update: 'Mise à jour'
         placeholders:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -655,6 +655,7 @@ it:
         labels:
           profile_picture: 'Immagine del profilo'
           remove_picture: 'Rimuovi immagine'
+          about: Cos’è
           password_for: 'Password del tuo account <strong>if me</strong>'
           update: Modifica
         placeholders:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -655,6 +655,7 @@ nb:
         labels:
           profile_picture: Profilbilde
           remove_picture: 'Fjern bilde'
+          about: Om
           password_for: 'Passord for <strong>if me</strong> konto'
           update: Oppdater
         placeholders:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -655,6 +655,7 @@ nl:
         labels:
           profile_picture: 'Profielfoto'
           remove_picture: 'Verwijder afbeelding'
+          about: Over
           password_for: 'Wachtwoord voor <strong>if me</strong> account'
           update: Updaten
         placeholders:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -655,6 +655,7 @@ pt-BR:
         labels:
           profile_picture: 'Foto de perfil'
           remove_picture: 'Remover foto'
+          about: Sobre
           password_for: 'Senha para a conta do<strong>if me</strong>'
           update: Atualização
         placeholders:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -655,6 +655,7 @@ sv:
         labels:
           profile_picture: Profilbild
           remove_picture: 'Ta bort bilden'
+          about: Om
           password_for: 'Lösenord för <strong>if me</strong>-konto'
           update: Uppdatering
         placeholders:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -655,6 +655,7 @@ vi:
         labels:
           profile_picture: 'Hình ảnh đại diện'
           remove_picture: 'Gỡ bỏ hình ảnh đại diện'
+          about: Về
           password_for: 'Mật khẩu cho tài khoản <strong>if me</strong>'
           update: 'Cập nhật'
         placeholders:


### PR DESCRIPTION
# Description 
Adds a new text string so that the Account Edit page can have its own `About` text.

## Corresponding Issue
Fixes #1251 

# Test Coverage

✅ <!--[YES, remove line if not applicable]-->
