### PR TITLE
Add bundle exec to build:i18n script in package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "ifme",
   "private": true,
   "scripts": {
-    "build:i18n": "rake react_on_rails:locale",
+    "build:i18n": "bundle exec rake react_on_rails:locale",
     "build:test": "NODE_ENV=test webpack --config webpack.config.js --display-error-details",
     "build:production": "yarn build:i18n && NODE_ENV=production webpack --config webpack.config.js",
     "build:development": "yarn build:i18n && NODE_ENV=development webpack -w --config webpack.config.js",


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

We have to add `bundle exec` to the `build:i18n` script in package.json because the Docker container in Circle CI is throwing the following issue:

```
yarn run v1.17.3
$ chmod +x ./.storybook/deploy.sh && ./.storybook/deploy.sh
Deploy changes to design.if-me.org
$ npm run build:i18n && build-storybook -c .storybook -o .out
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1570047847943-0.4082384902930616/node but npm is using /usr/local/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> ifme@ build:i18n /home/circleci/ifmeorg/ifme/client
> rake react_on_rails:locale

(in /home/circleci/ifmeorg/ifme)
rake aborted!
Gem::LoadError: You have already activated rake 12.3.2, but your Gemfile requires rake 12.3.3. Prepending `bundle exec` to your command may solve this.
/home/circleci/ifmeorg/ifme/config/boot.rb:5:in `<top (required)>'
/home/circleci/ifmeorg/ifme/config/application.rb:3:in `require_relative'
/home/circleci/ifmeorg/ifme/config/application.rb:3:in `<top (required)>'
/home/circleci/ifmeorg/ifme/Rakefile:7:in `<top (required)>'
(See full trace by running task with --trace)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ifme@ build:i18n: `rake react_on_rails:locale`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the ifme@ build:i18n script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/circleci/.npm/_logs/2019-10-02T20_24_08_474Z-debug.log
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
mv: cannot stat '.out': No such file or directory
$ /home/circleci/ifmeorg/ifme/client/node_modules/.bin/surge --project .public --domain design.if-me.org

   Running as join.ifme@gmail.com (Student)

   Aborted - No such file or directory: .public

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Exited with code 1
```

Tested manually in my local Docker environment and it works!
