### PR TITLE
resource/communities:update link for CanvasoftheMinds (domain now ina…

### DIFF
--- a/doc/pages/communities.json
+++ b/doc/pages/communities.json
@@ -73,7 +73,7 @@
   },
   {
     "name": "A Canvas of the Minds",
-    "link": "https://acanvasoftheminds.com/",
+    "link": "https://acanvasoftheminds.wordpress.com/",
     "tags": ["free", "blog"],
     "languages": ["en"]
   },


### PR DESCRIPTION
# Description

The domain is no longer active, so changing the link to the wordpress hosted URL