### PR TITLE
Bump ruby version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM ruby:2.3-alpine
+FROM ruby:2.6-alpine
 
 ENV PORT 3000
 ENV PATH /node_modules/.bin:$PATH


### PR DESCRIPTION
# Description 

Updating the image of docker to use ruby version `2.6.0`

## More Details

The command `docker-compose up`, is returning this error:

```
Step 9/13 : RUN bundle install && npm install
 ---> Running in 591b81e1e048
Your Ruby version is 2.3.8, but your Gemfile specified ~> 2.6.0
ERROR: Service 'app' failed to build: The command '/bin/sh -c bundle install && npm install' returned a non-zero code: 18
```

because the image is using the wrong version of ruby.

# Test Coverage

🚫  The change consists in the update of the docker image with the ruby upgraded
