### PR TITLE
resource/communities:fix if-me.org typo

### DIFF
--- a/doc/pages/communities.json
+++ b/doc/pages/communities.json
@@ -12,7 +12,7 @@
     "languages": ["en", "es"]
   },
   {
-    "name": "if-me.og",
+    "name": "if-me.org",
     "link": "https://www.if-me.org/",
     "tags": ["blog", "open_source", "directory", "goal_tracking", "mood_tracking", "journaling"],
     "languages": ["en", "es", "de", "fr", "it", "hi", "nb", "nl", "pt-BR", "sv", "vi"]


### PR DESCRIPTION
# Description

Corrects a teensy-weensy typo introduced at https://github.com/ifmeorg/ifme/commit/d8065dfff260787c32f82dca9c217b66eb648e8d#diff-5b4ce5fbd810c78508896d76a43dd01aR15