### PR TITLE
Automatically Generate Refill Date

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -46,15 +46,16 @@ class MedicationsController < ApplicationController
   end
 
   def add_refill(medication)
-    return medication[:refill] unless medication[:refill].empty?
+    return medication[:refill] if medication[:refill].present?
 
-    time = Time.zone.now.strftime('%d/%m/%Y')
-    weekly_dosage = medication[:weekly_dosage] || [0, 1, 2, 3, 4, 5, 6]
-    no_of_days = medication[:total].to_i / medication[:dosage].to_i
+    weekly_dosage = @medication&.weekly_dosage ||
+                    medication[:weekly_dosage] || [0, 1, 2, 3, 4, 5, 6]
+    total = @medication&.total || medication[:total]
+    dosage = @medication&.dosage || medication[:dosage]
+    no_of_days = total.to_i / dosage.to_i
     no_of_weeks = no_of_days.to_i / weekly_dosage.length
-    rem = no_of_days % weekly_dosage.length
-    days = 7 * no_of_weeks + rem
-    time.to_date + days - 1
+    days = 7 * no_of_weeks + (no_of_days % weekly_dosage.length)
+    Time.zone.now.strftime('%d/%m/%Y').to_date + days - 1
   end
 
   # POST /medications
@@ -78,7 +79,9 @@ class MedicationsController < ApplicationController
   def update
     return unless save_refill_to_google_calendar(@medication)
 
-    if @medication.update(medication_params)
+    if @medication.update(medication_params.merge(
+                            refill: add_refill(medication_params)
+                          ))
       redirect_to_medication(@medication)
     else
       render_unprocessable_medication
@@ -107,8 +110,7 @@ class MedicationsController < ApplicationController
     respond_to do |format|
       format.html { render :new }
       format.json do
-        render(json: @medication.errors,
-               status: :unprocessable_entity)
+        render(json: @medication.errors, status: :unprocessable_entity)
       end
     end
   end
@@ -122,8 +124,7 @@ class MedicationsController < ApplicationController
 
   def medication_params
     params.require(:medication).permit(
-      :name, :dosage, :refill,
-      :total, :strength,
+      :name, :dosage, :refill, :total, :strength,
       :dosage_unit, :total_unit, :strength_unit,
       :comments, :add_to_google_cal,
       take_medication_reminder_attributes: %i[active id],

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -45,11 +45,24 @@ class MedicationsController < ApplicationController
     redirect_to_medication(@medication)
   end
 
+  def add_refill(medicine)
+    if medicine.refill.nil?
+      time = Time.zone.now.strftime('%d/%m/%Y')
+      no_of_days = medicine.total / medicine.dosage
+      no_of_weeks = no_of_days / medicine.weekly_dosage.length
+      rem = no_of_days % medicine.weekly_dosage.length
+      days = 7 * no_of_weeks + rem
+      return time.to_date + days - 1
+    end
+    medicine.refill
+  end
+
   # POST /medications
   # POST /medications.json
   def create
     @medication =
       Medication.new(medication_params.merge(user_id: current_user.id))
+    @medication.refill = add_refill(@medication)
     return unless save_refill_to_google_calendar(@medication)
 
     if @medication.save

--- a/app/helpers/medications_form_helper.rb
+++ b/app/helpers/medications_form_helper.rb
@@ -146,7 +146,7 @@ module MedicationsFormHelper
       label: t('medications.form.refill'),
       value: @medication.refill&.to_date || nil,
       info: t('medications.form.refill_hint'),
-      required: true
+      required: false
     }.merge(medication_basic_props('refill'))
   end
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,7 +14,7 @@
         <%= t('devise.remember_me') %>
       </div>
     <% end -%>
-
+    
     <%= f.submit t('account.sign_in'), class: 'buttonGhostM smallMarginTop' %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,7 +14,6 @@
         <%= t('devise.remember_me') %>
       </div>
     <% end -%>
-    
     <%= f.submit t('account.sign_in'), class: 'buttonGhostM smallMarginTop' %>
   </div>
 <% end %>

--- a/client/app/components/Story/StoryMedication.jsx
+++ b/client/app/components/Story/StoryMedication.jsx
@@ -11,13 +11,12 @@ export type Props = {
   medicationRefill?: string,
 };
 
-const medicDosage = (medicationDosages: Object) => {
-  const {
-    isDaily,
-    dosageDaily,
-    dosageWeekly,
-    weeklyDosageMap,
-  } = medicationDosages;
+const medicDosage = ({
+  isDaily,
+  dosageDaily,
+  dosageWeekly,
+  weeklyDosageMap,
+}: Object) => {
   if (isDaily) {
     return <strong>{dosageDaily}</strong>;
   }
@@ -30,44 +29,37 @@ const medicDosage = (medicationDosages: Object) => {
   );
 };
 
-const displayStrength = (medicationStrength: Object) => {
-  const { strength, strengthUnits } = medicationStrength;
-  return (
-    <div>
-      <strong>{strength}</strong>
-      {' '}
-      {strengthUnits}
-    </div>
-  );
-};
+const displayStrength = ({ strength, strengthUnits }: Object) => (
+  <div>
+    <strong>{strength}</strong>
+    {' '}
+    {strengthUnits}
+  </div>
+);
 
-export const StoryMedication = (props: Props) => {
-  const {
-    medicationStrength,
-    quantity,
-    totalUnits,
-    medicationDosages,
-    dosageUnit,
-    refill,
-    medicationRefill,
-  } = props;
-
-  return (
+export const StoryMedication = ({
+  medicationStrength,
+  quantity,
+  totalUnits,
+  medicationDosages,
+  dosageUnit,
+  refill,
+  medicationRefill,
+}: Props) => (
+  <div>
+    {displayStrength(medicationStrength)}
     <div>
-      {displayStrength(medicationStrength)}
-      <div>
-        <strong>{quantity}</strong>
-        {' '}
-        {totalUnits}
-      </div>
-      {medicDosage(medicationDosages)}
+      <strong>{quantity}</strong>
       {' '}
-      {dosageUnit}
-      <div>
-        <strong>{refill}</strong>
-        {' '}
-        {medicationRefill}
-      </div>
+      {totalUnits}
     </div>
-  );
-};
+    {medicDosage(medicationDosages)}
+    {' '}
+    {dosageUnit}
+    <div>
+      <strong>{refill}</strong>
+      {' '}
+      {medicationRefill}
+    </div>
+  </div>
+);

--- a/client/app/components/Story/StoryMedication.jsx
+++ b/client/app/components/Story/StoryMedication.jsx
@@ -23,8 +23,7 @@ const medicDosage = (medicationDosages: Object) => {
   }
   return (
     <div>
-      <strong>{dosageWeekly}</strong>
-      {weeklyDosageMap}
+      <strong>{dosageWeekly}</strong> {weeklyDosageMap}
     </div>
   );
 };
@@ -33,8 +32,7 @@ const displayStrength = (medicationStrength: Object) => {
   const { strength, strengthUnits } = medicationStrength;
   return (
     <div>
-      <strong>{strength}</strong>
-      {strengthUnits}
+      <strong>{strength}</strong> {strengthUnits}
     </div>
   );
 };
@@ -54,14 +52,11 @@ export const StoryMedication = (props: Props) => {
     <div>
       {displayStrength(medicationStrength)}
       <div>
-        <strong>{quantity}</strong>
-        {totalUnits}
+        <strong>{quantity}</strong> {totalUnits}
       </div>
-      {medicDosage(medicationDosages)}
-      {dosageUnit}
+      {medicDosage(medicationDosages)} {dosageUnit}
       <div>
-        <strong>{refill}</strong>
-        {medicationRefill}
+        <strong>{refill}</strong> {medicationRefill}
       </div>
     </div>
   );

--- a/client/app/components/Story/StoryMedication.jsx
+++ b/client/app/components/Story/StoryMedication.jsx
@@ -23,7 +23,9 @@ const medicDosage = (medicationDosages: Object) => {
   }
   return (
     <div>
-      <strong>{dosageWeekly}</strong> {weeklyDosageMap}
+      <strong>{dosageWeekly}</strong>
+      {' '}
+      {weeklyDosageMap}
     </div>
   );
 };
@@ -32,7 +34,9 @@ const displayStrength = (medicationStrength: Object) => {
   const { strength, strengthUnits } = medicationStrength;
   return (
     <div>
-      <strong>{strength}</strong> {strengthUnits}
+      <strong>{strength}</strong>
+      {' '}
+      {strengthUnits}
     </div>
   );
 };
@@ -52,11 +56,17 @@ export const StoryMedication = (props: Props) => {
     <div>
       {displayStrength(medicationStrength)}
       <div>
-        <strong>{quantity}</strong> {totalUnits}
+        <strong>{quantity}</strong>
+        {' '}
+        {totalUnits}
       </div>
-      {medicDosage(medicationDosages)} {dosageUnit}
+      {medicDosage(medicationDosages)}
+      {' '}
+      {dosageUnit}
       <div>
-        <strong>{refill}</strong> {medicationRefill}
+        <strong>{refill}</strong>
+        {' '}
+        {medicationRefill}
       </div>
     </div>
   );

--- a/spec/controllers/medications_controller_spec.rb
+++ b/spec/controllers/medications_controller_spec.rb
@@ -1,78 +1,61 @@
 # frozen_string_literal: true
-
 describe MedicationsController do
   describe '#print_reminders' do
     let(:user) { FactoryBot.create(:user1) }
-
     subject { controller.print_reminders(medication) }
-
     describe 'when medication has no reminders' do
       let(:medication) { FactoryBot.create(:medication, user_id: user.id) }
-
       it 'is empty' do
         expect(subject).to eq('')
       end
     end
-
     describe 'when medication has refill reminder' do
       let(:medication) { FactoryBot.create(:medication, :with_refill_reminder, user_id: user.id) }
-
       it 'prints the reminder' do
         expect(subject).to eq('<div><i class="fa fa-bell smallMarginRight"></i>Refill reminder email</div>')
       end
     end
-
     describe 'when medication has daily reminder' do
       let(:medication) { FactoryBot.create(:medication, :with_daily_reminder, user_id: user.id) }
-
       it 'prints the reminders' do
         expect(subject).to eq('<div><i class="fa fa-bell smallMarginRight"></i>Daily reminder email</div>')
       end
     end
-
     describe 'when medication has both reminders' do
       let(:medication) { FactoryBot.create(:medication, :with_both_reminders, user_id: user.id) }
-
       it 'prints the reminders' do
         expect(subject).to eq('<div><i class="fa fa-bell smallMarginRight"></i>Refill reminder email, Daily reminder email</div>')
       end
     end
-
     describe 'DELETE #destroy' do
       let(:user) { create(:user) }
       let!(:medication) { create(:medication, user: user) }
-
       context 'when the user is logged in' do
         include_context :logged_in_user
         it 'deletes the medication' do
           expect { delete :destroy, params: { id: medication.id } }
             .to change(Medication, :count).by(-1)
         end
-
         it 'redirects to the medications index page' do
           delete :destroy, params: { id: medication.id }
           expect(response).to redirect_to medications_path
         end
       end
-
       context 'when the user is not logged in' do
         before { delete :destroy, params: { id: medication.id } }
         it_behaves_like :with_no_logged_in_user
       end
     end
   end
-
   describe 'GET #index' do
     let(:user) { create(:user) }
     let!(:medication) { create(:medication, user: user) }
-
     context 'when signed in' do
       before { sign_in user }
       it 'renders index page' do
         get :index
         expect(response).to render_template(:index)
       end
-
       context 'when request type is JSON' do
         before { get :index, params: { page: 1, id: medication.id }, format: :json }
         it 'returns a response with the correct path' do
@@ -85,11 +68,9 @@ describe MedicationsController do
       it_behaves_like :with_no_logged_in_user
     end
   end
-
   describe 'GET #new' do
     let(:user) { create(:user) }
     let(:medication) { create(:medication, user: user) }
-
     context 'when signed in' do
       before { sign_in user }
       it 'renders the new page' do
@@ -97,17 +78,14 @@ describe MedicationsController do
         expect(response).to render_template(:new)
       end
     end
-
     context 'when not signed in' do
       before { get :new }
       it_behaves_like :with_no_logged_in_user
     end
   end
-
   describe 'GET #show' do
     let(:user) { create(:user) }
     let(:medication) { create(:medication, user: user) }
-
     context 'when signed in' do
       before { sign_in user }
       it 'render the show page' do
@@ -116,33 +94,30 @@ describe MedicationsController do
         expect(response).to render_template(:show)
       end
     end
-
     context 'when not signed in' do
       before { get :show, params: { id: medication.id } }
       it_behaves_like :with_no_logged_in_user
     end
   end
-
   describe 'POST #create' do
     let(:user) { create(:user1) }
     let(:valid_medication_params) { attributes_for(:medication) }
-
     def post_create(medication_params)
       post :create, params: { medication: medication_params }
     end
-
     context 'when the user is logged in' do
       include_context :logged_in_user
-
       context 'when valid params are supplied' do
         it 'creates a medication' do
           expect { post_create valid_medication_params }
             .to change(Medication, :count).by(1)
         end
-
         it 'has no validation errors' do
           post_create valid_medication_params
           expect(assigns(:medication).errors).to be_empty
+
+          expect(assigns(:medication)[:refill]).to be_between(assigns(:medication)[:created_at].to_date,
+            ((7 * assigns(:medication)[:total]) / (assigns(:medication)[:dosage] * assigns(:medication)[:weekly_dosage].count)).days.from_now)
         end
 
         it 'redirects to the medication page' do
@@ -150,21 +125,16 @@ describe MedicationsController do
           expect(response).to redirect_to medication_path(assigns(:medication))
         end
       end
-
       context 'when invalid params are supplied' do
         let(:invalid_medication_params) { valid_medication_params.merge(name: nil, dosage: nil) }
-
         before { post_create invalid_medication_params }
-
         it 're-renders the creation form' do
           expect(response).to render_template(:new)
         end
-
         it 'adds errors to the medication ivar' do
           expect(assigns(:medication).errors).not_to be_empty
         end
       end
-
       context 'when the user_id is hacked' do
         it 'creates a new medication, ignoring the user_id parameter' do
           # passing a user_id isn't an error, but it shouldn't
@@ -178,7 +148,6 @@ describe MedicationsController do
         end
       end
     end
-
     context 'when the user is not logged in' do
       before { post :create }
       it_behaves_like :with_no_logged_in_user

--- a/spec/controllers/medications_controller_spec.rb
+++ b/spec/controllers/medications_controller_spec.rb
@@ -139,11 +139,21 @@ describe MedicationsController do
             .to change(Medication, :count).by(1)
         end
 
-        it 'has no validation errors' do
-          post_create valid_medication_params
-          expect(assigns(:medication).errors).to be_empty
-          expect(assigns(:medication)[:refill]).to be_between(assigns(:medication)[:created_at].to_date,
-            ((7 * assigns(:medication)[:total]) / (assigns(:medication)[:dosage] * assigns(:medication)[:weekly_dosage].count)).days.from_now)
+        context 'when refill exists' do
+          it 'has no validation errors and has correct refill' do
+            post_create valid_medication_params
+            expect(assigns(:medication).errors).to be_empty
+            expect(assigns(:medication)[:refill]).to be(assigns(:medication).refill)
+          end
+        end
+
+        context 'when refill does not exist' do
+          it 'has no validation errors and uses auto-generated refill' do
+            post_create valid_medication_params.merge(refill: nil)
+            expect(assigns(:medication).errors).to be_empty
+            expect(assigns(:medication)[:refill]).to be_between(assigns(:medication)[:created_at].to_date,
+              ((7 * assigns(:medication)[:total]) / (assigns(:medication)[:dosage] * assigns(:medication)[:weekly_dosage].count)).days.from_now)
+          end
         end
 
         it 'redirects to the medication page' do


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description
Added feature to automatically fill in medication refill date, if not specified.
<!--[A few sentences describing your changes]-->

## More Details

<!--[More details on your changes, remove if not applicable]-->

## Corresponding Issue
#1638 



<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

# Screenshots

![Screenshot from 2020-02-02 11-34-43](https://user-images.githubusercontent.com/32172764/73668585-13f02780-46cc-11ea-8cd8-a10d32145882.png)

In this example, refill date is not filled in by the user. So it defaults to the second-last day of the dosage.

![Screenshot from 2020-02-02 11-35-39](https://user-images.githubusercontent.com/32172764/73668604-1a7e9f00-46cc-11ea-9c79-d249b3320d0a.png)


<br><br><br>
![Screenshot from 2020-02-02 11-38-33](https://user-images.githubusercontent.com/32172764/73668754-574a9600-46cc-11ea-9778-fc0d7f53b00f.png)

Here, the date is explicitly specified by the user, so it remains as it is.

![Screenshot from 2020-02-02 11-39-03](https://user-images.githubusercontent.com/32172764/73668769-5d407700-46cc-11ea-9f4e-130239a2426b.png)


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
