### PR TITLE
Migration for Moment Strategies

### DIFF
--- a/app/models/allyship.rb
+++ b/app/models/allyship.rb
@@ -3,7 +3,7 @@
 #
 # Table name: allyships
 #
-#  id         :bigint(8)        not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer
 #  created_at :datetime
 #  updated_at :datetime

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,7 +3,7 @@
 #
 # Table name: categories
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  description :text
 #  created_at  :datetime

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,7 +3,7 @@
 #
 # Table name: comments
 #
-#  id               :bigint(8)        not null, primary key
+#  id               :bigint           not null, primary key
 #  commentable_type :string
 #  commentable_id   :integer
 #  comment_by       :integer

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,7 +3,7 @@
 #
 # Table name: groups
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  created_at  :datetime
 #  updated_at  :datetime

--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -3,7 +3,7 @@
 #
 # Table name: group_members
 #
-#  id         :bigint(8)        not null, primary key
+#  id         :bigint           not null, primary key
 #  group_id   :integer
 #  user_id    :integer
 #  leader     :boolean

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -18,7 +18,8 @@
 #  comments          :text
 #  slug              :string
 #  add_to_google_cal :boolean          default(FALSE)
-#  weekly_dosage     :integer          default(["0", "1", "2", "3", "4", "5", "6"]), is an Array
+#  weekly_dosage     :integer
+#   default(["0", "1", "2", "3", "4", "5", "6"]), is an Array
 #
 
 class Medication < ApplicationRecord

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -3,7 +3,7 @@
 #
 # Table name: medications
 #
-#  id                :bigint(8)        not null, primary key
+#  id                :bigint           not null, primary key
 #  name              :string
 #  dosage            :integer
 #  refill            :datetime
@@ -18,9 +18,7 @@
 #  comments          :text
 #  slug              :string
 #  add_to_google_cal :boolean          default(FALSE)
-# rubocop:disable LineLength
 #  weekly_dosage     :integer          default(["0", "1", "2", "3", "4", "5", "6"]), is an Array
-# rubocop:enable LineLength
 #
 
 class Medication < ApplicationRecord

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -3,7 +3,7 @@
 #
 # Table name: meetings
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  description :text
 #  location    :text

--- a/app/models/meeting_member.rb
+++ b/app/models/meeting_member.rb
@@ -3,7 +3,7 @@
 #
 # Table name: meeting_members
 #
-#  id                  :bigint(8)        not null, primary key
+#  id                  :bigint           not null, primary key
 #  meeting_id          :integer
 #  user_id             :integer
 #  leader              :boolean

--- a/app/models/moments_category.rb
+++ b/app/models/moments_category.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 # == Schema Information
 #
-# Table name: moments_moods
+# Table name: moments_categories
 #
-#  id         :int        not null, primary key
-#  mood_id    :int
-#  moment_id  :int
+#  id          :bigint           not null, primary key
+#  moment_id   :integer
+#  category_id :integer
+#
 
 class MomentsCategory < ApplicationRecord
   belongs_to :moment

--- a/app/models/moments_mood.rb
+++ b/app/models/moments_mood.rb
@@ -3,9 +3,10 @@
 #
 # Table name: moments_moods
 #
-#  id         :int        not null, primary key
-#  mood_id    :int
-#  moment_id  :int
+#  id        :bigint           not null, primary key
+#  moment_id :integer
+#  mood_id   :integer
+#
 
 class MomentsMood < ApplicationRecord
   belongs_to :moment

--- a/app/models/moments_strategy.rb
+++ b/app/models/moments_strategy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: moments_strategies
+#
+#  id          :bigint           not null, primary key
+#  moment_id   :integer
+#  strategy_id :integer
+#
+
+class MomentsStrategy < ApplicationRecord
+  belongs_to :moment
+  belongs_to :strategy
+
+  validates :moment_id, uniqueness: { scope: :strategy_id }
+end

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -3,7 +3,7 @@
 #
 # Table name: moods
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  description :text
 #  created_at  :datetime

--- a/app/models/password_history.rb
+++ b/app/models/password_history.rb
@@ -4,9 +4,11 @@
 #
 # Table name: password_histories
 #
-#  id                     :integer          not null, primary key
-#  user_id                :integer           default(''), not null
-#  encrypted_password     :string           default(''), not null
+#  id                 :bigint           not null, primary key
+#  user_id            :integer          not null
+#  encrypted_password :string
+#  created_at         :datetime         not null
+#
 
 class PasswordHistory < ApplicationRecord
   belongs_to :user

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,7 +3,7 @@
 #
 # Table name: reports
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  reporter_id :integer
 #  reportee_id :integer
 #  reasons     :text

--- a/app/models/strategy.rb
+++ b/app/models/strategy.rb
@@ -3,7 +3,7 @@
 #
 # Table name: strategies
 #
-#  id           :bigint(8)        not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  category     :text
 #  description  :text
@@ -39,6 +39,8 @@ class Strategy < ApplicationRecord
 
   scope :published, -> { where.not(published_at: nil) }
   scope :recent, -> { order('created_at DESC') }
+
+  has_many :moments_strategies, dependent: :destroy
 
   def active_reminders
     [perform_strategy_reminder].select(&:active?) if perform_strategy_reminder

--- a/app/models/support.rb
+++ b/app/models/support.rb
@@ -3,7 +3,7 @@
 #
 # Table name: supports
 #
-#  id           :bigint(8)        not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  support_type :string
 #  support_ids  :text

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 #
 # Table name: users
 #
-#  id                     :bigint(8)        not null, primary key
+#  id                     :bigint           not null, primary key
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
@@ -42,6 +42,7 @@
 #  refresh_token          :string
 #  banned                 :boolean          default(FALSE)
 #  admin                  :boolean          default(FALSE)
+#  third_party_avatar     :text
 #
 
 class User < ApplicationRecord

--- a/app/views/moments/index.html.erb
+++ b/app/views/moments/index.html.erb
@@ -30,14 +30,21 @@
   <%= raw t('moments.index.instructions') %>
   <div class="gridTwo marginTop">
     <div class="gridTwoItemBoxLight">
+      <%
+        example_mood_names = t('moods.example_moods')
+        example_moods = []
+        example_mood_names.split(',').each do |m|
+          example_moods.push({ name: m, slug: '' })
+        end
+      %>
       <%= react_component('Story', html_options: html_options, props: {
         name: t('moments.index.example_name'),
         link: moments_path,
         actions: {
           viewers: t('comment.control')
         },
-        categories: [t('moments.index.example_category')],
-        moods: t('moods.example_moods').split(',')
+        categories: [{ name: t('moments.index.example_category'), slug: '' }],
+        moods: example_moods
       }) %>
     </div>
   </div>

--- a/db/migrate/20200224231844_create_moment_strategies_join_table.rb
+++ b/db/migrate/20200224231844_create_moment_strategies_join_table.rb
@@ -1,0 +1,12 @@
+class CreateMomentStrategiesJoinTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :moments_strategies do |t|
+      t.integer :moment_id
+      t.integer :strategy_id
+    end
+
+    add_index :moments_strategies, [:moment_id, :strategy_id], unique: true
+    add_foreign_key :moments_strategies, :moments
+    add_foreign_key :moments_strategies, :strategies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_205313) do
+ActiveRecord::Schema.define(version: 2020_02_24_231844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -160,6 +160,12 @@ ActiveRecord::Schema.define(version: 2020_02_24_205313) do
     t.index ["moment_id", "mood_id"], name: "index_moments_moods_on_moment_id_and_mood_id", unique: true
   end
 
+  create_table "moments_strategies", force: :cascade do |t|
+    t.integer "moment_id"
+    t.integer "strategy_id"
+    t.index ["moment_id", "strategy_id"], name: "index_moments_strategies_on_moment_id_and_strategy_id", unique: true
+  end
+
   create_table "moods", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -288,4 +294,6 @@ ActiveRecord::Schema.define(version: 2020_02_24_205313) do
   add_foreign_key "moments_categories", "moments"
   add_foreign_key "moments_moods", "moments"
   add_foreign_key "moments_moods", "moods"
+  add_foreign_key "moments_strategies", "moments"
+  add_foreign_key "moments_strategies", "strategies"
 end

--- a/lib/tasks/cleaner.rake
+++ b/lib/tasks/cleaner.rake
@@ -13,4 +13,9 @@ namespace :cleaner do
       end
     end
   end
+
+  desc 'Convert existing Moment strategy IDs to join table records'
+  task populate_moments_strategies: :environment do
+    Moment.populate_moments_strategies
+  end
 end

--- a/spec/models/allyship_spec.rb
+++ b/spec/models/allyship_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: allyships
 #
-#  id         :bigint(8)        not null, primary key
+#  id         :bigint           not null, primary key
 #  user_id    :integer
 #  created_at :datetime
 #  updated_at :datetime

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: categories
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  description :text
 #  created_at  :datetime

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: comments
 #
-#  id               :bigint(8)        not null, primary key
+#  id               :bigint           not null, primary key
 #  commentable_type :string
 #  commentable_id   :integer
 #  comment_by       :integer

--- a/spec/models/group_member_spec.rb
+++ b/spec/models/group_member_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: group_members
 #
-#  id         :bigint(8)        not null, primary key
+#  id         :bigint           not null, primary key
 #  group_id   :integer
 #  user_id    :integer
 #  leader     :boolean

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: groups
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  created_at  :datetime
 #  updated_at  :datetime

--- a/spec/models/medication_spec.rb
+++ b/spec/models/medication_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: medications
 #
-#  id                :bigint(8)        not null, primary key
+#  id                :bigint           not null, primary key
 #  name              :string
 #  dosage            :integer
 #  refill            :datetime

--- a/spec/models/meeting_member_spec.rb
+++ b/spec/models/meeting_member_spec.rb
@@ -3,12 +3,13 @@
 #
 # Table name: meeting_members
 #
-#  id         :bigint(8)        not null, primary key
-#  meeting_id :integer
-#  user_id    :integer
-#  leader     :boolean
-#  created_at :datetime
-#  updated_at :datetime
+#  id                  :bigint           not null, primary key
+#  meeting_id          :integer
+#  user_id             :integer
+#  leader              :boolean
+#  created_at          :datetime
+#  updated_at          :datetime
+#  google_cal_event_id :string
 #
 
 describe MeetingMember do

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: meetings
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  description :text
 #  location    :text

--- a/spec/models/mood_spec.rb
+++ b/spec/models/mood_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: moods
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  name        :string
 #  description :text
 #  created_at  :datetime

--- a/spec/models/password_history_spec.rb
+++ b/spec/models/password_history_spec.rb
@@ -4,9 +4,11 @@
 #
 # Table name: password_histories
 #
-#  id                     :integer          not null, primary key
-#  user_id                :integer           default(''), not null
-#  encrypted_password     :string           default(''), not null
+#  id                 :bigint           not null, primary key
+#  user_id            :integer          not null
+#  encrypted_password :string
+#  created_at         :datetime         not null
+#
 
 describe PasswordHistory do
   let!(:password_history1) { FactoryBot.create(:password_history) }

--- a/spec/models/refill_reminder_spec.rb
+++ b/spec/models/refill_reminder_spec.rb
@@ -2,13 +2,13 @@
 
 # == Schema Information
 #
-# Table name: perform_strategy_reminders
+# Table name: refill_reminders
 #
-#  id          :integer          not null, primary key
-#  strategy_id :integer          not null
-#  active      :boolean          not null
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id            :integer          not null, primary key
+#  medication_id :integer          not null
+#  active        :boolean          not null
+#  created_at    :datetime
+#  updated_at    :datetime
 #
 describe RefillReminder do
   context 'with relations' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: reports
 #
-#  id          :bigint(8)        not null, primary key
+#  id          :bigint           not null, primary key
 #  reporter_id :integer
 #  reportee_id :integer
 #  reasons     :text

--- a/spec/models/strategy_spec.rb
+++ b/spec/models/strategy_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: strategies
 #
-#  id           :bigint(8)        not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  category     :text
 #  description  :text

--- a/spec/models/support_spec.rb
+++ b/spec/models/support_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: supports
 #
-#  id           :bigint(8)        not null, primary key
+#  id           :bigint           not null, primary key
 #  user_id      :integer
 #  support_type :string
 #  support_ids  :text

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: users
 #
-#  id                     :bigint(8)        not null, primary key
+#  id                     :bigint           not null, primary key
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
@@ -42,6 +42,7 @@
 #  refresh_token          :string
 #  banned                 :boolean          default(FALSE)
 #  admin                  :boolean          default(FALSE)
+#  third_party_avatar     :text
 #
 
 describe User do


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This PR creates a migration for Moments Strategies and a rake task called `populate_moments_strategies` to move existing data from a `moment.strategy` to the new table. It follows the same structure as what @leeacto did for Moods!

We'll need to run this task in production once this PR is deployed (after running `rake db:migrate`). This PR runs `annotate` to update the Model comments. It also fixes a minor bug with the example Moments post shown for users with no posts.

The next PR will handle cleanup and update the UI.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
