### PR TITLE
Decrease chart.js bytes

### DIFF
--- a/client/app/stories/Chart.stories.jsx
+++ b/client/app/stories/Chart.stories.jsx
@@ -1,4 +1,3 @@
-import 'chartjs';
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Chart } from '../components/Chart';

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,6 @@
     "axios": "^0.18.0",
     "babel-core": "7.0.0-bridge.0",
     "chart.js": "^2.6.0",
-    "chartjs": "^0.3.24",
     "chartkick": "^2.2.4",
     "es5-shim": "^4.5.9",
     "font-awesome": "^4.7.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -10,6 +10,7 @@ const ManifestPlugin = require('webpack-manifest-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const webpackConfigLoader = require('react-on-rails/webpackConfigLoader');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const webpack = require('webpack');
 const baseConfig = require('./webpack.config.base');
 
 const configPath = resolve('..', 'config');
@@ -99,6 +100,8 @@ const config = Object.assign(baseConfig, {
       hot: !!devOrTestMode,
     }),
     new ManifestPlugin({ publicPath: output.publicPath, writeToFileEmit: true }),
+    // only load moment.js data for locales we support (see config/locale.rb)
+    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en|es|de|it|nb|nl|pt-BR|sv|vi|fr/),
   ],
 
   module: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -101,7 +101,7 @@ const config = Object.assign(baseConfig, {
     }),
     new ManifestPlugin({ publicPath: output.publicPath, writeToFileEmit: true }),
     // only load moment.js data for locales we support (see config/locale.rb)
-    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en|es|de|it|nb|nl|pt-BR|sv|vi|fr/),
+    new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en|es|de|it|nb|nl|pt-BR|sv|vi|fr/),
   ],
 
   module: {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2762,11 +2762,6 @@ chartjs-color@^2.1.0:
     chartjs-color-string "^0.5.0"
     color-convert "^0.5.3"
 
-chartjs@^0.3.24:
-  version "0.3.24"
-  resolved "https://registry.yarnpkg.com/chartjs/-/chartjs-0.3.24.tgz#3addeb5ae3606b3e89e346c27d52ca158416e93d"
-  integrity sha1-Ot3rWuNgaz6J40bCfVLKFYQW6T0=
-
 chartkick@^2.2.4:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-2.3.6.tgz#a507c54da7d117e66c9a9c5309f7ecccc2d28b51"


### PR DESCRIPTION
# Description 

Excluded data for unsupported locales, and removed an unused dependency.

## More Details
- Configured Webpack to exclude moment.js locale data for locales ifme doesn't support.
- Removed unused [`chartjs`](https://www.npmjs.com/package/chartjs) dependency (typo of [`chart.js`](https://www.npmjs.com/package/chart.js))

## Corresponding Issue
- part of #1024

## Issues
### unlocalized charts
We aren't actually configuring the locale for charts: time axis labels are always in English (at least on `/moments`: tested in prod, and tested in a container with my changes).

chart.js pulls in all the moment.js locales, but only ever uses the builtin English locale data (unless you reconfigure moment.js before using chart.js).  They're abandoning time axis labeling altogether, so we'll need to handle labels ourselves:
- [issue with discussion on removing moment.js](https://github.com/chartjs/Chart.js/issues/5235)
- [PR updating docs to use chart.js without moment.js](https://github.com/chartjs/Chart.js/pull/5958)

@julianguyen Has anyone worked on #726?