### PR TITLE
Updated French translation of 'About' on user account edit page

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -662,7 +662,7 @@ fr:
         labels:
           profile_picture: 'Photo de profile'
           remove_picture: 'Effacer la photo'
-          about: 'À notre propos'
+          about: 'À propos'
           password_for: 'Mot de passe pour votre compte <strong>if me</strong>'
           update: 'Mise à jour'
         placeholders:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

French translation of the new i18n entry for the account page label. "About Us" becomes "About".

## Corresponding Issue

#1262

# Screenshots
Not sure how to view yet -- working on it!
<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

# Test Coverage

✅ <!--[YES, remove line if not applicable]-->
🚫 <!--[NO, remove line if not applicable]-->

<!--[Must be YES, if NO explain why]-->
