### PR TITLE
Remove mismatching german instruction translations containing %{icon}

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -148,7 +148,7 @@ de:
       premade3_description: 'Über meine Arbeit'
       premade4_name: Meditation
       premade4_description: 'Meditation, Atemübungen und Entspannung'
-      instructions: 'Du hast noch keine eigenen Kategorieren erstellt. Klicke %{icon} um welche hinzuzufügen!<br>Du kannst auch die folgenden Vorschläge benutzen und diese mit der Zeit anpassen.'
+      instructions: 'Du hast noch keine eigenen Kategorieren erstellt.<br />Du kannst auch die folgenden Vorschläge benutzen und diese mit der Zeit anpassen.'
   errors:
     home_page: 'Zurück zur Homepage'
     internal_server_error:
@@ -169,7 +169,7 @@ de:
       available_groups: 'Verfügbare Gruppen'
       joined_groups: 'Beigetretenen Gruppen'
       leader: (Administrator)
-      instructions: 'Du bist noch keiner Gruppe beigetreten, aber du kannst hier klicken %{icon}, um eine zu erstellen!'
+      instructions: 'Du bist noch keiner Gruppe beigetreten.'
     join:
       success: 'Du bist dieser Gruppe beigetreten.'
       group_not_exists: 'Sie können keiner Gruppe beitreten, die nicht existiert.'
@@ -240,7 +240,7 @@ de:
     index:
       title: Arzneimittel
       subtitle: 'Behalte deine Arzneimittel im Auge, wie z.B. deren Dosis und wann sie wieder aufgefüllt werden müssen.'
-      instructions: 'Du hast noch keine Arzneimittel gespeichert. Klicke %{icon} um eins hinzuzufügen!<br><br>Hier ist ein Beispieleintrag! Du kannst natürlich deine eigenen Daten benutzen.'
+      instructions: 'Du hast noch keine Arzneimittel gespeichert.<br /><br />Hier ist ein Beispieleintrag! Du kannst natürlich deine eigenen Daten benutzen.'
       example_name: Prozac
       example_strength: '10 mg'
       example_total: '40 Tabletten'
@@ -297,7 +297,7 @@ de:
       draft_question: 'Möchtest du deinen Moment als Entwurf speichern?'
     index:
       subtitle: 'Setze dich intensiv mit Ereignissen auseinander, die deinen Geist und Seele betreffen.'
-      instructions: 'Du hast noch über keine Ereignisse berichtet. Klicke %{icon} um welche hinzuzufügen!<br><br>Nicht sicher, wo du anfangen sollst? Berichte von etwas, dass heute passiert ist und du gerne mit jemandem Vertrautes teilen würdest? Es kann positiv oder negativ sein! Du musst es auch nicht sofort teilen - sondern erst, wenn du soweit bist! Hier ist ein Beispiel für einen solchen Moment.'
+      instructions: 'Du hast noch über keine Ereignisse berichtet.<br /><br />Nicht sicher, wo du anfangen sollst? Berichte von etwas, dass heute passiert ist und du gerne mit jemandem Vertrautes teilen würdest? Es kann positiv oder negativ sein! Du musst es auch nicht sofort teilen - sondern erst, wenn du soweit bist! Hier ist ein Beispiel für einen solchen Moment.'
       example_name: 'Panik vor dem Bewerbungsgespräch morgen!'
       example_category: Karriere
     show:
@@ -323,7 +323,7 @@ de:
       premade4_description: 'Bestimmte Dinge machen mich nervös, sauer, rachsüchtig und/oder neidisch'
       premade5_name: Hoffnungslos
       premade5_description: 'Traurig und hoffnungslos - nicht in der Lage, irgendeine Lösung zu finden'
-      instructions: 'Du hast noch keine Stimmungen hinzugefügt. Klicke %{icon}, um welche hinzuzufügen!<br>Du kannst auch die folgenden, vordefinierten Stimmungen hinzufügen und zu einen späteren Zeitpunkt anpassen.'
+      instructions: 'Du hast noch keine Stimmungen hinzugefügt.<br />Du kannst auch die folgenden, vordefinierten Stimmungen hinzufügen und zu einen späteren Zeitpunkt anpassen.'
   notifications:
     plural: Benachrichtigungen
     none: 'Keine vorhanden'
@@ -634,7 +634,7 @@ de:
       subtitle: 'Erstelle einen Plan zur Selbsthilfe, um eine neue Einstellung und Herangehensweise für diesen Moment zu erarbeiten.'
       premade1_name: 'Fünf Minuten meditieren'
       premade1_description: '1) <b>Finde eine entspannte und komfortable Position.</b> Du kannst auf einem Stuhl sitzen oder mit einem Kissen auf dem Boden. Halte deinen Rücken gerade, aber nicht zu steif. Deine Hände kannst du ausruhen, wo es dir am bequemsten ist. Die Zunge liegt am Gaumen oder woimmer es am angenehmsten ist.<br><br>2) <b>Spüre und entspannte deinen Körper.</b> Versuche, dich auf die Form deines Körpers zu konzentieren, sowie sein Gewicht. Entspanne dich und folge neugierig deinem Körper in seiner Sitzhaltung—Die Empfindungen, die du wahrnimmst, der Kontakt, mit dem Boden oder dem Stuhl, auf dem du sitzt. Entspanne die Regionen des Körpers, die sich angespannt steif anfühlen. Atme durch.<br><br>3) <b>Konzentriere dich auf deinen Atem.</b> Spüre das natürliche Auf und Ab des Atems. Du musst nichts weiter tun, als dich auf deinen Atem zu konzentrieren. Nicht zu lang, nicht zu kurz, aber ganz mühelos. Spüre, wo du den Atem in deinem Körper wahrnimmst. Vielleicht im Bauchraum. Vielleicht im Brustbereich, im Hals oder in der Nase. Versuche, den Atem mit allen Sinnen wahrzunehmen, ein Atemzug nach dem anderen. Wenn ein Atemzug endet, so beginnt darauf der nächste.<br><br>4) <b>Sei nicht zu streng mit deinem regsamen Geist.</b> Jetzt wo du mittendrin bist, bemerkst du vielleicht, wie deine Gedanken zu wandern beginnen. Vielleicht lässt es sich von anderen Dingen ablenken. Wenn das passiert, ist das kein Problem. Das ist ganz normal. Nimm einfach zur Kenntnis, dass du abgelenkt wurdest. Du kannst in Gedanken die Worte “nachdenklich“ oder “abschweifend” wiederholen. Und dann kannst du deine Konzentration behutsam auf das Atmen zurücklenken.<br><br>5) <b>Verbleibe in diesem Zustand für fünf bis sieben Minuten.</b> Nimm in aller Ruhe deinen Atem war. Von Zeit zu Zeit wirst du gedanklich abgelenkt werden. Bring dann deine Konzentration einfach wieder auf den Atem zurück.<br><br>6) <b>Gehe tief in dich, bevor du zum Ende kommst.</b> Nach ein paar Minuten nimm noch einmal deinen ganzen Körper wahr, sitzend und ruhend. Entspanne dich ein letztes Mal so tief wie du kannst und dann klopf dir gerne auf die Schulter dafür, dass du diese Übung heute durchgeführt hast.<br><br><i>Auszug von http://www.mindful.org/a-five-minute-breathing-meditation/</i>'
-      instructions: 'Du hast noch keine eigenen Strategien erstellt. Klicke %{icon}, um welche hinzuzufügen!<br>Du kannst ebenfalls die folgenden vorgefertigen Strategien verwenden und zu einem späteren Zeipunkt anpassen.'
+      instructions: 'Du hast noch keine eigenen Strategien erstellt.<br />Du kannst ebenfalls die folgenden vorgefertigen Strategien verwenden und zu einem späteren Zeipunkt anpassen.'
     reminder_mailer:
       subject: 'Vergiss nicht, an %{name} zu denken!'
       body: 'Hier ist eine freundliche Erinnerung, damit du %{name} nicht vergisst!'


### PR DESCRIPTION
# Description 

Removes mismatching German instruction copy on tabs so that the copy matches other translations and doesn't contain raw variables exposed to the user (e.g. %{icon}).

## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1479

# Screenshots

<img width="1082" alt="Screen Shot 2019-05-08 at 7 49 02 PM" src="https://user-images.githubusercontent.com/16996661/57419927-6ac2e200-71ca-11e9-8b1c-0b10ff8f4991.png">

# Test Coverage

🚫 this is a translation copy change only