### PR TITLE
[#1671] expand when pre checked

### DIFF
--- a/client/app/widgets/QuickCreate/index.jsx
+++ b/client/app/widgets/QuickCreate/index.jsx
@@ -45,7 +45,7 @@ export class QuickCreate extends React.Component<Props, State> {
     this.state = {
       checkboxes: sortAlpha(props.checkboxes),
       open: false,
-      accordionOpen: false,
+      accordionOpen: props.checkboxes.some((cb) => cb.checked),
     };
   }
 

--- a/spec/features/user_creates_a_draft_moment_spec.rb
+++ b/spec/features/user_creates_a_draft_moment_spec.rb
@@ -116,21 +116,18 @@ describe 'UserCreatesADraftMoment', js: true do
       expect(find('.pageTitle')).to have_content 'Edit My New Moment'
 
       within('#moment_category_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Category'
         expect(page).to have_content 'Some New Category'
         find('.accordion').click
       end
 
       within('#moment_mood_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Mood'
         expect(page).to have_content 'Some New Mood'
         find('.accordion').click
       end
 
       within('#moment_strategy_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Strategy'
         expect(page).to have_content 'Some New Strategy'
         find('.accordion').click

--- a/spec/features/user_creates_a_draft_strategy_spec.rb
+++ b/spec/features/user_creates_a_draft_strategy_spec.rb
@@ -81,7 +81,6 @@ describe 'UserCreatesADraftStrategy', js: true do
       expect(find('.pageTitle')).to have_content 'Edit My New Strategy'
 
       within('#strategy_category_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Category'
         expect(page).to have_content 'Some New Category'
         find('.accordion').click

--- a/spec/features/user_creates_a_published_moment_spec.rb
+++ b/spec/features/user_creates_a_published_moment_spec.rb
@@ -116,21 +116,18 @@ describe 'UserCreatesAPublishedMoment', js: true do
       expect(find('.pageTitle')).to have_content 'Edit My New Moment'
 
       within('#moment_category_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Category'
         expect(page).to have_content 'Some New Category'
         find('.accordion').click
       end
 
       within('#moment_mood_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Mood'
         expect(page).to have_content 'Some New Mood'
         find('.accordion').click
       end
 
       within('#moment_strategy_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Strategy'
         expect(page).to have_content 'Some New Strategy'
         find('.accordion').click

--- a/spec/features/user_creates_a_published_moment_spec.rb
+++ b/spec/features/user_creates_a_published_moment_spec.rb
@@ -91,7 +91,7 @@ describe 'UserCreatesAPublishedMoment', js: true do
 
       find('#moment_comment_switch').click
       find('#moment_publishing_switch').click
-      find('#submit').click
+      find('#submit', wait: 10).click
 
       # VIEWING
       expect(find('.pageTitle')).to have_content 'My New Moment'

--- a/spec/features/user_creates_a_published_moment_spec.rb
+++ b/spec/features/user_creates_a_published_moment_spec.rb
@@ -91,7 +91,7 @@ describe 'UserCreatesAPublishedMoment', js: true do
 
       find('#moment_comment_switch').click
       find('#moment_publishing_switch').click
-      find('#submit', wait: 10).click
+      find('#submit').click
 
       # VIEWING
       expect(find('.pageTitle')).to have_content 'My New Moment'

--- a/spec/features/user_creates_a_published_strategy_spec.rb
+++ b/spec/features/user_creates_a_published_strategy_spec.rb
@@ -78,7 +78,6 @@ describe 'UserCreatesAPublishedStrategy', js: true do
       expect(find('.pageTitle')).to have_content 'Edit My New Strategy'
 
       within('#strategy_category_accordion') do
-        find('.accordion').click
         expect(page).to have_content 'Test Category'
         expect(page).to have_content 'Some New Category'
         find('.accordion').click


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description
QuickCreate component's accordionOpen state property is closed by default. In the case that a user is editing an object, they may want to see all of the pre-selected items. For instance, a Moment with categories will not show pre-selected categories upon page load.

This change conditionally opens the accordion if any options have already been checked.

## Corresponding Issue
https://github.com/ifmeorg/ifme/issues/1671


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
