### PR TITLE
Migration for Moment Categories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -18,4 +18,6 @@ class Category < ApplicationRecord
   friendly_id :name
   validates :user_id, :name, presence: true
   belongs_to :user
+
+  has_many :moments_categories, dependent: :destroy
 end

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -40,6 +40,8 @@ class Moment < ApplicationRecord
   has_many :comments, as: :commentable
   has_many :moments_moods, dependent: :destroy
   has_many :moods, through: :moments_moods
+  has_many :moments_categories, dependent: :destroy
+  has_many :categories, through: :moments_categories
 
   validates :comment, inclusion: [true, false]
   validates :user_id, :name, :why, presence: true
@@ -59,8 +61,19 @@ class Moment < ApplicationRecord
     )
   end
 
+  def self.populate_moments_categories
+    Moment.all.find_each do |moment|
+      moment.category = Category.where(id: moment.category).pluck(:id)
+      moment.save
+    end
+  end
+
   def category_array_data
-    self.category = category.collect(&:to_i) if category.is_a?(Array)
+    return unless category.is_a?(Array)
+
+    category_ids = category.collect(&:to_i)
+    self.category = category_ids
+    self.categories = Category.where(user_id: user_id, id: category_ids)
   end
 
   def viewers_array_data

--- a/app/models/moments_category.rb
+++ b/app/models/moments_category.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: moments_moods
+#
+#  id         :int        not null, primary key
+#  mood_id    :int
+#  moment_id  :int
+
+class MomentsCategory < ApplicationRecord
+  belongs_to :moment
+  belongs_to :category
+
+  validates :moment_id, uniqueness: { scope: :category_id }
+end

--- a/db/migrate/20200224201131_create_moment_categories_join_table.rb
+++ b/db/migrate/20200224201131_create_moment_categories_join_table.rb
@@ -1,0 +1,12 @@
+class CreateMomentCategoriesJoinTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :moments_categories do |t|
+      t.integer :moment_id
+      t.integer :category_id
+    end
+
+    add_index :moments_categories, [:moment_id, :category_id], unique: true
+    add_foreign_key :moments_categories, :moments
+    add_foreign_key :moments_categories, :categories
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_21_153634) do
+ActiveRecord::Schema.define(version: 2020_02_24_201131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,6 +149,12 @@ ActiveRecord::Schema.define(version: 2020_02_21_153634) do
     t.index ["slug"], name: "index_moments_on_slug", unique: true
   end
 
+  create_table "moments_categories", force: :cascade do |t|
+    t.integer "moment_id"
+    t.integer "category_id"
+    t.index ["moment_id", "category_id"], name: "index_moments_categories_on_moment_id_and_category_id", unique: true
+  end
+
   create_table "moments_moods", force: :cascade do |t|
     t.integer "moment_id"
     t.integer "mood_id"
@@ -279,6 +285,8 @@ ActiveRecord::Schema.define(version: 2020_02_21_153634) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "moments_categories", "categories"
+  add_foreign_key "moments_categories", "moments"
   add_foreign_key "moments_moods", "moments"
   add_foreign_key "moments_moods", "moods"
 end

--- a/lib/tasks/cleaner.rake
+++ b/lib/tasks/cleaner.rake
@@ -13,4 +13,9 @@ namespace :cleaner do
       end
     end
   end
+
+  desc 'Convert existing Moment category IDs to join table records'
+  task populate_moments_categories: :environment do
+    Moment.populate_moments_categories
+  end
 end

--- a/spec/models/moment_spec.rb
+++ b/spec/models/moment_spec.rb
@@ -141,4 +141,82 @@ describe Moment do
       end
     end
   end
+
+  describe '.populate_moments_categories' do
+    let(:user) { create(:user) }
+    let(:user_two) { create(:user) }
+
+    let(:category) { create(:category, user: user) }
+    let(:category_two) { create(:category, user: user) }
+    let(:category_three) { create(:category, user: user_two) }
+
+    let!(:moment) { create(:moment, user: user, category: [category.id]) }
+    let!(:moment_two) {
+      create(:moment, user: user, category: [category.id, category_two.id]) }
+    let!(:moment_three) {
+      create(:moment, user: user_two, category: [category_three.id]) }
+    let!(:moment_four) { create(:moment, user: user_two) }
+
+    it 'creates join table records' do
+      # Must delete join table records because they're automatically saved
+      ActiveRecord::Base.connection.execute("DELETE from moments_categories")
+      expect(moment.categories.count).to eq(0)
+      expect(moment_two.categories.count).to eq(0)
+      expect(moment_three.categories.count).to eq(0)
+      expect(moment_four.categories.count).to eq(0)
+
+      Moment.populate_moments_categories
+
+      expect(moment.categories.count).to eq(1)
+      expect(moment.categories).to include category
+
+      expect(moment_two.categories.count).to eq(2)
+      expect(moment_two.categories).to include category
+      expect(moment_two.categories).to include category_two
+
+      expect(moment_three.categories.count).to eq(1)
+      expect(moment_three.categories).to include category_three
+
+      expect(moment_four.categories.count).to eq(0)
+    end
+end
+
+describe '#category_array_data' do
+  let!(:moment) { create(:moment, :with_user) }
+  let!(:category) { create(:category, user: moment.user) }
+
+  context 'saving categories as IDs' do
+    it 'sets categories on field upon save' do
+      expect(moment.category).to eq([])
+      moment.category = [category.id.to_s]
+      expect {
+        moment.save
+      }.to change{ moment.category }.to([category.id])
+    end
+  end
+
+  context 'saving categories via relation' do
+    let!(:category_two) { create(:category, user: moment.user) }
+
+    it 'creates relations between moment and category models' do
+      expect(moment.categories.count).to eq(0)
+      moment.category = [category.id.to_s, category_two.id.to_s]
+      moment.save
+
+      expect(moment.categories.count).to eq(2)
+      expect(moment.categories).to include(category)
+      expect(moment.categories).to include(category_two)
+    end
+
+    it 'removes old categories when updating' do
+      moment.category = [category.id.to_s]
+      moment.save
+      expect(moment.categories).to eq [category]
+
+      moment.category = [category_two.id.to_s]
+      moment.save
+      expect(moment.categories).to eq [category_two]
+    end
+  end
+end
 end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This PR creates a migration for Moments Categories and a rake task called `populate_moments_categories` to move existing data from a `moment.category` to the new table. It follows the same structure as what @leeacto did for Moods!

We'll need to run this task in production once this PR is deployed.

The next PR will handle cleanup and update the UI.

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

#1665

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
