### PR TITLE
Eliminate inconsistant padding in InputTextarea

### DIFF
--- a/app/assets/stylesheets/base/_sizes.scss
+++ b/app/assets/stylesheets/base/_sizes.scss
@@ -27,4 +27,4 @@ $size-46: 46px;
 $size-48: 48px;
 $size-50: 50px;
 $size-60: 60px;
-$size-73: 73px;
+$size-70: 70px;

--- a/app/assets/stylesheets/base/_sizes.scss
+++ b/app/assets/stylesheets/base/_sizes.scss
@@ -27,3 +27,4 @@ $size-46: 46px;
 $size-48: 48px;
 $size-50: 50px;
 $size-60: 60px;
+$size-73: 73px;

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -142,7 +142,7 @@ export class InputTextarea extends React.Component<Props, State> {
           this.editorRef = element;
         }}
       >
-        <div className={`editor ${css.minHeight}`} />
+        <div className={`editor ${css.editor}`} />
         {this.displayHidden()}
       </div>
     );

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -142,7 +142,7 @@ export class InputTextarea extends React.Component<Props, State> {
           this.editorRef = element;
         }}
       >
-        <div className={"editor "+ css.minHeight }/>
+        <div className={`editor ${css.minHeight}`} />
         {this.displayHidden()}
       </div>
     );

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -142,7 +142,7 @@ export class InputTextarea extends React.Component<Props, State> {
           this.editorRef = element;
         }}
       >
-        <div className="editor" />
+        <div className={"editor "+ css.minHeight }/>
         {this.displayHidden()}
       </div>
     );

--- a/client/app/components/Input/InputTextarea.scss
+++ b/client/app/components/Input/InputTextarea.scss
@@ -59,3 +59,7 @@
     }
   }
 }
+
+.minHeight{
+  min-height: $size-73;
+}

--- a/client/app/components/Input/InputTextarea.scss
+++ b/client/app/components/Input/InputTextarea.scss
@@ -60,6 +60,6 @@
   }
 }
 
-.minHeight{
-  min-height: $size-73;
+.editor{
+  min-height: $size-70;
 }


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

Inconsistent padding was going on in any form field that hosts the format controls in firefox browser. Added min-height to solve this issue.

## Corresponding Issue
#1373 

# Screenshots
![Screenshot (186)](https://user-images.githubusercontent.com/19610074/65485557-d7135900-debf-11e9-91e9-b1b479844ccd.png)

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

# Test Coverage

✅

<!--[Must be YES, if NO explain why]-->
