### PR TITLE
resources/education:add link to resource page of BIC

### DIFF
--- a/doc/pages/education.json
+++ b/doc/pages/education.json
@@ -274,5 +274,11 @@
     "link": "https://www.forhers.com/blog",
     "tags": ["sexual_health", "women", "blog"],
     "languages": ["en"]
+  },
+  {
+    "name": "Benzodiazepine Information Coalition (Resources)",
+    "link": "https://www.benzoinfo.com/resources/",
+    "tags": ["books", "videos", "podcast", "blog", "learning", "physical_dependence"],
+    "languages": ["en"]
   }
 ]


### PR DESCRIPTION
# Description

Adding a link to the resource page of the Benzodiazepine Information Coalition