### PR TITLE
remove volume from docker-compose.yml (our overrides set it by default)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
   app:
     build: .
     container_name: ifme_app
-    volumes:
-    - .:/app
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
# Description 

Removes a dev-environment setting from the general-purpose `docker-compose.yml`

## More Details

This was added in [PR #1259](https://github.com/ifmeorg/ifme/pull/1259), but was already the default for dev workflows.

In [PR #1223](https://github.com/ifmeorg/ifme/pull/1223), I'd moved this setting to `docker-compose.override.yml`, [which is run by default with `docker-compose up`](https://docs.docker.com/compose/extends/#multiple-compose-files).

https://github.com/ifmeorg/ifme/blob/003785f3d72587f5ae6925d69e94a155b46f0b03/docker-compose.override.yml#L4-L5

That way, dev settings are set for developers, but they're left out for tests and deployments.

### Example scenarios
| scenario | command | dev settings applied? |
| --- | --- | --- |
| development | `docker-compose up` | yes, implicitly |
| development | `docker-compose --file docker-compose.yml --file docker-compose.override.yml` | yes, explicitly |
| testing | `docker-compose --file docker-compose.yml --file docker-compose.test.yml` | no |

### other overrides
From the same file, we also have overrides to run Rails, Rack, and Node in development mode:

https://github.com/ifmeorg/ifme/blob/003785f3d72587f5ae6925d69e94a155b46f0b03/docker-compose.override.yml#L6-L9
