### PR TITLE
Adding error handling and tests to PusherController

### DIFF
--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -8,10 +8,21 @@ class PusherController < ApplicationController
   #
   # Returns an auth token from Pusher that looks like this
   # {:auth=>":7944d5b3dc2915f6a9c55dbedcbe91037799bb3627fc868890c2a7fd6f5fde4b"}
+  # 
+  # If there is an error, the response will look like this
+  # {"channel_name":["can't be blank"],"socket_id":["can't be blank"]}
   def auth
     if current_user
-      response = Pusher[params[:channel_name]].authenticate(params[:socket_id])
-      render json: response
+      errors = {}
+      errors[:channel_name] = ["can't be blank"] if params[:channel_name].blank?
+      errors[:socket_id] = ["can't be blank"] if params[:socket_id].blank?
+      
+      if errors.empty?
+        response = Pusher[params[:channel_name]].authenticate(params[:socket_id])
+        render json: response
+      else
+        render json: errors, status: :bad_request
+      end
     else
       render text: t('pusher.not_authorized'), status: '403'
     end

--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -4,6 +4,10 @@ class PusherController < ApplicationController
   # stop rails CSRF protection for this action
   protect_from_forgery except: :auth
 
+  # POST /pusher/auth
+  #
+  # Returns an auth token from Pusher that looks like this
+  # {:auth=>":7944d5b3dc2915f6a9c55dbedcbe91037799bb3627fc868890c2a7fd6f5fde4b"}
   def auth
     if current_user
       response = Pusher[params[:channel_name]].authenticate(params[:socket_id])

--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -5,9 +5,11 @@ class PusherController < ApplicationController
   protect_from_forgery except: :auth
 
   # POST /pusher/auth
+  # @argument channel_name [String] The name of the pusher channel.
+  # @argument socket_id [String] The id of the pusher socket.
   #
   # Returns an auth token from Pusher that looks like this
-  # {:auth=>":7944d5b3dc2915f6a9c55dbedcbe91037799bb3627fc868890c2a7fd6f5fde4b"}
+  # {"auth": ":7944d5b3dc2915f6a9c55dbedcbe91037799bb3627fc868890c2a7fd6f5fde4b"}
   # 
   # If there is an error, the response will look like this
   # {"channel_name":["can't be blank"],"socket_id":["can't be blank"]}

--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -10,7 +10,7 @@ class PusherController < ApplicationController
   #
   # Returns an auth token from Pusher that looks like this
   # {"auth": "some-auth-key"}
-  # 
+  #
   # If there is an error, the response will look like this
   # {"channel_name":["can't be blank"],"socket_id":["can't be blank"]}
   def auth
@@ -18,7 +18,7 @@ class PusherController < ApplicationController
       errors = {}
       errors[:channel_name] = [I18n.t('errors.empty_params')] if params[:channel_name].blank?
       errors[:socket_id] = [I18n.t('errors.empty_params')] if params[:socket_id].blank?
-      
+
       if errors.empty?
         response = Pusher[params[:channel_name]].authenticate(params[:socket_id])
         render json: response

--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -14,19 +14,16 @@ class PusherController < ApplicationController
   # If there is an error, the response will look like this
   # {"channel_name":["can't be blank"],"socket_id":["can't be blank"]}
   def auth
-    if current_user
-      errors = {}
-      errors[:channel_name] = [I18n.t('errors.empty_params')] if params[:channel_name].blank?
-      errors[:socket_id] = [I18n.t('errors.empty_params')] if params[:socket_id].blank?
+    errors = {}
+    message = [I18n.t('errors.empty_params')]
+    errors[:channel_name] = message if params[:channel_name].blank?
+    errors[:socket_id] = message if params[:socket_id].blank?
 
-      if errors.empty?
-        response = Pusher[params[:channel_name]].authenticate(params[:socket_id])
-        render json: response
-      else
-        render json: errors, status: :bad_request
-      end
+    if errors.empty?
+      response = Pusher[params[:channel_name]].authenticate(params[:socket_id])
+      render json: response
     else
-      render text: t('pusher.not_authorized'), status: '403'
+      render json: errors, status: :bad_request
     end
   end
 end

--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -9,15 +9,15 @@ class PusherController < ApplicationController
   # @argument socket_id [String] The id of the pusher socket.
   #
   # Returns an auth token from Pusher that looks like this
-  # {"auth": ":7944d5b3dc2915f6a9c55dbedcbe91037799bb3627fc868890c2a7fd6f5fde4b"}
+  # {"auth": "some-auth-key"}
   # 
   # If there is an error, the response will look like this
   # {"channel_name":["can't be blank"],"socket_id":["can't be blank"]}
   def auth
     if current_user
       errors = {}
-      errors[:channel_name] = ["can't be blank"] if params[:channel_name].blank?
-      errors[:socket_id] = ["can't be blank"] if params[:socket_id].blank?
+      errors[:channel_name] = [I18n.t('errors.empty_params')] if params[:channel_name].blank?
+      errors[:socket_id] = [I18n.t('errors.empty_params')] if params[:socket_id].blank?
       
       if errors.empty?
         response = Pusher[params[:channel_name]].authenticate(params[:socket_id])

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -155,6 +155,7 @@ de:
       header_message: 'Diese Seite kann nicht angezeigt werden'
     not_found:
       header_message: 'Diese Seite existiert nicht'
+    empty_params: 'Kann nicht leer sein'
   groups:
     singular: Gruppe
     plural: Gruppen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,7 @@ en:
       header_message: 'This page cannot be displayed'
     not_found:
       header_message: 'This page does not exist'
+    empty_params: 'Can''t be blank'
   groups:
     singular: Group
     plural: Groups

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -154,6 +154,7 @@ es:
       header_message: 'Esta página no puede ser mostrada'
     not_found:
       header_message: 'Esta página no existe'
+    empty_params: 'No puede estar en blanco'
   groups:
     singular: Grupo
     plural: Grupos

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -154,6 +154,7 @@ fr:
       header_message: 'Cette page ne peut pas être affichée'
     not_found:
       header_message: 'Cette page n''existe pas'
+    empty_params: 'Ne peut pas être vide'
   groups:
     singular: Groupe
     plural: Groupes

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -154,6 +154,7 @@ hi:
       header_message: 'यह पन्ना नहीं दिखाया जा सकता'
     not_found:
       header_message: 'यह पृष्ठ मौजूद नहीं है'
+    empty_params: 'रिक्त नहीं हो सकता'
   groups:
     singular: 'समूह'
     plural: 'समूह'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -154,6 +154,7 @@ it:
       header_message: 'Questa pagina non può essere visualizzata'
     not_found:
       header_message: 'Questa pagina non esiste'
+    empty_params: 'Non può essere vuoto'
   groups:
     singular: Gruppo
     plural: Gruppi

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -154,6 +154,7 @@ nb:
       header_message: 'Denne siden kan ikke vises'
     not_found:
       header_message: 'Denne siden finnes ikke'
+    empty_params: 'Kan ikke være tomt'
   groups:
     singular: Gruppe
     plural: Grupper

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -154,6 +154,7 @@ nl:
       header_message: 'Deze pagina kan niet worden weergegeven'
     not_found:
       header_message: 'Deze pagina bestaat niet'
+    empty_params: 'Kan niet leeg zijn'
   groups:
     singular: Groep
     plural: Groepen

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -154,6 +154,7 @@ pt-BR:
       header_message: 'Essa página não pode ser visualizada.'
     not_found:
       header_message: 'Essa página não existe'
+    empty_params: 'Não pode ficar em branco'
   groups:
     singular: Grupo
     plural: Grupos

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -154,6 +154,7 @@ sv:
       header_message: 'Sidan kan inte visas'
     not_found:
       header_message: 'Den här sidan existerar inte'
+    empty_params: 'Kan inte vara tomt'
   groups:
     singular: Grupp
     plural: Grupper

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -154,6 +154,7 @@ vi:
       header_message: 'Trang không thể hiển thị'
     not_found:
       header_message: 'Trang này không tồn tại'
+    empty_params: 'Không thể để trống'
   groups:
     singular: Nhóm
     plural: Nhóm

--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
     "node_modules",
     "client/node_modules"
   ],
-  "version": "11.10.1"
+  "version": "1.9.4"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,5 @@
   "cacheDirectories": [
     "node_modules",
     "client/node_modules"
-  ],
-  "version": "1.9.4"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   "cacheDirectories": [
     "node_modules",
     "client/node_modules"
-  ]
+  ],
+  "version": "11.10.1"
 }

--- a/spec/controllers/pusher_controller_spec.rb
+++ b/spec/controllers/pusher_controller_spec.rb
@@ -1,0 +1,16 @@
+describe PusherController do
+
+  let(:user) { create(:user) }
+  let(:pusher) { create(:pusher) }
+
+  describe 'auth' do
+    context 'when the user is logged in' do
+      before { sign_in user }
+
+    it 'renders pusher response notification' do
+        get :auth
+        expect(response).to render_template("auth")
+      end
+    end
+  end
+end

--- a/spec/controllers/pusher_controller_spec.rb
+++ b/spec/controllers/pusher_controller_spec.rb
@@ -7,17 +7,42 @@ describe PusherController do
       before { sign_in user }
 
       it 'returns the pusher auth token in json' do
-        post :auth, params: { channel_name: 'janessa', socket_id: '123.456' }
+        post :auth, params: { channel_name: 'channel_one', socket_id: '123.456' }
         json = JSON.parse(response.body)
 
         expect(json['auth']).to_not be_nil
+      end
+
+      it 'returns an error if channel_name is not passed' do
+        post :auth, params: { socket_id: '123.456' }
+        json = JSON.parse(response.body)
+
+        expect(response.code).to eq("400")
+        expect(json['channel_name']).to eq(["can't be blank"])
+      end
+
+      it 'returns an error if socket_id is not passed' do
+        post :auth, params: { channel_name: 'channel_one' }
+        json = JSON.parse(response.body)
+
+        expect(response.code).to eq("400")
+        expect(json['socket_id']).to eq(["can't be blank"])
+      end
+
+      it 'returns an error if channel_name or socket_id is empty' do
+        post :auth, params: { channel_name: '', socket_id: '' }
+        json = JSON.parse(response.body)
+
+        expect(response.code).to eq("400")
+        expect(json['channel_name']).to eq(["can't be blank"])
+        expect(json['socket_id']).to eq(["can't be blank"])
       end
     end
 
     context 'when the user is not logged in' do
 
       it 'returns a login redirect' do
-        post :auth, params: { channel_name: 'janessa', socket_id: '123.456' }
+        post :auth, params: { channel_name: 'channel_one', socket_id: '123.456' }
 
         expect(response.status).to eq(302)
       end

--- a/spec/controllers/pusher_controller_spec.rb
+++ b/spec/controllers/pusher_controller_spec.rb
@@ -18,7 +18,7 @@ describe PusherController do
         json = JSON.parse(response.body)
 
         expect(response.code).to eq("400")
-        expect(json['channel_name']).to eq(["can't be blank"])
+        expect(json['channel_name']).to eq([I18n.t('errors.empty_params')])
       end
 
       it 'returns an error if socket_id is not passed' do
@@ -26,7 +26,7 @@ describe PusherController do
         json = JSON.parse(response.body)
 
         expect(response.code).to eq("400")
-        expect(json['socket_id']).to eq(["can't be blank"])
+        expect(json['socket_id']).to eq([I18n.t('errors.empty_params')])
       end
 
       it 'returns an error if channel_name or socket_id is empty' do
@@ -34,8 +34,8 @@ describe PusherController do
         json = JSON.parse(response.body)
 
         expect(response.code).to eq("400")
-        expect(json['channel_name']).to eq(["can't be blank"])
-        expect(json['socket_id']).to eq(["can't be blank"])
+        expect(json['channel_name']).to eq([I18n.t('errors.empty_params')])
+        expect(json['socket_id']).to eq([I18n.t('errors.empty_params')])
       end
     end
 

--- a/spec/controllers/pusher_controller_spec.rb
+++ b/spec/controllers/pusher_controller_spec.rb
@@ -1,16 +1,27 @@
 describe PusherController do
 
   let(:user) { create(:user) }
-  let(:pusher) { create(:pusher) }
 
   describe 'auth' do
     context 'when the user is logged in' do
       before { sign_in user }
 
-    it 'renders pusher response notification' do
-        get :auth
-        expect(response).to render_template("auth")
+      it 'returns the pusher auth token in json' do
+        post :auth, params: { channel_name: 'janessa', socket_id: '123.456' }
+        json = JSON.parse(response.body)
+
+        expect(json['auth']).to_not be_nil
       end
     end
+
+    context 'when the user is not logged in' do
+
+      it 'returns a login redirect' do
+        post :auth, params: { channel_name: 'janessa', socket_id: '123.456' }
+
+        expect(response.status).to eq(302)
+      end
+    end
+
   end
 end

--- a/spec/controllers/pusher_controller_spec.rb
+++ b/spec/controllers/pusher_controller_spec.rb
@@ -1,5 +1,11 @@
 describe PusherController do
 
+  before do
+    Pusher.app_id = ""
+    Pusher.key =  ""
+    Pusher.secret = ""
+  end
+
   let(:user) { create(:user) }
 
   describe 'auth' do


### PR DESCRIPTION
# Description 
If the two required parameters, `channel_name` and `socket_id`, are not passed to the Pusher endpoint, an error message is returned in the same Rails ActiveModel error format as the other controllers.

## Corresponding Issue
#1410 

# Test Coverage
✅ 
