### PR TITLE
Issue 1655 moment moods cleanup

### DIFF
--- a/app/controllers/concerns/shared.rb
+++ b/app/controllers/concerns/shared.rb
@@ -34,8 +34,13 @@ module Shared
   end
 
   def shared_destroy(model_object)
-    current_user.moments.each do |m|
-      update_object(model_object, m)
+    # Moods are managed via join table, not attr on Moment
+    # This block can be removed when all model objects managed
+    # via join table
+    if model_object.class != Mood
+      current_user.moments.each do |m|
+        update_object(model_object, m)
+      end
     end
     if model_object.class == Category
       current_user.strategies.each do |s|

--- a/app/controllers/concerns/shared.rb
+++ b/app/controllers/concerns/shared.rb
@@ -38,9 +38,7 @@ module Shared
     # This block can be removed when all model objects managed
     # via join table
     if model_object.class != Mood
-      current_user.moments.each do |m|
-        update_object(model_object, m)
-      end
+      current_user.moments.each { |m| update_object(model_object, m) }
     end
     if model_object.class == Category
       current_user.strategies.each do |s|

--- a/app/helpers/moments_form_helper.rb
+++ b/app/helpers/moments_form_helper.rb
@@ -108,7 +108,7 @@ module MomentsFormHelper
     when 'Category'
       @moment.category
     when 'Mood'
-      @moment.mood
+      @moment.moods.pluck(:id)
     when 'Strategy'
       @moment.strategy
     end

--- a/app/helpers/most_focus_helper.rb
+++ b/app/helpers/most_focus_helper.rb
@@ -26,10 +26,10 @@ module MostFocusHelper
   def get_data_type(model_object, data_type)
     data = []
     model_object.select do |item|
-      related_objects = data_type == 'moods' ? item.moods.pluck(:id) : item[data_type]
-      next unless related_objects.any? && viewable?(item)
+      objs = data_type == 'moods' ? item.moods.pluck(:id) : item[data_type]
+      next unless objs.any? && viewable?(item)
 
-      data.concat(related_objects)
+      data.concat(objs)
     end
     data
   end

--- a/app/helpers/most_focus_helper.rb
+++ b/app/helpers/most_focus_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module MostFocusHelper
   def most_focus(data_type, user)
-    return unless user && %w[mood strategy category].include?(data_type)
+    return unless user && %w[moods strategy category].include?(data_type)
 
     data = get_data(data_type, user)
     return unless data.any?
@@ -26,9 +26,10 @@ module MostFocusHelper
   def get_data_type(model_object, data_type)
     data = []
     model_object.select do |item|
-      next unless item[data_type].any? && viewable?(item)
+      related_objects = data_type == 'moods' ? item.moods : item[data_type]
+      next unless related_objects.any? && viewable?(item)
 
-      data.concat(item[data_type])
+      data.concat(related_objects)
     end
     data
   end

--- a/app/helpers/most_focus_helper.rb
+++ b/app/helpers/most_focus_helper.rb
@@ -26,7 +26,7 @@ module MostFocusHelper
   def get_data_type(model_object, data_type)
     data = []
     model_object.select do |item|
-      related_objects = data_type == 'moods' ? item.moods : item[data_type]
+      related_objects = data_type == 'moods' ? item.moods.pluck(:id) : item[data_type]
       next unless related_objects.any? && viewable?(item)
 
       data.concat(related_objects)

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -71,7 +71,7 @@ module TagsHelper
     return unless tag && data
 
     result = []
-    attribute = tag.kind_of?(Mood) ? 'moods' : tag.class.name.downcase
+    attribute = tag.is_a?(Mood) ? 'moods' : tag.class.name.downcase
     data.each do |d|
       result << d if d.send(attribute).include?(tag.id)
     end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -71,7 +71,7 @@ module TagsHelper
     return unless tag && data
 
     result = if tag.is_a?(Mood)
-               get_moods_from_data(data, mood_id)
+               get_moods_from_data(data, tag.id)
              else
                get_attribute_from_data(data, tag)
              end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -70,12 +70,21 @@ module TagsHelper
   def get_tagged_data(tag, data)
     return unless tag && data
 
-    result = []
-    attribute = tag.is_a?(Mood) ? 'moods' : tag.class.name.downcase
-    data.each do |d|
-      result << d if d.send(attribute).include?(tag.id)
-    end
+    result = if tag.is_a?(Mood)
+               get_moods_from_data(data, mood_id)
+             else
+               get_attribute_from_data(data, tag)
+             end
     { total: get_total(result),
       posts: Kaminari.paginate_array(result).page(params[:page]) }
+  end
+
+  def get_moods_from_data(data, mood_id)
+    data.select { |d| d.moods.include?(mood_id) }
+  end
+
+  def get_attribute_from_data(data, tag)
+    attribute = tag.class.name.downcase
+    data.select { |d| d if d.send(attribute).include?(tag.id) }
   end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -71,8 +71,9 @@ module TagsHelper
     return unless tag && data
 
     result = []
+    attribute = tag.kind_of?(Mood) ? 'moods' : tag.class.name.downcase
     data.each do |d|
-      result << d if d[tag.class.name.downcase].include?(tag.id)
+      result << d if d.send(attribute).include?(tag.id)
     end
     { total: get_total(result),
       posts: Kaminari.paginate_array(result).page(params[:page]) }

--- a/app/helpers/viewers_helper.rb
+++ b/app/helpers/viewers_helper.rb
@@ -13,7 +13,7 @@ module ViewersHelper
 
   def get_viewers_for(data, data_type)
     result = []
-    if data && %w[category mood strategy].include?(data_type)
+    if data && %w[category moods strategy].include?(data_type)
       result += get_viewers(data, data_type, Moment)
       if data_type == 'category'
         result += get_viewers(data, data_type, Strategy)
@@ -46,6 +46,7 @@ module ViewersHelper
     objs = obj.where(user_id: data.user_id).all.order('created_at DESC')
     objs.each do |ob|
       item = ob.send(data_type)
+      item = item.pluck(:id) if data_type == 'moods'
       return ob.viewers if item.include?(data.id)
     end
     []

--- a/app/models/concerns/common_methods.rb
+++ b/app/models/concerns/common_methods.rb
@@ -3,10 +3,10 @@ module CommonMethods
   extend ActiveSupport::Concern
 
   def mood_names_and_slugs
-    return unless attribute(:mood)
+    return unless self.class.reflect_on_association(:moods)
 
     names_and_slugs_hash(
-      Mood.where(id: mood).pluck(:name, :slug),
+      moods.pluck(:name, :slug),
       'moods'
     )
   end

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -17,4 +17,6 @@ class Mood < ApplicationRecord
   friendly_id :name
   validates :user_id, :name, presence: true
   belongs_to :user
+
+  has_many :moments_moods, dependent: :destroy
 end

--- a/app/views/moods/index.html.erb
+++ b/app/views/moods/index.html.erb
@@ -7,7 +7,7 @@
 
 <% if @moods.any? %>
   <%= render partial: '/search/posts', locals: { data_type: 'mood' } %>
-  <%= render partial: '/shared/stats', locals: { data_type: 'mood', user: current_user } %>
+  <%= render partial: '/shared/stats', locals: { data_type: 'moods', user: current_user } %>
 
   <%= react_component('BaseContainer', props: {
     container: 'StoryContainer',

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -56,7 +56,7 @@
 <% if !@stories.nil? && @stories.any? %>
   <div class="marginTop">
     <%= render partial: '/shared/stats', locals: { data_type: 'category', user: @profile } %>
-    <%= render partial: '/shared/stats', locals: { data_type: 'mood', user: @profile } %>
+    <%= render partial: '/shared/stats', locals: { data_type: 'moods', user: @profile } %>
     <%= render partial: '/shared/stats', locals: { data_type: 'strategy', user: @profile } %>
   </div>
   <div class="title">

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,4 +1,4 @@
-<% if %w[category mood strategy].include?(local_assigns[:data_type]) %>
+<% if %w[category moods strategy].include?(local_assigns[:data_type]) %>
   <% most_focus_data = most_focus(local_assigns[:data_type], local_assigns[:user]) %>
   <% if most_focus_data.present? %>
     <div class="stats">
@@ -24,9 +24,9 @@
                 <div class="someFocusTextName">
                   <%= Category.find_by(id: key).name %>
                 </div>
-              <% elsif local_assigns[:data_type] == 'mood' && local_assigns[:user] == current_user %>
+              <% elsif local_assigns[:data_type] == 'moods' && local_assigns[:user] == current_user %>
                 <%= viewers_hover(get_viewers_for(Mood.where(id: key).first, 'mood'), Mood.where(id: key).first) %>
-              <% elsif local_assigns[:data_type] == 'mood' && local_assigns[:user] %>
+              <% elsif local_assigns[:data_type] == 'moods' && local_assigns[:user] %>
                 <div class="someFocusTextName">
                   <%= Mood.find_by(id: key).name %>
                 </div>

--- a/db/migrate/20200221153634_drop_moments_mood_column.rb
+++ b/db/migrate/20200221153634_drop_moments_mood_column.rb
@@ -1,0 +1,5 @@
+class DropMomentsMoodColumn < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :moments, :mood
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_19_155053) do
+ActiveRecord::Schema.define(version: 2020_02_21_153634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,7 +133,6 @@ ActiveRecord::Schema.define(version: 2020_02_19_155053) do
   create_table "moments", force: :cascade do |t|
     t.text "category"
     t.string "name"
-    t.text "mood"
     t.text "why"
     t.text "fix"
     t.datetime "created_at"

--- a/lib/tasks/cleaner.rake
+++ b/lib/tasks/cleaner.rake
@@ -13,9 +13,4 @@ namespace :cleaner do
       end
     end
   end
-
-  desc 'Convert existing Moment mood IDs to join table records'
-  task populate_moments_moods: :environment do
-    Moment.populate_moments_moods
-  end
 end

--- a/spec/controllers/moods_controller_spec.rb
+++ b/spec/controllers/moods_controller_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe MoodsController, type: :controller do
       end
       it 'removes moods from existing moments' do
         delete :destroy, params: { id: user_mood.id }
-        expect(moment.reload.mood).not_to include(user_mood.id)
+        expect(moment.reload.moods).not_to include(user_mood)
       end
       it 'redirects to the mood index page' do
         delete :destroy, params: { id: user_mood.id }

--- a/spec/helpers/shared_examples.rb
+++ b/spec/helpers/shared_examples.rb
@@ -7,7 +7,7 @@ shared_examples :most_focus do |data_type|
   let(:datum) { create(data_type, user_id: profile.id) }
   let(:data) { create_list(data_type, data_length, user_id: profile.id) }
   let(:data_ids) { data.map(&:id) }
-  data_type_name = data_type.to_s
+  data_type_name = data_type == :mood ? 'moods' : data_type.to_s
 
   before do
     sign_in user1

--- a/spec/helpers/viewers_helper_spec.rb
+++ b/spec/helpers/viewers_helper_spec.rb
@@ -76,7 +76,7 @@ describe ViewersHelper do
       new_user2 = create(:user2)
       new_mood = create(:mood, user_id: new_user1.id)
       new_moment = create(:moment, user_id: new_user1.id, mood: Array.new(1, new_mood.id), viewers: Array.new(1, new_user2.id))
-      result = get_viewers_for(new_mood, 'mood')
+      result = get_viewers_for(new_mood, 'moods')
       expect(result.length).to eq(1)
       expect(result[0]).to eq(new_user2.id)
     end
@@ -87,7 +87,7 @@ describe ViewersHelper do
       new_user3 = create(:user3)
       new_mood = create(:mood, user_id: new_user1.id)
       new_moment = create(:moment, user_id: new_user1.id, mood: Array.new(1, new_mood.id), viewers: [new_user2.id, new_user3.id])
-      result = get_viewers_for(new_mood, 'mood')
+      result = get_viewers_for(new_mood, 'moods')
       expect(result.length).to eq(2)
       expect(result[0]).to eq(new_user2.id)
       expect(result[1]).to eq(new_user3.id)

--- a/spec/models/moment_spec.rb
+++ b/spec/models/moment_spec.rb
@@ -6,7 +6,6 @@
 #  id                      :bigint(8)        not null, primary key
 #  category                :text
 #  name                    :string
-#  mood                    :text
 #  why                     :text
 #  fix                     :text
 #  created_at              :datetime
@@ -51,12 +50,13 @@ describe Moment do
   context 'with relations' do
     it { is_expected.to belong_to :user }
     it { is_expected.to have_many :comments }
+    it { is_expected.to have_many :moments_moods }
+    it { is_expected.to have_many(:moods).through(:moments_moods) }
   end
 
   context 'with serialize' do
     it { is_expected.to serialize :category }
     it { is_expected.to serialize :viewers }
-    it { is_expected.to serialize :mood }
     it { is_expected.to serialize :strategy }
   end
 
@@ -113,58 +113,9 @@ describe Moment do
     end
   end
 
-  describe '.populate_moments_moods' do
-      let(:user) { create(:user) }
-      let(:user_two) { create(:user) }
-
-      let(:mood) { create(:mood, user: user) }
-      let(:mood_two) { create(:mood, user: user) }
-      let(:mood_three) { create(:mood, user: user_two) }
-
-      let!(:moment) { create(:moment, user: user, mood: [mood.id]) }
-      let!(:moment_two) {
-        create(:moment, user: user, mood: [mood.id, mood_two.id]) }
-      let!(:moment_three) {
-        create(:moment, user: user_two, mood: [mood_three.id]) }
-      let!(:moment_four) { create(:moment, user: user_two) }
-
-      it 'creates join table records' do
-        # Must delete join table records because they're automatically saved
-        ActiveRecord::Base.connection.execute("DELETE from moments_moods")
-        expect(moment.moods.count).to eq(0)
-        expect(moment_two.moods.count).to eq(0)
-        expect(moment_three.moods.count).to eq(0)
-        expect(moment_four.moods.count).to eq(0)
-
-        Moment.populate_moments_moods
-
-        expect(moment.moods.count).to eq(1)
-        expect(moment.moods).to include mood
-
-        expect(moment_two.moods.count).to eq(2)
-        expect(moment_two.moods).to include mood
-        expect(moment_two.moods).to include mood_two
-
-        expect(moment_three.moods.count).to eq(1)
-        expect(moment_three.moods).to include mood_three
-
-        expect(moment_four.moods.count).to eq(0)
-      end
-  end
-
   describe '#mood_array_data' do
     let!(:moment) { create(:moment, :with_user) }
     let!(:mood) { create(:mood, user: moment.user) }
-
-    context 'saving moods as IDs' do
-      it 'sets moods on field upon save' do
-        expect(moment.mood).to eq([])
-        moment.mood = [mood.id.to_s]
-        expect {
-          moment.save
-        }.to change{ moment.mood }.to([mood.id])
-      end
-    end
 
     context 'saving moods via relation' do
       let!(:mood_two) { create(:mood, user: moment.user) }


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Removes Moment#mood column and works with the join table relation instead. 
There's a lot of shared code and metaprogramming related to strategies and categories. Since the old field was named `mood` (singular) and the proper relation is `moods`, there is some code based around `mood` being examined. When other models get properly related, the conditional statements will go away.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
