### PR TITLE
Profile index cleanup

### DIFF
--- a/app/helpers/moments_helper.rb
+++ b/app/helpers/moments_helper.rb
@@ -77,11 +77,11 @@ module MomentsHelper
   def story_by(element)
     {
       author: link_to(
-        User.find(element.user_id).name,
-        profile_index_path(uid: User.find_by(id: element.user_id).uid)
+        element.user.name,
+        profile_index_path(uid: element.user.uid)
       ),
       avatar: ProfilePicture.normalize_url(
-        User.find(element.user_id).avatar.url
+        element.user.avatar.url
       )
     }
   end

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -13,7 +13,11 @@ module ProfileHelper
   end
 
   def setup_stories
-    @profile = current_user.uid == params[:uid] ? current_user : User.find_by(uid: params[:uid])
+    if current_user.uid == params[:uid]
+      @profile = current_user
+    else
+      @profile = User.find_by(uid: params[:uid])
+    end
 
     return unless @profile == current_user ||
                   current_user.mutual_allies?(@profile)

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -13,11 +13,11 @@ module ProfileHelper
   end
 
   def setup_stories
-    if current_user.uid == params[:uid]
-      @profile = current_user
-    else
-      @profile = User.find_by(uid: params[:uid])
-    end
+    @profile = if current_user.uid == params[:uid]
+                 current_user
+               else
+                 User.find_by(uid: params[:uid])
+               end
 
     return unless @profile == current_user ||
                   current_user.mutual_allies?(@profile)

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -13,7 +13,8 @@ module ProfileHelper
   end
 
   def setup_stories
-    @profile = User.find_by(uid: params[:uid])
+    @profile = current_user.uid == params[:uid] ? current_user : User.find_by(uid: params[:uid])
+
     return unless @profile == current_user ||
                   current_user.mutual_allies?(@profile)
 

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -12,9 +12,9 @@
         <%= link_to t('profile.index.edit_user'), edit_user_registration_path %>
       </div>
     <% end %>
-    <% if User.where(id: @profile.id).first.location.present? %>
+    <% if @profile.location.present? %>
       <div>
-        <i class="fa fa-location-arrow fa-inline smallMarginRight"></i><%= User.where(id: @profile.id).first.location %>
+        <i class="fa fa-location-arrow fa-inline smallMarginRight"></i><%= @profile.location %>
       </div>
     <% end %>
     <% if @profile.id != current_user.id %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,6 +1,6 @@
 <% if %w[category mood strategy].include?(local_assigns[:data_type]) %>
   <% most_focus_data = most_focus(local_assigns[:data_type], local_assigns[:user]) %>
-	<% if most_focus_data.present? %>
+  <% if most_focus_data.present? %>
     <div class="stats">
       <% if local_assigns[:user] %>
         <div class="title">
@@ -19,7 +19,7 @@
           <div class="someFocus">
             <div class="someFocusText">
               <% if local_assigns[:data_type] == 'category' && local_assigns[:user] == current_user %>
-                <%= viewers_hover(get_viewers_for(Category.where(id: key).first, 'category'), Category.where(id: key).first) %>
+                <%= viewers_hover(get_viewers_for(Category.find(key), 'category'), Category.find(key)) %>
               <% elsif local_assigns[:data_type] == 'category' && local_assigns[:user] %>
                 <div class="someFocusTextName">
                   <%= Category.find_by(id: key).name %>
@@ -42,7 +42,7 @@
         <% end %>
       </div>
     </div>
-	<% end %>
+  <% end %>
 <% elsif local_assigns[:data_type] == 'moment' %>
-	<%= sanitize(moments_stats) %>
+  <%= sanitize(moments_stats) %>
 <% end %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -11,7 +11,7 @@
         <% if local_assigns[:user] == current_user %>
           <%= t('shared.stats.you_are_focusing') %>
         <% elsif local_assigns[:user] %>
-          <%= t('shared.stats.user_is_focusing', name: User.where(id: local_assigns[:user]).first.name) %>
+          <%= t('shared.stats.user_is_focusing', name: local_assigns[:user].name) %>
         <% end %>
       </div>
       <div class="mostFocus">
@@ -31,10 +31,10 @@
                   <%= Mood.find_by(id: key).name %>
                 </div>
               <% elsif local_assigns[:data_type] == 'strategy' && local_assigns[:user] == current_user %>
-                <%= viewers_hover(get_viewers_for(Strategy.where(id: key).first, 'strategy'), Strategy.where(id: key).first) %>
+                <%= viewers_hover(get_viewers_for(Strategy.find(key), 'strategy'), Strategy.find(key)) %>
               <% elsif local_assigns[:data_type] == 'strategy' && local_assigns[:user] %>
                 <div class="someFocusTextName">
-                  <%= Strategy.find_by(id: key).name %>
+                  <%= Strategy.find(key).name %>
                 </div>
               <% end %>
             </div>


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description
I noticed the the Profile page does some extra querying when it already has the data it needs. For instance, the profile user gets re-queried a few times. 

This PR is mainly for quick wins: replacing some queries with already provided objects. I see that the stats partial is a little more in depth. I'd like to make a separate PR for that because it involves providing some instance variables from the controller.

## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1660

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
