### PR TITLE
Automatically generate refill dates

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -50,6 +50,20 @@ class MedicationsController < ApplicationController
   def create
     @medication =
       Medication.new(medication_params.merge(user_id: current_user.id))
+    b = @medication.refill.nil?
+    if b
+      time = Time.now.strftime("%d/%m/%Y")
+      total = @medication.total
+      dosage = @medication.dosage
+      days_of_week = @medication.weekly_dosage
+      no_of_days = total/dosage
+      no_of_weeks = no_of_days / days_of_week.length
+      rem = no_of_days % days_of_week.length
+      days = 7*(no_of_weeks)
+      days += rem
+      date = time.to_date + days-1
+      @medication.refill = date
+    end
     return unless save_refill_to_google_calendar(@medication)
 
     if @medication.save

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -48,8 +48,15 @@ class MedicationsController < ApplicationController
   # POST /medications
   # POST /medications.json
   def create
-    @medication = Medication.new(medication_params.merge(user_id: current_user.id))
-    @medication.refill = @medication.refill.nil? ? Time.zone.now.strftime("%d/%m/%Y").to_date + 7 * ((@medication.total / @medication.dosage) / @medication.weekly_dosage.length) + ((@medication.total / @medication.dosage) % @medication.weekly_dosage.length) - 1 : @medication.refill
+    @medication =
+    Medication.new(medication_params.merge(user_id: current_user.id))
+    @medication.refill = @medication.refill.nil? ?
+    Time.zone.now.strftime('%d/%m/%Y').to_date +
+    7 * ((@medication.total / @medication.dosage)
+    / @medication.weekly_dosage.length) +
+    ((@medication.total / @medication.dosage)
+    % @medication.weekly_dosage.length) - 1
+    : @medication.refill
     return unless save_refill_to_google_calendar(@medication)
 
     if @medication.save

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -52,16 +52,16 @@ class MedicationsController < ApplicationController
       Medication.new(medication_params.merge(user_id: current_user.id))
     b = @medication.refill.nil?
     if b
-      time = Time.now.strftime("%d/%m/%Y")
+      time = Time.now.strftime('%d/%m/%Y')
       total = @medication.total
       dosage = @medication.dosage
       days_of_week = @medication.weekly_dosage
-      no_of_days = total/dosage
+      no_of_days = total / dosage
       no_of_weeks = no_of_days / days_of_week.length
       rem = no_of_days % days_of_week.length
-      days = 7*(no_of_weeks)
+      days = 7 * no_of_weeks
       days += rem
-      date = time.to_date + days-1
+      date = time.to_date + days - 1
       @medication.refill = date
     end
     return unless save_refill_to_google_calendar(@medication)

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -48,22 +48,8 @@ class MedicationsController < ApplicationController
   # POST /medications
   # POST /medications.json
   def create
-    @medication =
-      Medication.new(medication_params.merge(user_id: current_user.id))
-    b = @medication.refill.nil?
-    if b
-      time = Time.now.strftime('%d/%m/%Y')
-      total = @medication.total
-      dosage = @medication.dosage
-      days_of_week = @medication.weekly_dosage
-      no_of_days = total / dosage
-      no_of_weeks = no_of_days / days_of_week.length
-      rem = no_of_days % days_of_week.length
-      days = 7 * no_of_weeks
-      days += rem
-      date = time.to_date + days - 1
-      @medication.refill = date
-    end
+    @medication = Medication.new(medication_params.merge(user_id: current_user.id))
+    @medication.refill = @medication.refill.nil? ? Time.zone.now.strftime("%d/%m/%Y").to_date + 7 * ((@medication.total / @medication.dosage) / @medication.weekly_dosage.length) + ((@medication.total / @medication.dosage) % @medication.weekly_dosage.length) - 1 : @medication.refill
     return unless save_refill_to_google_calendar(@medication)
 
     if @medication.save


### PR DESCRIPTION
# Description

Added feature to automatically fill in medication refill date, if not specified.
In this example, refill date is not filled in by the user. So it defaults to the second-last day of the dosage.
Here, the date is explicitly specified by the user, so it remains as it is.

## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1638

# Screenshots
![image](https://user-images.githubusercontent.com/43354059/73609013-7c1d0b80-45ef-11ea-8cc1-e3fd5c8b35d3.png)

In this example, refill date is not filled in by the user. So it defaults to the second-last day of the dosage.
![image](https://user-images.githubusercontent.com/43354059/73609027-90610880-45ef-11ea-87d6-8149196cad7e.png)

![image](https://user-images.githubusercontent.com/43354059/73609031-9820ad00-45ef-11ea-8d99-47235bab3450.png)

Here, the date is explicitly specified by the user, so it remains as it is.

![image](https://user-images.githubusercontent.com/43354059/73609034-a4a50580-45ef-11ea-9116-3c2494ff7ad4.png)



