### PR TITLE
fix(Dockerfile): added bash to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk update \
     nodejs \
     curl \
     npm \
+    bash \
     build-base \
     postgresql-dev \
     tzdata \


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

Without the bash command, docker-compose up returns `sh: bash: not found`. Adding bash to the
dockerfile fixes this issue.

# Screenshots
<img width="587" alt="Screen Shot 2019-09-18 at 10 25 21 AM" src="https://user-images.githubusercontent.com/7353585/65170565-f5d4a400-da16-11e9-9c88-bad1941ccd13.png">
