### PR TITLE
upgrade Pell (resolves ifmeorg/ifme#1084)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "js-cookie": "^2.2.0",
     "jstimezonedetect": "^1.0.6",
     "location-autocomplete": "^1.2.4",
-    "pell": "^1.0.4",
+    "pell": "^1.0.6",
     "react": "^16.4.0",
     "react-autocomplete": "^1.8.1",
     "react-chartkick": "^0.1.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8119,10 +8119,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pell@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/pell/-/pell-1.0.4.tgz#fe13873d83cdb6f1e95a7021cf3228f1ac3b3c5a"
-  integrity sha512-eO3FCe7Dnerbi94UmEVzc1iQ83JuAyiosyIfc9ddFoGnfp3/82sHyI86jr/M3qVpTJEbFd7TD607qSqusRq6/g==
+pell@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/pell/-/pell-1.0.6.tgz#9edb026f1edec2b4964251cdb2cd6fcadff08a76"
+  integrity sha512-wuackvgjFCHmVABy7ACSmY2u53w+TlYFrVL2hN6V3rGL/iWWwVXMw2uphpZSXNnqFQTI8nMpD3UNNX8+R4BAYw==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Description 

Upgrade [pell](https://github.com/jaredreich/pell/) to `^1.0.6`, which resolves the bug causing #1084.

## More Details

Behavior in pell 1.0.4 was causing #1084, and [my PR changing that behavior](https://github.com/jaredreich/pell/pull/155) has been merged.  I'm bumping the pell requirement to `^1.0.6` so we get a version with that change.

## Corresponding Issue

[#1084 <cite>Can't tab out out of InputTextarea into the next input field</cite>](https://github.com/ifmeorg/ifme/issues/1084)

# Screenshots

This wouldn't fit in a single-frame screenshot.

# Test Coverage

No tests are provided, since the change is in an upstream component.