### PR TITLE
Add test coverage for Notifications widget

### DIFF
--- a/client/app/components/Header/HeaderProfile.jsx
+++ b/client/app/components/Header/HeaderProfile.jsx
@@ -34,12 +34,7 @@ const displayInfoLinks = (headerProfile: Profile) => {
         </a>
       </div>
       <div>
-        <Notifications
-          element={notificationsElement(notifications.plural)}
-          plural={notifications.plural}
-          none={notifications.none}
-          clear={notifications.clear}
-        />
+        <Notifications element={notificationsElement(notifications.plural)} />
       </div>
     </div>
   );

--- a/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
+++ b/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import axios from 'axios';
 import { mount } from 'enzyme';
-import { Notifications } from '../index'
+import { Notifications } from '../index';
 
 let axiosGetSpy;
 let axiosDeleteSpy;
@@ -11,24 +11,28 @@ let componentDidMountSpy;
 const data = {
   signed_in: 1,
   fetch_notifications: ['Notification 1'],
-}
+};
 
-const component = <Notifications
-                    element={<button>"Notifications"</button>}
-                    plural="Notifications"
-                    none="There are none"
-                    clear="Clear" 
-                  />;
+const component = (
+  <Notifications
+    element={<button type="button">Notifications</button>}
+    plural="Notifications"
+    none="There are none"
+    clear="Clear"
+  />
+);
 
 describe('Notifications', () => {
   beforeEach(() => {
     axiosGetSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({
-      data
+      data,
     }));
     axiosDeleteSpy = jest.spyOn(axios, 'delete').mockImplementation(() => Promise.resolve({
-      data: {ok: true}
+      data: { ok: true },
     }));
-    componentDidMountSpy = jest.spyOn(Notifications.prototype, 'componentDidMount').mockImplementation(() => {})
+    componentDidMountSpy = jest
+      .spyOn(Notifications.prototype, 'componentDidMount')
+      .mockImplementation(() => {});
   });
 
   it('renders correctly', () => {
@@ -41,25 +45,32 @@ describe('Notifications', () => {
 
   it('gets notifications and clears them', async (done) => {
     const wrapper = mount(component);
+    componentDidMountSpy();
     const instance = wrapper.instance();
     instance.setState({ signedInKey: 1 });
-    instance.fetchNotifications()
+    instance
+      .fetchNotifications()
       .then(() => {
+        axiosGetSpy();
         wrapper.update();
-        expect(wrapper.state('notifications')).toBe('<div>Notification 1</div>');
+        expect(wrapper.state('notifications')).toBe(
+          '<div>Notification 1</div>',
+        );
       })
       .then(async () => {
         await wrapper.find('.buttonDarkS').simulate('click');
+        axiosDeleteSpy();
         wrapper.update();
         expect(wrapper.find('.modal').exists()).toEqual(false);
       })
       .then(async () => {
         data.fetch_notifications = [];
         await instance.fetchNotifications();
+        axiosGetSpy();
         wrapper.update();
         expect(wrapper.state('notifications')).toBe('');
         done();
       })
       .catch(done);
-  })
-})
+  });
+});

--- a/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
+++ b/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
@@ -7,20 +7,15 @@ import { faItalic } from '@fortawesome/free-solid-svg-icons';
 
 let axiosGetSpy;
 let axiosDeleteSpy;
+let componentDidMountSpy;
 
-const notification = [
-  "Notification 1",
-  "Notification 2"
-]
-
-const notificationsElement = (notifications) => (
-  <button type="button" className="buttonGhostXS" aria-label={notifications}>
-    "Placeholder"
-  </button>
-);
+const data = {
+    signed_in: 1,
+    fetch_notifications: ['Notification 1'],
+}
 
 const component = <Notifications
-                    element={notificationsElement("Notifications")}
+                    element={<button>"Notifications"</button>}
                     plural="Notifications"
                     none="There are none"
                     clear="Clear" 
@@ -29,11 +24,12 @@ const component = <Notifications
 describe('Notifications', () => {
   beforeEach(() => {
     axiosGetSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({
-      data: { notification }
+      data
     }));
     axiosDeleteSpy = jest.spyOn(axios, 'delete').mockImplementation(() => Promise.resolve({
       data: {ok: true}
     }));
+    componentDidMountSpy = jest.spyOn(Notifications.prototype, 'componentDidMount').mockImplementation(() => {})
   });
 
   it('renders correctly', () => {
@@ -42,5 +38,17 @@ describe('Notifications', () => {
       wrapper = mount(component);
     }).not.toThrow();
     expect(wrapper).not.toBeNull();
-  });  
+  });
+
+  it('gets notifications', async () => {
+    const wrapper = mount(component);
+    const instance = wrapper.instance();
+    instance.setState({ signedInKey: 1 })
+    instance.fetchNotifications()
+      .then(async () => {
+        await axiosGetSpy()
+        wrapper.update();
+        expect(wrapper.state('notifications')).toBe('<div>Notification 1</div>')
+      });
+  })
 })

--- a/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
+++ b/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
@@ -3,15 +3,14 @@ import React from 'react';
 import axios from 'axios';
 import { mount } from 'enzyme';
 import { Notifications } from '../index'
-import { faItalic } from '@fortawesome/free-solid-svg-icons';
 
 let axiosGetSpy;
 let axiosDeleteSpy;
 let componentDidMountSpy;
 
 const data = {
-    signed_in: 1,
-    fetch_notifications: ['Notification 1'],
+  signed_in: 1,
+  fetch_notifications: ['Notification 1'],
 }
 
 const component = <Notifications
@@ -40,15 +39,27 @@ describe('Notifications', () => {
     expect(wrapper).not.toBeNull();
   });
 
-  it('gets notifications', async () => {
+  it('gets notifications and clears them', async (done) => {
     const wrapper = mount(component);
     const instance = wrapper.instance();
-    instance.setState({ signedInKey: 1 })
+    instance.setState({ signedInKey: 1 });
     instance.fetchNotifications()
-      .then(async () => {
-        await axiosGetSpy()
+      .then(() => {
         wrapper.update();
-        expect(wrapper.state('notifications')).toBe('<div>Notification 1</div>')
-      });
+        expect(wrapper.state('notifications')).toBe('<div>Notification 1</div>');
+      })
+      .then(async () => {
+        await wrapper.find('.buttonDarkS').simulate('click');
+        wrapper.update();
+        expect(wrapper.find('.modal').exists()).toEqual(false);
+      })
+      .then(async () => {
+        data.fetch_notifications = [];
+        await instance.fetchNotifications();
+        wrapper.update();
+        expect(wrapper.state('notifications')).toBe('');
+        done();
+      })
+      .catch(done);
   })
 })

--- a/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
+++ b/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react';
+import axios from 'axios';
+import { mount } from 'enzyme';
+import { Notifications } from '../index'
+import { faItalic } from '@fortawesome/free-solid-svg-icons';
+
+let axiosGetSpy;
+let axiosDeleteSpy;
+
+const notification = [
+  "Notification 1",
+  "Notification 2"
+]
+
+const notificationsElement = (notifications) => (
+  <button type="button" className="buttonGhostXS" aria-label={notifications}>
+    "Placeholder"
+  </button>
+);
+
+const component = <Notifications
+                    element={notificationsElement("Notifications")}
+                    plural="Notifications"
+                    none="There are none"
+                    clear="Clear" 
+                  />;
+
+describe('Notifications', () => {
+  beforeEach(() => {
+    axiosGetSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({
+      data: { notification }
+    }));
+    axiosDeleteSpy = jest.spyOn(axios, 'delete').mockImplementation(() => Promise.resolve({
+      data: {ok: true}
+    }));
+  });
+
+  it('renders correctly', () => {
+    let wrapper = null;
+    expect(() => {
+      wrapper = mount(component);
+    }).not.toThrow();
+    expect(wrapper).not.toBeNull();
+  });  
+})

--- a/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
+++ b/client/app/widgets/Notifications/__tests__/Notifications.spec.jsx
@@ -6,7 +6,6 @@ import { Notifications } from '../index';
 
 let axiosGetSpy;
 let axiosDeleteSpy;
-let componentDidMountSpy;
 
 const data = {
   signed_in: 1,
@@ -14,12 +13,7 @@ const data = {
 };
 
 const component = (
-  <Notifications
-    element={<button type="button">Notifications</button>}
-    plural="Notifications"
-    none="There are none"
-    clear="Clear"
-  />
+  <Notifications element={<button type="button">Notifications</button>} />
 );
 
 describe('Notifications', () => {
@@ -30,9 +24,6 @@ describe('Notifications', () => {
     axiosDeleteSpy = jest.spyOn(axios, 'delete').mockImplementation(() => Promise.resolve({
       data: { ok: true },
     }));
-    componentDidMountSpy = jest
-      .spyOn(Notifications.prototype, 'componentDidMount')
-      .mockImplementation(() => {});
   });
 
   it('renders correctly', () => {
@@ -45,7 +36,6 @@ describe('Notifications', () => {
 
   it('gets notifications and clears them', async (done) => {
     const wrapper = mount(component);
-    componentDidMountSpy();
     const instance = wrapper.instance();
     instance.setState({ signedInKey: 1 });
     instance

--- a/client/app/widgets/Notifications/index.jsx
+++ b/client/app/widgets/Notifications/index.jsx
@@ -4,12 +4,10 @@ import axios from 'axios';
 import renderHTML from 'react-render-html';
 import { Modal } from '../../components/Modal';
 import { Utils } from '../../utils';
+import { I18n } from '../../libs/i18n/index';
 
 export type Props = {
   element: any,
-  plural: string,
-  none: string,
-  clear: string,
 };
 
 export type State = {
@@ -99,7 +97,6 @@ export class Notifications extends React.Component<Props, State> {
   };
 
   displayNotifications = () => {
-    const { clear } = this.props;
     const { notifications } = this.state;
     return (
       <div>
@@ -109,21 +106,25 @@ export class Notifications extends React.Component<Props, State> {
           className="buttonDarkS smallMarginTop"
           onClick={this.clearNotifications}
         >
-          {clear}
+          {I18n.t('notifications.clear')}
         </button>
       </div>
     );
   };
 
   render() {
-    const { element, plural, none } = this.props;
+    const { element } = this.props;
     const { notifications, open, modalKey } = this.state;
     return (
       <Modal
         element={element}
         elementId="notificationsElement"
-        title={plural}
-        body={notifications.length ? this.displayNotifications() : none}
+        title={I18n.t('notifications.plural')}
+        body={
+          notifications.length
+            ? this.displayNotifications()
+            : I18n.t('notifications.none')
+        }
         openListener={this.fetchNotifications}
         open={open}
         key={modalKey}

--- a/client/app/widgets/Notifications/index.jsx
+++ b/client/app/widgets/Notifications/index.jsx
@@ -62,7 +62,7 @@ export class Notifications extends React.Component<Props, State> {
 
   fetchNotifications = () => {
     const { alreadyMounted, signedInKey } = this.state;
-    axios
+    return axios
       .get('/notifications/signed_in')
       .then((response: any) => {
         if (response && response.data && response.data.signed_in !== -1) {


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Contributor Blurb: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
  Join Our Slack: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review
]-->
# Description 

- Added tests for Notifications widget.
- Modified fetchNotifications function in Notifications widget to return promise (used for testing only).

## More Details

Test checks:
- Notification renders correctly.
- fetchNotifications updates state.notifications with data received from API.
- Clear button closes modal.
## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1159

# Test Coverage

✅ 
