### PR TITLE
Fix bug with tagged posts count being inaccurate

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,9 +5,7 @@ class CategoriesController < ApplicationController
   include CategoriesHelper
   include Shared
   include TagsHelper
-  before_action :set_category, only: %i[show edit update destroy
-                                        tagged_moments_data
-                                        tagged_strategies_data]
+  before_action :set_category, only: %i[show edit update destroy]
   respond_to :json, only: [:index]
 
   # GET /categories
@@ -30,24 +28,6 @@ class CategoriesController < ApplicationController
   def show
     setup_stories
     redirect_to_path(categories_path) if @category.user_id != current_user.id
-  end
-
-  def tagged_moments_data
-    setup_stories
-    respond_to do |format|
-      format.json do
-        render json: tagged_moments_data_json if @moments
-      end
-    end
-  end
-
-  def tagged_strategies_data
-    setup_stories
-    respond_to do |format|
-      format.json do
-        render json: tagged_strategies_data_json if @strategies
-      end
-    end
   end
 
   # GET /categories/new

--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -5,8 +5,7 @@ class MoodsController < ApplicationController
   include CategoriesHelper
   include Shared
   include TagsHelper
-  before_action :set_mood, only: %i[show edit update destroy
-                                    tagged_moments_data]
+  before_action :set_mood, only: %i[show edit update destroy]
 
   # GET /moods
   # GET /moods.json
@@ -28,15 +27,6 @@ class MoodsController < ApplicationController
   def show
     setup_stories
     redirect_to_path(moods_path) if @mood.user_id != current_user.id
-  end
-
-  def tagged_moments_data
-    setup_stories
-    respond_to do |format|
-      format.json do
-        render json: tagged_moments_data_json if @moments
-      end
-    end
   end
 
   # GET /moods/new

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -8,8 +8,7 @@ class StrategiesController < ApplicationController
   include MomentsHelper
   include TagsHelper
 
-  before_action :set_strategy, only: %i[show edit update destroy
-                                        tagged_moments_data]
+  before_action :set_strategy, only: %i[show edit update destroy]
 
   # GET /strategies
   # GET /strategies.json
@@ -17,9 +16,8 @@ class StrategiesController < ApplicationController
     page_collection('@strategies', 'strategy')
     respond_to do |format|
       format.json do
-        render json:
-          { data: moments_or_strategy_props(@strategies),
-            lastPage: @strategies.last_page? }
+        render json: { data: moments_or_strategy_props(@strategies),
+                       lastPage: @strategies.last_page? }
       end
       format.html
     end
@@ -30,13 +28,6 @@ class StrategiesController < ApplicationController
   def show
     setup_stories
     show_with_comments(@strategy)
-  end
-
-  def tagged_moments_data
-    setup_stories
-    respond_to do |format|
-      format.json { render json: tagged_moments_data_json } if @moments
-    end
   end
 
   #  POST /strategies/quick_create
@@ -110,6 +101,15 @@ class StrategiesController < ApplicationController
   # DELETE /strategies/1.json
   def destroy
     shared_destroy(@strategy)
+  end
+
+  def tagged
+    setup_stories
+    respond_to do |format|
+      format.json do
+        render json: tagged_strategies_data_json if @strategies
+      end
+    end
   end
 
   private

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -13,6 +13,7 @@ module TagsHelper
   end
 
   def setup_stories
+    set_tags
     return unless viewable_tag?(@category) || viewable_tag?(@mood) ||
                   viewable_tag?(@strategy)
 
@@ -21,6 +22,12 @@ module TagsHelper
   end
 
   private
+
+  def set_tags
+    @category = Category.find(params[:category_id]) if params[:category_id]
+    @mood = Mood.find(params[:mood_id]) if params[:mood_id]
+    @strategy = Strategy.find(params[:strategy_id]) if params[:strategy_id]
+  end
 
   def fetch_moments
     data = get_tagged_data(

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -16,16 +16,32 @@ module TagsHelper
     return unless viewable_tag?(@category) || viewable_tag?(@mood) ||
                   viewable_tag?(@strategy)
 
-    @moments = get_tagged_data(
-      @category || @mood || @strategy,
-      User.find_by(id: current_user.id).moments.recent
-    )
-    @strategies = get_tagged_data(
-      @category, User.find_by(id: current_user.id).strategies.recent
-    )
+    @moments = fetch_moments
+    @strategies = fetch_strategies
   end
 
   private
+
+  def fetch_moments
+    data = get_tagged_data(
+      @category || @mood || @strategy,
+      User.find_by(id: current_user.id).moments.recent
+    )
+    return unless data
+
+    @total_moments = data[:total]
+    data[:posts]
+  end
+
+  def fetch_strategies
+    data = get_tagged_data(
+      @category, User.find_by(id: current_user.id).strategies.recent
+    )
+    return unless data
+
+    @total_strategies = data[:total]
+    data[:posts]
+  end
 
   def viewable_tag?(data)
     return false unless data&.respond_to?(:user_id)
@@ -35,6 +51,15 @@ module TagsHelper
         data.published?)
   end
 
+  def get_total(result)
+    total = 0
+    total_pages = Kaminari.paginate_array(result).page(1).total_pages
+    total_pages.times do |i|
+      total += Kaminari.paginate_array(result).page(i + 1).count
+    end
+    total
+  end
+
   def get_tagged_data(tag, data)
     return unless tag && data
 
@@ -42,6 +67,7 @@ module TagsHelper
     data.each do |d|
       result << d if d[tag.class.name.downcase].include?(tag.id)
     end
-    Kaminari.paginate_array(result).page(params[:page])
+    { total: get_total(result),
+      posts: Kaminari.paginate_array(result).page(params[:page]) }
   end
 end

--- a/app/views/tag_usage/_index.html.erb
+++ b/app/views/tag_usage/_index.html.erb
@@ -1,10 +1,10 @@
 <div class="smallMarginTop">
   <% if @moments&.any? %>
-    <h2 class="title"><%= t('moments.tagged_moments') %> (<%= @moments.count %>)</h2>
+    <h2 class="title"><%= t('moments.tagged_moments') %> (<%= @total_moments %>)</h2>
     <%= render partial: '/tag_usage/stories', locals: { data: @moments, data_type: 'moment' } %>
   <% end %>
   <% if !@strategies.nil? && @strategies.any? %>
-    <h2 class="title"><%= t('strategies.tagged_strategies') %> (<%= @strategies.count %>)</h2>
+    <h2 class="title"><%= t('strategies.tagged_strategies') %> (<%= @total_strategies %>)</h2>
     <%= render partial: '/tag_usage/stories', locals: { data: @strategies, data_type: 'strategy' } %>
   <% end %>
 </div>

--- a/app/views/tag_usage/_stories.html.erb
+++ b/app/views/tag_usage/_stories.html.erb
@@ -1,6 +1,6 @@
 <%= react_component('BaseContainer', props: {
   container: 'StoryContainer',
   data: moments_or_strategy_props(local_assigns[:data]),
-  fetchUrl: local_assigns[:data_type] == 'moment' ? moments_path : strategy_path,
+  fetchUrl: local_assigns[:data_type] == 'moment' ? tagged_moments_path(category_id: @category&.id, mood_id: @mood&.id, strategy_id: @strategy&.id) : tagged_strategies_path(category_id: @category&.id),
   lastPage: local_assigns[:data].last_page?
 }) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,6 @@ Rails.application.routes.draw do
     collection do
       post 'premade'
       post 'quick_create'
-      get 'tagged_moments_data', defaults: { format: 'json' }
     end
   end
 
@@ -35,13 +34,14 @@ Rails.application.routes.draw do
     collection do
       post 'premade'
       post 'quick_create'
-      get 'tagged_moments_data', defaults: { format: 'json' }
-      get 'tagged_strategies_data', defaults: { format: 'json' }
     end
   end
 
   resources :moments do
-    post 'picture', to: 'moments#picture', as: 'picture'
+    collection do
+      post 'picture', to: 'moments#picture', as: 'picture'
+      get 'tagged', defaults: { format: 'json' }
+    end
   end
 
   resources :secret_shares, only: %i[create show destroy]
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
     collection do
       post 'premade'
       post 'quick_create'
-      get 'tagged_moments_data', defaults: { format: 'json' }
+      get 'tagged', defaults: { format: 'json' }
     end
   end
 

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -56,54 +56,6 @@ RSpec.describe CategoriesController, type: :controller do
     end
   end
 
-  describe '#tagged_moments_data' do
-    let!(:moment) { create(:moment, user_id: user.id, category: [category.id]) }
-    context 'when the user is logged in' do
-      include_context :logged_in_user
-      before do
-        get :tagged_moments_data, params: { page: 1, id: category.id }, format: :json
-      end
-
-      it 'returns a response with the correct path' do
-        expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
-      end
-    end
-
-    context 'when the user is not logged in' do
-      before do
-        get :tagged_moments_data, params: { page: 1, id: category.id }, format: :json
-      end
-
-      it 'returns a no_content status' do
-        expect(response).to have_http_status(:no_content)
-      end
-    end
-  end
-
-  describe '#tagged_strategies_data' do
-    let!(:strategy) { create(:strategy, user_id: user.id, category: [category.id]) }
-    context 'when the user is logged in' do
-      include_context :logged_in_user
-      before do
-        get :tagged_strategies_data, params: { page: 1, id: category.id }, format: :json
-      end
-
-      it 'returns a response with the correct path' do
-        expect(JSON.parse(response.body)['data'].first['link']).to eq strategy_path(strategy)
-      end
-    end
-
-    context 'when the user is not logged in' do
-      before do
-        get :tagged_strategies_data, params: { page: 1, id: category.id }, format: :json
-      end
-
-      it 'returns a no_content status' do
-        expect(response).to have_http_status(:no_content)
-      end
-    end
-  end
-
   describe '#new' do
     context 'when the user is logged in' do
       include_context :logged_in_user

--- a/spec/controllers/moments_controller_spec.rb
+++ b/spec/controllers/moments_controller_spec.rb
@@ -1,93 +1,125 @@
 # frozen_string_literal: true
 
 describe MomentsController do
-  context 'when the user is signed in' do
-    let(:user) { create(:user) }
-    let(:moment) { build(:moment, user: user) }
+  let(:user) { create(:user) }
+  let(:moment) { build(:moment, user: user) }
+
+  describe '#index' do
+    before { sign_in user }
+
+    it 'renders template' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+
+    context 'when request type is JSON' do
+      let(:moment) { create(:moment, user: user) }
+      before { get :index, params: { page: 1, id: moment.id }, format: :json }
+      it 'returns a response with the correct path' do
+        expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
+      end
+    end
+  end
+
+  describe '#new' do
+    before { sign_in user }
+
+    it 'creates a new moment' do
+      get :new
+      expect(response).to render_template(:new)
+      expect { post :create, params: { moment: moment.attributes } }
+        .to(change(Moment, :count).by(1))
+    end
+  end
+
+  describe '#show' do
+    before { sign_in user }
+
+    it 'renders template' do
+      moment.save!
+      get :show, params: { id: moment.id }
+      expect(response).to render_template(:show)
+    end
+  end
+
+  describe '#create' do
+    let(:valid_moment_params) { attributes_for(:moment) }
 
     before { sign_in user }
 
-    describe '#index' do
-      it 'renders template' do
-        get :index
-        expect(response).to render_template(:index)
+    def post_create(moment_params)
+      post :create, params: { moment: moment_params }
+    end
+
+    context 'when valid params are supplied' do
+      it 'creates a moment' do
+        expect { post_create valid_moment_params }
+          .to change(Moment, :count).by(1)
       end
 
-      context 'when request type is JSON' do
-        let(:moment) { create(:moment, user: user) }
-        before { get :index, params: { page: 1, id: moment.id }, format: :json }
-        it 'returns a response with the correct path' do
-          expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
-        end
+      it 'has no validation errors' do
+        post_create valid_moment_params
+        expect(assigns(:moment).errors).to be_empty
+      end
+
+      it 'redirects to the moment page' do
+        post_create valid_moment_params
+        expect(response).to redirect_to moment_path(assigns(:moment))
       end
     end
 
-    describe '#new' do
-      it 'creates a new moment' do
-        get :new
+    context 'when invalid params are supplied' do
+      let(:invalid_moment_params) { valid_moment_params.merge(name: nil, why: nil) }
+
+      before { post_create invalid_moment_params }
+
+      it 're-renders the creation form' do
         expect(response).to render_template(:new)
-        expect { post :create, params: { moment: moment.attributes } }
-          .to(change(Moment, :count).by(1))
+      end
+
+      it 'adds errors to the moment ivar' do
+        expect(assigns(:moment).errors).not_to be_empty
       end
     end
 
-    describe '#show' do
-      it 'renders template' do
-        moment.save!
-        get :show, params: { id: moment.id }
-        expect(response).to render_template(:show)
+    context 'when the user_id is hacked' do
+      it 'creates a new moment, ignoring the user_id parameter' do
+        # passing a user_id isn't an error, but it shouldn't
+        # affect the owner of the created item
+        another_user = create(:user2)
+        hacked_moment_params =
+          valid_moment_params.merge(user_id: another_user.id)
+        expect { post_create hacked_moment_params }
+          .to change(Moment, :count).by(1)
+        expect(Moment.last.user_id).to eq(user.id)
+      end
+    end
+  end
+
+  describe '#tagged' do
+    let!(:category) { create(:category, user_id: user.id) }
+    let!(:mood) { create(:mood, user_id: user.id) }
+    let!(:strategy) { create(:strategy, user_id: user.id) }
+    let!(:moment) { create(:moment, user_id: user.id, category: [category.id], mood: [mood.id], strategy: [strategy.id]) }
+
+    context 'when the user is logged in' do
+      include_context :logged_in_user
+      before do
+        get :tagged, params: { page: 1, category_id: category.id, mood_id: mood.id, strategy_id: strategy.id }, format: :json
+      end
+
+      it 'returns a response with the correct path' do
+        expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
       end
     end
 
-    describe '#create' do
-      let(:valid_moment_params) { attributes_for(:moment) }
-
-      def post_create(moment_params)
-        post :create, params: { moment: moment_params }
+    context 'when the user is not logged in' do
+      before do
+        get :tagged, params: { page: 1, category_id: category.id, mood_id: mood.id, strategy_id: strategy.id }, format: :json
       end
 
-      context 'when valid params are supplied' do
-        it 'creates a moment' do
-          expect { post_create valid_moment_params }
-            .to change(Moment, :count).by(1)
-        end
-
-        it 'has no validation errors' do
-          post_create valid_moment_params
-          expect(assigns(:moment).errors).to be_empty
-        end
-
-        it 'redirects to the moment page' do
-          post_create valid_moment_params
-          expect(response).to redirect_to moment_path(assigns(:moment))
-        end
-      end
-
-      context 'when invalid params are supplied' do
-        let(:invalid_moment_params) { valid_moment_params.merge(name: nil, why: nil) }
-
-        before { post_create invalid_moment_params }
-
-        it 're-renders the creation form' do
-          expect(response).to render_template(:new)
-        end
-
-        it 'adds errors to the moment ivar' do
-          expect(assigns(:moment).errors).not_to be_empty
-        end
-      end
-
-      context 'when the user_id is hacked' do
-        it 'creates a new moment, ignoring the user_id parameter' do
-          # passing a useri_d isn't an error, but it shouldn't
-          # affect the owner of the created item
-          another_user = create(:user2)
-          hacked_moment_params =
-            valid_moment_params.merge(user_id: another_user.id)
-          expect { post_create hacked_moment_params }
-            .to change(Moment, :count).by(1)
-          expect(Moment.last.user_id).to eq(user.id)
-        end
+      it 'returns a no_content status' do
+        expect(response).to have_http_status(:no_content)
       end
     end
   end

--- a/spec/controllers/moods_controller_spec.rb
+++ b/spec/controllers/moods_controller_spec.rb
@@ -56,30 +56,6 @@ RSpec.describe MoodsController, type: :controller do
     end
   end
 
-  describe '#tagged_moments_data' do
-    let!(:moment) { create(:moment, user_id: user.id, mood: [user_mood.id]) }
-    context 'when the user is logged in' do
-      include_context :logged_in_user
-      before do
-        get :tagged_moments_data, params: { page: 1, id: user_mood.id }, format: :json
-      end
-
-      it 'returns a response with the correct path' do
-        expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
-      end
-    end
-
-    context 'when the user is not logged in' do
-      before do
-        get :tagged_moments_data, params: { page: 1, id: user_mood.id }, format: :json
-      end
-
-      it 'returns a no_content status' do
-        expect(response).to have_http_status(:no_content)
-      end
-    end
-  end
-
   describe '#new' do
     context 'when the user is logged in' do
       include_context :logged_in_user

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -63,7 +63,7 @@ describe PagesController, type: :controller do
     let!(:moment) { create(:moment, user: user) }
     context 'when the user is logged in' do
       include_context :logged_in_user
-      before { get :home_data, params: { page: 1, id: moment.id }, format: :json }
+      before { get :home_data, params: { page: 1 }, format: :json }
 
       it 'returns a response with the correct path' do
         expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
@@ -71,7 +71,7 @@ describe PagesController, type: :controller do
     end
 
     context 'when the user is not logged in' do
-      before { get :home_data, params: { page: 1, id: moment.id }, format: :json }
+      before { get :home_data, params: { page: 1 }, format: :json }
 
       it 'returns a no_content status' do
         expect(response).to have_http_status(:no_content)

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -63,7 +63,7 @@ describe ProfileController do
 
     context 'when the user is signed in' do
       include_context :logged_in_user
-      before { get :data, params: { page: 1, id: moment.id, uid: user.uid }, format: :json }
+      before { get :data, params: { page: 1, uid: user.uid }, format: :json }
 
       it 'returns a response with the correct path' do
         expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
@@ -71,7 +71,7 @@ describe ProfileController do
     end
 
     context 'when the user is not signed in' do
-      before { get :data, params: { page: 1, id: moment.id, uid: user.uid }, format: :json }
+      before { get :data, params: { page: 1, uid: user.uid }, format: :json }
 
       it 'returns a no_content status' do
         expect(response).to have_http_status(:no_content)

--- a/spec/controllers/strategies_controller_spec.rb
+++ b/spec/controllers/strategies_controller_spec.rb
@@ -80,30 +80,6 @@ describe StrategiesController do
     end
   end
 
-  describe '#tagged_moments_data' do
-    let!(:moment) { create(:moment, user_id: user.id, strategy: [strategy.id]) }
-    context 'when the user is logged in' do
-      include_context :logged_in_user
-      before do
-        get :tagged_moments_data, params: { page: 1, id: strategy.id }, format: :json
-      end
-
-      it 'returns a response with the correct path' do
-        expect(JSON.parse(response.body)['data'].first['link']).to eq moment_path(moment)
-      end
-    end
-
-    context 'when the user is not logged in' do
-      before do
-        get :tagged_moments_data, params: { page: 1, id: strategy.id }, format: :json
-      end
-
-      it 'returns a no_content status' do
-        expect(response).to have_http_status(:no_content)
-      end
-    end
-  end
-
   describe '#premade' do
     context 'when the user is logged in' do
       include_context :logged_in_user
@@ -345,6 +321,32 @@ describe StrategiesController do
             'Daily reminder email</div>'
           )
         )
+      end
+    end
+  end
+
+  describe '#tagged' do
+    let!(:category) { create(:category, user_id: user.id) }
+    let!(:strategy) { create(:strategy, user_id: user.id, category: [category.id]) }
+
+    context 'when the user is logged in' do
+      include_context :logged_in_user
+      before do
+        get :tagged, params: { page: 1, category_id: category.id }, format: :json
+      end
+
+      it 'returns a response with the correct path' do
+        expect(JSON.parse(response.body)['data'].first['link']).to eq strategy_path(strategy)
+      end
+    end
+
+    context 'when the user is not logged in' do
+      before do
+        get :tagged, params: { page: 1, category_id: category.id }, format: :json
+      end
+
+      it 'returns a no_content status' do
+        expect(response).to have_http_status(:no_content)
       end
     end
   end

--- a/spec/helpers/tags_helper_spec.rb
+++ b/spec/helpers/tags_helper_spec.rb
@@ -9,8 +9,8 @@ describe TagsHelper do
     it 'is looking for categories tagged nowhere' do
       @category = create(:category, user_id: user1.id)
       setup_stories
-      expect(@moments.length).to eq(0)
-      expect(@strategies.length).to eq(0)
+      expect(@moments.length).to eq(@total_moments)
+      expect(@strategies.length).to eq(@total_strategies)
     end
 
     it 'is looking for categories tagged in moments and strategies' do
@@ -18,8 +18,8 @@ describe TagsHelper do
       create(:moment, user_id: user1.id, category: Array.new(1, @category.id))
       create(:strategy, user_id: user1.id, category: Array.new(1, @category.id))
       setup_stories
-      expect(@moments.length).to eq(1)
-      expect(@strategies.length).to eq(1)
+      expect(@moments.length).to eq(@total_moments)
+      expect(@strategies.length).to eq(@total_strategies)
     end
 
     it 'is looking for moods tagged nowhere' do
@@ -33,14 +33,14 @@ describe TagsHelper do
       @mood = create(:mood, user_id: user1.id)
       create(:moment, user_id: user1.id, mood: Array.new(1, @mood.id))
       setup_stories
-      expect(@moments.length).to eq(1)
+      expect(@moments.length).to eq(@total_moments)
       expect(@strategies).to eq(nil)
     end
 
     it 'is looking for strategies tagged nowhere' do
       @strategy = create(:strategy, user_id: user1.id)
       setup_stories
-      expect(@moments.length).to eq(0)
+      expect(@moments.length).to eq(@total_moments)
       expect(@strategies).to eq(nil)
     end
 
@@ -48,7 +48,7 @@ describe TagsHelper do
       @strategy = create(:strategy, user_id: user1.id)
       create(:moment, user_id: user1.id, strategy: Array.new(1, @strategy.id))
       setup_stories
-      expect(@moments.length).to eq(1)
+      expect(@moments.length).to eq(@total_moments)
       expect(@strategies).to eq(nil)
     end
   end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

After merging in a [PR that refactor tag_usage partial to use BaseContainer component](https://github.com/ifmeorg/ifme/pull/1644), I realized that the counter displaying the number of tagged posts displays the number of posts on the first page of the paginated data. It should be getting the sum of all the posts on every page.

This PR fixes that and also simplifies `tagged_moments` and `tagged_strategies` to be used in MomentsController and StrategiesController respectively.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
