### PR TITLE
Adding and configuring bullet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ group :development, :test do
   gem 'rubocop-rspec'
 
   gem 'foreman'
+
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,9 +60,11 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     builder (3.2.3)
+    bullet (5.7.6)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11.0)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
-      thor (~> 0.18)
     byebug (11.0.0)
     capybara (3.14.0)
       addressable
@@ -447,6 +449,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.1)
+    uniform_notifier (1.11.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     warden (1.2.8)
@@ -469,6 +472,7 @@ DEPENDENCIES
   annotate (~> 2.7)
   bcrypt (= 3.1.12)
   better_errors (~> 2.5)
+  bullet
   bundler-audit
   byebug
   capybara (~> 3.14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       uniform_notifier (~> 1.11.0)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
+      thor (~> 0.18)
     byebug (11.0.0)
     capybara (3.14.0)
       addressable

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,10 @@
+unless Rails.env.production?
+  Rails.application.configure do
+    config.after_initialize do
+      Bullet.enable = true
+      Bullet.bullet_logger = true
+      Bullet.console = true
+      Bullet.rails_logger = true
+    end
+  end
+end

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -3,8 +3,6 @@ unless Rails.env.production?
     config.after_initialize do
       Bullet.enable = true
       Bullet.bullet_logger = true
-      Bullet.console = true
-      Bullet.rails_logger = true
     end
   end
 end


### PR DESCRIPTION
Co-authored-by: Marcella Alcantara <marcellalcantara@gmail.com>

# Description 

This PR just adds and configures the [Bullet](https://github.com/flyerhzm/bullet).

This GEM provides many configs to enable the Bullet notifications, but for while we just enabled three configs to help the process of development:

`Bullet.bullet_logger`: log to the Bullet log file (Rails.root/log/bullet.log)
`Bullet.console`: log warnings to your browser's console.log (Safari/Webkit browsers or Firefox w/Firebug installed)
`Bullet.rails_logger`: add warnings directly to the Rails log

We started working on these points where they were being reported in the logs, but our lack of knowledge of the features started to get a bit difficult to map the collateral effects of our changes. 

So, we follow a different approach for while, just adding and configuring the gem to identify queries performance issues during the development of some feature. 

And after that, maybe create separate issues for specific resources. e.g.:

- comments;
- groups;
- moments;
- etc...

## More Details

The Bullet gem is designed to help you increase your application's performance by reducing the number of queries it makes. It will watch your queries while you develop your application and notify you when you should add eager loading (N+1 queries), when you're using eager loading that isn't necessary and when you should use a counter cache.

## Corresponding Issue

#1160

# Test Coverage

🚫

This PR just adds and configure a GEM to help the process of development on environments `test` and `development`. It's disabled for the production environment.
