### PR TITLE
[#1548]  Locale bug fix

### DIFF
--- a/spec/features/toggle_locale_spec.rb
+++ b/spec/features/toggle_locale_spec.rb
@@ -32,9 +32,7 @@ describe 'ToggleLocale', js: true do
 
         change_page(
           lambda {
-            within '.footer' do
-              click_link('Acerca de')
-            end
+            visit about_path
           },
           '.pageTitle',
           have_content('Acerca de')

--- a/spec/support/page_transition_support.rb
+++ b/spec/support/page_transition_support.rb
@@ -12,12 +12,7 @@ module PageTransitionSupport
 
   def change_page(trigger, check_for_element, condition = be_present)
     trigger.call
-    begin
-      expect(find(check_for_element, wait: 10)).to condition
-    rescue Capybara::ElementNotFound => e
-      print page.html
-      raise e
-    end
+    expect(find(check_for_element, wait: 10)).to condition
   end
 end
 

--- a/spec/support/page_transition_support.rb
+++ b/spec/support/page_transition_support.rb
@@ -12,7 +12,12 @@ module PageTransitionSupport
 
   def change_page(trigger, check_for_element, condition = be_present)
     trigger.call
-    expect(find(check_for_element, wait: 10)).to condition
+    begin
+      expect(find(check_for_element, wait: 10)).to condition
+    rescue Capybara::ElementNotFound => e
+      print page.html
+      raise e
+    end
   end
 end
 


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description
OK I have a much better (but not complete) idea of what's going on:
The flakey test is triggered by Capybara seeing the About link in the footer and attempting to click on it, but nothing happens. It can find the element (it would raise an error otherwise), but every so often the wait time is exceeded on page load and clicking does nothing. The root page doesn't have the pageTitle class, which is why it fails.

The test is not based on the randomization of other tests around it, either. I've run it in isolation about 100+ times and maybe 5-10% of them fail.

My solution here is to avoid the About link clicking and instead navigate to the About page. The thing being tested (persistent locale) is still valid. If there are any other tests that flake out like this (can't find pageTitle class), then I think this is a suitable workaround.

## Corresponding Issue
https://github.com/ifmeorg/ifme/issues/1548
---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
