### PR TITLE
Moment Categories cleanup

### DIFF
--- a/app/controllers/concerns/shared.rb
+++ b/app/controllers/concerns/shared.rb
@@ -47,7 +47,7 @@ module Shared
   private
 
   def temp_remove_model_objects(model_object)
-    return unless model_object.class != Mood && model_object.class != Category
+    return if [Mood, Category].include?(model_object.class)
 
     current_user.moments.each { |m| update_object(model_object, m) }
   end

--- a/app/controllers/concerns/shared.rb
+++ b/app/controllers/concerns/shared.rb
@@ -34,12 +34,7 @@ module Shared
   end
 
   def shared_destroy(model_object)
-    # Moods are managed via join table, not attr on Moment
-    # This block can be removed when all model objects managed
-    # via join table
-    if model_object.class != Mood
-      current_user.moments.each { |m| update_object(model_object, m) }
-    end
+    temp_remove_model_objects(model_object)
     if model_object.class == Category
       current_user.strategies.each do |s|
         update_object(model_object, s)
@@ -50,6 +45,12 @@ module Shared
   end
 
   private
+
+  def temp_remove_model_objects(model_object)
+    return unless model_object.class != Mood && model_object.class != Category
+
+    current_user.moments.each { |m| update_object(model_object, m) }
+  end
 
   def index_path(model_object)
     case model_object.class.name
@@ -94,7 +95,8 @@ module Shared
   def format_failure(format, model_object, is_update)
     format.html { render is_update ? :edit : :new }
     format.json do
-      render json: model_object.errors, status: :unprocessable_entity
+      render json: model_object.errors,
+             status: :unprocessable_entity
     end
   end
 
@@ -111,11 +113,7 @@ module Shared
   def shared_quick_create_result(model_object)
     return { success: false } unless model_object.save
 
-    {
-      success: true,
-      id: model_object.id,
-      name: model_object.name,
-      slug: model_object.slug
-    }
+    { success: true, id: model_object.id,
+      name: model_object.name, slug: model_object.slug }
   end
 end

--- a/app/helpers/moments_form_helper.rb
+++ b/app/helpers/moments_form_helper.rb
@@ -106,7 +106,7 @@ module MomentsFormHelper
   def data_for(item)
     case item.class.name
     when 'Category'
-      @moment.category
+      @moment.categories.pluck(:id)
     when 'Mood'
       @moment.moods.pluck(:id)
     when 'Strategy'

--- a/app/helpers/most_focus_helper.rb
+++ b/app/helpers/most_focus_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module MostFocusHelper
   def most_focus(data_type, user)
-    return unless user && %w[moods strategy category].include?(data_type)
+    return unless user && %w[moods strategy categories].include?(data_type)
 
     data = get_data(data_type, user)
     return unless data.any?
@@ -23,10 +23,21 @@ module MostFocusHelper
     current_user.id == item.user_id || item.viewer?(current_user)
   end
 
+  def get_data_objs(item, data_type)
+    case data_type
+    when 'moods'
+      item.moods.pluck(:id)
+    when 'categories'
+      item.categories.pluck(:id)
+    else
+      item[data_type]
+    end
+  end
+
   def get_data_type(model_object, data_type)
     data = []
     model_object.select do |item|
-      objs = data_type == 'moods' ? item.moods.pluck(:id) : item[data_type]
+      objs = get_data_objs(item, data_type)
       next unless objs.any? && viewable?(item)
 
       data.concat(objs)

--- a/app/helpers/most_focus_helper.rb
+++ b/app/helpers/most_focus_helper.rb
@@ -24,10 +24,9 @@ module MostFocusHelper
   end
 
   def get_data_objs(item, data_type)
-    case data_type
-    when 'moods'
+    if data_type == 'moods'
       item.moods.pluck(:id)
-    when 'categories'
+    elsif data_type == 'categories' && item.is_a?(Moment)
       item.categories.pluck(:id)
     else
       item[data_type]

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -69,9 +69,9 @@ module TagsHelper
 
   def tagged_data_result(tag, data)
     if tag.is_a?(Mood)
-      get_moods_from_data(data, tag.id)
+      get_moods_from_data(data, tag)
     elsif tag.is_a?(Category) && data.first.is_a?(Moment)
-      get_categories_from_data(data, tag.id)
+      get_categories_from_data(data, tag)
     else
       get_attribute_from_data(data, tag)
     end
@@ -85,12 +85,12 @@ module TagsHelper
       posts: Kaminari.paginate_array(result).page(params[:page]) }
   end
 
-  def get_moods_from_data(data, mood_id)
-    data.select { |d| d.moods.include?(mood_id) }
+  def get_moods_from_data(data, mood)
+    data.select { |d| d.moods.include?(mood) }
   end
 
-  def get_categories_from_data(data, category_id)
-    data.select { |d| d.categories.include?(category_id) }
+  def get_categories_from_data(data, category)
+    data.select { |d| d.categories.include?(category) }
   end
 
   def get_attribute_from_data(data, tag)

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -67,16 +67,20 @@ module TagsHelper
     total
   end
 
+  def tagged_data_result(tag, data)
+    if tag.is_a?(Mood)
+      get_moods_from_data(data, tag.id)
+    elsif tag.is_a?(Category) && data.first.is_a?(Moment)
+      get_categories_from_data(data, tag.id)
+    else
+      get_attribute_from_data(data, tag)
+    end
+  end
+
   def get_tagged_data(tag, data)
     return unless tag && data
 
-    result = if tag.is_a?(Mood)
-               get_moods_from_data(data, tag.id)
-             elsif tag.is_a?(Category)
-               get_categories_from_data(data, tag.id)
-             else
-               get_attribute_from_data(data, tag)
-             end
+    result = tagged_data_result(tag, data)
     { total: get_total(result),
       posts: Kaminari.paginate_array(result).page(params[:page]) }
   end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -72,6 +72,8 @@ module TagsHelper
 
     result = if tag.is_a?(Mood)
                get_moods_from_data(data, tag.id)
+             elsif tag.is_a?(Category)
+               get_categories_from_data(data, tag.id)
              else
                get_attribute_from_data(data, tag)
              end
@@ -81,6 +83,10 @@ module TagsHelper
 
   def get_moods_from_data(data, mood_id)
     data.select { |d| d.moods.include?(mood_id) }
+  end
+
+  def get_categories_from_data(data, category_id)
+    data.select { |d| d.categories.include?(category_id) }
   end
 
   def get_attribute_from_data(data, tag)

--- a/app/helpers/viewers_helper.rb
+++ b/app/helpers/viewers_helper.rb
@@ -13,7 +13,7 @@ module ViewersHelper
 
   def get_viewers_for(data, data_type)
     result = []
-    if data && %w[category moods strategy].include?(data_type)
+    if data && %w[categories moods strategy].include?(data_type)
       result += get_viewers(data, data_type, Moment)
       if data_type == 'category'
         result += get_viewers(data, data_type, Strategy)
@@ -46,7 +46,7 @@ module ViewersHelper
     objs = obj.where(user_id: data.user_id).all.order('created_at DESC')
     objs.each do |ob|
       item = ob.send(data_type)
-      item = item.pluck(:id) if data_type == 'moods'
+      item = item.pluck(:id) if %w[moods categories].include? data_type
       return ob.viewers if item.include?(data.id)
     end
     []

--- a/app/models/concerns/common_methods.rb
+++ b/app/models/concerns/common_methods.rb
@@ -12,12 +12,15 @@ module CommonMethods
   end
 
   def category_names_and_slugs
-    return unless self.class.reflect_on_association(:categories)
-
-    names_and_slugs_hash(
-      categories.pluck(:name, :slug),
-      'categories'
-    )
+    # TODO: Remove usage of Category when Strategy Categories is created
+    if is_a?(Strategy) && attribute(:category)
+      names_and_slugs_hash(
+        Category.where(id: category).pluck(:name, :slug),
+        'categories'
+      )
+    elsif self.class.reflect_on_association(:categories)
+      names_and_slugs_hash(categories.pluck(:name, :slug), 'categories')
+    end
   end
 
   private

--- a/app/models/concerns/common_methods.rb
+++ b/app/models/concerns/common_methods.rb
@@ -12,10 +12,10 @@ module CommonMethods
   end
 
   def category_names_and_slugs
-    return unless attribute(:category)
+    return unless self.class.reflect_on_association(:categories)
 
     names_and_slugs_hash(
-      Category.where(id: category).pluck(:name, :slug),
+      categories.pluck(:name, :slug),
       'categories'
     )
   end

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -26,7 +26,6 @@ class Moment < ApplicationRecord
   extend FriendlyId
 
   friendly_id :name
-  serialize :category, Array
   serialize :viewers, Array
   serialize :strategy, Array
 
@@ -53,6 +52,7 @@ class Moment < ApplicationRecord
   scope :recent, -> { order('created_at DESC') }
 
   attr_accessor :mood
+  attr_accessor :category
 
   def self.find_secret_share!(identifier)
     find_by!(
@@ -61,18 +61,10 @@ class Moment < ApplicationRecord
     )
   end
 
-  def self.populate_moments_categories
-    Moment.all.find_each do |moment|
-      moment.category = Category.where(id: moment.category).pluck(:id)
-      moment.save
-    end
-  end
-
   def category_array_data
     return unless category.is_a?(Array)
 
     category_ids = category.collect(&:to_i)
-    self.category = category_ids
     self.categories = Category.where(user_id: user_id, id: category_ids)
   end
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -7,7 +7,7 @@
 <% if @categories.length > 0 %>
   <%= render partial: '/search/posts', locals: { data_type: 'category' } %>
 
-  <%= render partial: '/shared/stats', locals: { data_type: 'category', user: current_user } %>
+  <%= render partial: '/shared/stats', locals: { data_type: 'categories', user: current_user } %>
   <%= react_component('BaseContainer', props: {
     container: 'StoryContainer',
     data: categories_or_moods_props(@categories),

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -55,7 +55,7 @@
 
 <% if !@stories.nil? && @stories.any? %>
   <div class="marginTop">
-    <%= render partial: '/shared/stats', locals: { data_type: 'category', user: @profile } %>
+    <%= render partial: '/shared/stats', locals: { data_type: 'categories', user: @profile } %>
     <%= render partial: '/shared/stats', locals: { data_type: 'moods', user: @profile } %>
     <%= render partial: '/shared/stats', locals: { data_type: 'strategy', user: @profile } %>
   </div>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,4 +1,4 @@
-<% if %w[category moods strategy].include?(local_assigns[:data_type]) %>
+<% if %w[categories moods strategy].include?(local_assigns[:data_type]) %>
   <% most_focus_data = most_focus(local_assigns[:data_type], local_assigns[:user]) %>
   <% if most_focus_data.present? %>
     <div class="stats">
@@ -18,9 +18,9 @@
         <% most_focus_data.each do |key, value| %>
           <div class="someFocus">
             <div class="someFocusText">
-              <% if local_assigns[:data_type] == 'category' && local_assigns[:user] == current_user %>
+              <% if local_assigns[:data_type] == 'categories' && local_assigns[:user] == current_user %>
                 <%= viewers_hover(get_viewers_for(Category.find(key), 'category'), Category.find(key)) %>
-              <% elsif local_assigns[:data_type] == 'category' && local_assigns[:user] %>
+              <% elsif local_assigns[:data_type] == 'categories' && local_assigns[:user] %>
                 <div class="someFocusTextName">
                   <%= Category.find_by(id: key).name %>
                 </div>

--- a/db/migrate/20200224205313_drop_moments_category_column.rb
+++ b/db/migrate/20200224205313_drop_moments_category_column.rb
@@ -1,0 +1,5 @@
+class DropMomentsCategoryColumn < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :moments, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_201131) do
+ActiveRecord::Schema.define(version: 2020_02_24_205313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,7 +131,6 @@ ActiveRecord::Schema.define(version: 2020_02_24_201131) do
   end
 
   create_table "moments", force: :cascade do |t|
-    t.text "category"
     t.string "name"
     t.text "why"
     t.text "fix"

--- a/lib/tasks/cleaner.rake
+++ b/lib/tasks/cleaner.rake
@@ -13,9 +13,4 @@ namespace :cleaner do
       end
     end
   end
-
-  desc 'Convert existing Moment category IDs to join table records'
-  task populate_moments_categories: :environment do
-    Moment.populate_moments_categories
-  end
 end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe CategoriesController, type: :controller do
       end
       it 'removes categories from existing moments' do
         delete :destroy, params: { id: category.id }
-        expect(moment.reload.category).not_to include(category.id)
+        expect(moment.reload.categories).not_to include(category)
       end
       it 'removes categories from existing strategies' do
         delete :destroy, params: { id: category.id }

--- a/spec/helpers/shared_examples.rb
+++ b/spec/helpers/shared_examples.rb
@@ -7,8 +7,14 @@ shared_examples :most_focus do |data_type|
   let(:datum) { create(data_type, user_id: profile.id) }
   let(:data) { create_list(data_type, data_length, user_id: profile.id) }
   let(:data_ids) { data.map(&:id) }
-  data_type_name = data_type == :mood ? 'moods' : data_type.to_s
-  data_type_name = data_type == :category ? 'categories' : data_type.to_s
+
+  if data_type == :mood
+    data_type_name = 'moods'
+  elsif data_type == :category
+    data_type_name = 'categories'
+  else
+    data_type_name = data_type.to_s
+  end
 
   before do
     sign_in user1

--- a/spec/helpers/shared_examples.rb
+++ b/spec/helpers/shared_examples.rb
@@ -8,6 +8,7 @@ shared_examples :most_focus do |data_type|
   let(:data) { create_list(data_type, data_length, user_id: profile.id) }
   let(:data_ids) { data.map(&:id) }
   data_type_name = data_type == :mood ? 'moods' : data_type.to_s
+  data_type_name = data_type == :category ? 'categories' : data_type.to_s
 
   before do
     sign_in user1

--- a/spec/helpers/viewers_helper_spec.rb
+++ b/spec/helpers/viewers_helper_spec.rb
@@ -53,7 +53,7 @@ describe ViewersHelper do
       new_category = create(:category, user_id: new_user1.id)
       new_moment = create(:moment, user_id: new_user1.id, category: Array.new(1, new_category.id), viewers: Array.new(1, new_user2.id))
       new_strategy = create(:strategy, user_id: new_user1.id, category: Array.new(1, new_category.id), viewers: Array.new(1, new_user2.id))
-      result = get_viewers_for(new_category, 'category')
+      result = get_viewers_for(new_category, 'categories')
       expect(result.length).to eq(1)
       expect(result[0]).to eq(new_user2.id)
     end
@@ -65,7 +65,7 @@ describe ViewersHelper do
       new_category = create(:category, user_id: new_user1.id)
       new_moment = create(:moment, user_id: new_user1.id, category: Array.new(1, new_category.id), viewers: [new_user2.id, new_user3.id])
       new_strategy = create(:strategy, user_id: new_user1.id, category: Array.new(1, new_category.id), viewers: Array.new(1, new_user2.id))
-      result = get_viewers_for(new_category, 'category')
+      result = get_viewers_for(new_category, 'categories')
       expect(result.length).to eq(2)
       expect(result[0]).to eq(new_user2.id)
       expect(result[1]).to eq(new_user3.id)

--- a/spec/services/time_ago_spec.rb
+++ b/spec/services/time_ago_spec.rb
@@ -64,7 +64,7 @@ describe TimeAgo do
 
     context 'creating and editing happened on the same day (but not the exact same time)' do
       before do
-        new_moment.update(category: Array.new(1, new_category.id))
+        new_moment.update(category: [new_category.id], updated_at: Time.now + 1)
       end
 
       it 'returns created_at with (edited)' do
@@ -76,7 +76,7 @@ describe TimeAgo do
       let(:new_moment) { create(:moment, user_id: new_user1.id, created_at: '2014-01-01 00:00:00') }
 
       before do
-        new_moment.update(category: Array.new(1, new_category.id))
+        new_moment.update(category: [new_category.id])
       end
 
       it 'returns created_at with updated_at' do


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This PR cleans up the category column from the Moment table and updates the UI to use `moment.categories`. It also removes the rake task `populate_moments_categories`.

Everything has been manually tested!

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
