### PR TITLE
Install rubocop-rails

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,8 @@ engines:
     enabled: false
   rubocop:
     enabled: true
-    channel: rubocop-0-67
+    config:
+      file: .rubocop.yml
 ratings:
   paths:
   - Gemfile.lock

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,8 +25,7 @@ engines:
     enabled: false
   rubocop:
     enabled: true
-    config:
-      file: .rubocop.yml
+    channel: rubocop-0-71
 ratings:
   paths:
   - Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
-require: rubocop-performance
-require: rubocop-rails
+require:
+  - rubocop-rails
+  - rubocop-performance
 
 AllCops:
   TargetRubyVersion: 2.6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require: rubocop-performance
+require: rubocop-rails
 
 AllCops:
   TargetRubyVersion: 2.6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Rails/InverseOf:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
+Rails/HelperInstanceVariable:
+  Enabled: false
+
 Style/MixinUsage:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ group :development, :test do
 
   gem 'rubocop', '>= 0.49.0'
   gem 'rubocop-performance'
+  gem 'rubocop-rails'
   gem 'rubocop-rspec'
 
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,6 +391,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.3.0)
       rubocop (>= 0.68.0)
+    rubocop-rails (2.0.1)
+      rack (>= 1.1)
+      rubocop (>= 0.70.0)
     rubocop-rspec (1.33.0)
       rubocop (>= 0.60.0)
     ruby-graphviz (1.2.4)
@@ -533,6 +536,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (>= 0.49.0)
   rubocop-performance
+  rubocop-rails
   rubocop-rspec
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.0, >= 5.0.6)


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

This PR installs [rubocop-rails](https://github.com/rubocop-hq/rubocop-rails) and adds it to the project's RuboCop config file. This was prompted by RuboCop's CLI output that warned of Rails-related cops being moved out of the base RuboCop gem in newer versions, so this is a future-proof effort! 😁

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
