### PR TITLE
Fix medication refill bug for Google Calendar upload

### DIFF
--- a/app/services/calendar_uploader.rb
+++ b/app/services/calendar_uploader.rb
@@ -22,8 +22,7 @@ class CalendarUploader
   end
 
   def upload_event
-    parsed_date = Chronic.parse(date, endian_precedence: %i[little median])
-                         .to_time.iso8601
+    parsed_date = date.to_time.iso8601
 
     event = {
       summary: summary,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
       location: Location
       description: Description
       error_explanation: 'Please fill out the marked fields!'
-      search_by_keywords: 'Search by keyword'
+      search_by_keywords: 'Search by keywords'
     time_ago: '%{date} ago'
     write_to_us: 'write to us'
     days: Days

--- a/spec/services/calendar_uploader_spec.rb
+++ b/spec/services/calendar_uploader_spec.rb
@@ -1,18 +1,35 @@
 # frozen_string_literal: true
 describe CalendarUploader do
-  it 'uploads an event to Google Calendar' do
-    service = double
+  let(:service) { double }
+
+  before(:each) do
     allow(service).to receive_message_chain(:insert_event)
     allow(service).to receive_message_chain(:authorization=, :access_token=)
+  end
 
-    uploader = CalendarUploader.new(summary: 'an exciting event',
-                                    date: '2015/02/14',
-                                    access_token: 'a token',
-                                    email: 'an email',
-                                    service: service)
+  context 'date is a string' do
+    it 'uploads an event to Google Calendar' do
+      uploader = CalendarUploader.new(summary: 'an exciting event',
+                                      date: '2015/02/14',
+                                      access_token: 'a token',
+                                      email: 'an email',
+                                      service: service)
 
-    expect(service).to receive(:insert_event)
+      expect(service).to receive(:insert_event)
+      uploader.upload_event
+    end
+  end
 
-    uploader.upload_event
+  context 'date is a DateTime object' do
+    it 'uploads an event to Google Calendar' do
+      uploader = CalendarUploader.new(summary: 'an exciting event',
+                                      date: DateTime.now,
+                                      access_token: 'a token',
+                                      email: 'an email',
+                                      service: service)
+
+      expect(service).to receive(:insert_event)
+      uploader.upload_event
+    end
   end
 end

--- a/spec/services/calendar_uploader_spec.rb
+++ b/spec/services/calendar_uploader_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 describe CalendarUploader do
   it 'uploads an event to Google Calendar' do
     service = double


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

<!--[A few sentences describing your changes]-->
Fix medication refill bug for Google Calendar upload. The refill value is now a proper DateTime object, so we don't need to parse a string anymore.

# Test Coverage

✅ <!--[YES, remove line if not applicable]-->

<!--[Must be YES, if NO explain why]-->
