### PR TITLE
Modal no longer hidden behind url searchbar on Google Chrome mobile browser

### DIFF
--- a/client/app/components/Modal/Modal.scss
+++ b/client/app/components/Modal/Modal.scss
@@ -33,8 +33,10 @@
     height: 60vh;
     z-index: $z-index-front;
     @media screen and (max-width: $small) {
+      position: absolute;
       width: 100vw;
-      height: 100vh;
+      height: 80vh;
+      margin: 0 auto;
       border-radius: 0;
     }
     &Header {


### PR DESCRIPTION
# Description 

Fix the issue of pop up modal appearing behind url searchbar on Google Chrome mobile browser by reducing the size of the viewport height from 100 to 80.


## Corresponding Issue

#991 

# Screenshots
![screenmodal](https://user-images.githubusercontent.com/31711543/48921379-6b122f80-ee6d-11e8-90de-c5fac9fa3ba2.PNG)



# Test Coverage

✅ <!--[YES, remove line if not applicable]-->