### PR TITLE
Moments Strategies cleanup

### DIFF
--- a/app/controllers/concerns/shared.rb
+++ b/app/controllers/concerns/shared.rb
@@ -47,7 +47,7 @@ module Shared
   private
 
   def temp_remove_model_objects(model_object)
-    return if [Mood, Category].include?(model_object.class)
+    return if [Mood, Category, Strategy].include?(model_object.class)
 
     current_user.moments.each { |m| update_object(model_object, m) }
   end

--- a/app/helpers/moments_form_helper.rb
+++ b/app/helpers/moments_form_helper.rb
@@ -110,7 +110,7 @@ module MomentsFormHelper
     when 'Mood'
       @moment.moods.pluck(:id)
     when 'Strategy'
-      @moment.strategy
+      @moment.strategies.pluck(:id)
     end
   end
 end

--- a/app/helpers/most_focus_helper.rb
+++ b/app/helpers/most_focus_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module MostFocusHelper
   def most_focus(data_type, user)
-    return unless user && %w[moods strategy categories].include?(data_type)
+    return unless user && %w[moods strategies categories].include?(data_type)
 
     data = get_data(data_type, user)
     return unless data.any?
@@ -28,6 +28,8 @@ module MostFocusHelper
       item.moods.pluck(:id)
     elsif data_type == 'categories' && item.is_a?(Moment)
       item.categories.pluck(:id)
+    elsif data_type == 'strategies'
+      item.strategies.pluck(:id)
     else
       item[data_type]
     end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -72,6 +72,8 @@ module TagsHelper
       get_moods_from_data(data, tag)
     elsif tag.is_a?(Category) && data.first.is_a?(Moment)
       get_categories_from_data(data, tag)
+    elsif tag.is_a?(Strategy)
+      get_strategies_from_data(data, tag)
     else
       get_attribute_from_data(data, tag)
     end
@@ -91,6 +93,10 @@ module TagsHelper
 
   def get_categories_from_data(data, category)
     data.select { |d| d.categories.include?(category) }
+  end
+
+  def get_strategies_from_data(data, strategy)
+    data.select { |d| d.strategies.include?(strategy) }
   end
 
   def get_attribute_from_data(data, tag)

--- a/app/helpers/viewers_helper.rb
+++ b/app/helpers/viewers_helper.rb
@@ -13,9 +13,9 @@ module ViewersHelper
 
   def get_viewers_for(data, data_type)
     result = []
-    if data && %w[categories moods strategy].include?(data_type)
+    if data && %w[categories moods strategies].include?(data_type)
       result += get_viewers(data, data_type, Moment)
-      if data_type == 'category'
+      if data_type == 'categories'
         result += get_viewers(data, data_type, Strategy)
       end
     end
@@ -43,10 +43,13 @@ module ViewersHelper
   end
 
   def get_viewers(data, data_type, obj)
+    data_types = %w[moods categories strategies]
     objs = obj.where(user_id: data.user_id).all.order('created_at DESC')
     objs.each do |ob|
-      item = ob.send(data_type)
-      item = item.pluck(:id) if %w[moods categories].include? data_type
+      item = ob.send(ob.is_a?(Strategy) ? data_type.singularize : data_type)
+      if !ob.is_a?(Strategy) && data_types.include?(data_type)
+        item = item.pluck(:id)
+      end
       return ob.viewers if item.include?(data.id)
     end
     []

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -12,7 +12,6 @@
 #  user_id                 :integer
 #  viewers                 :text
 #  comment                 :boolean
-#  strategy                :text
 #  slug                    :string
 #  secret_share_identifier :uuid
 #  secret_share_expires_at :datetime
@@ -26,7 +25,6 @@ class Moment < ApplicationRecord
 
   friendly_id :name
   serialize :viewers, Array
-  serialize :strategy, Array
 
   before_save :category_array_data
   before_save :viewers_array_data
@@ -54,19 +52,13 @@ class Moment < ApplicationRecord
 
   attr_accessor :mood
   attr_accessor :category
+  attr_accessor :strategy
 
   def self.find_secret_share!(identifier)
     find_by!(
       # 'secret_share_expires_at > NOW()', TODO: Turn off temporarily
       secret_share_identifier: identifier
     )
-  end
-
-  def self.populate_moments_strategies
-    Moment.all.find_each do |moment|
-      moment.strategy = Strategy.where(id: moment.strategy).pluck(:id)
-      moment.save
-    end
   end
 
   def category_array_data
@@ -91,7 +83,6 @@ class Moment < ApplicationRecord
     return unless strategy.is_a?(Array)
 
     strategy_ids = strategy.collect(&:to_i)
-    self.strategy = strategy_ids
     self.strategies = Strategy.where(user_id: user_id, id: strategy_ids)
   end
 

--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -32,12 +32,12 @@
   </div>
 <% end %>
 
-<% if @moment.strategy.count > 0 %>
+<% if @moment.strategies.count > 0 %>
   <div class="smallMarginTop">
     <div class="label"><%= label_tag t('moments.show.strategies') %></div>
     <ul>
-      <% @moment.strategy.each do |item| %>
-          <li><%= link_to Strategy.find(item).name, Strategy.find(item) %></li>
+      <% @moment.strategies.each do |item| %>
+          <li><%= link_to item.name, item %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -57,7 +57,7 @@
   <div class="marginTop">
     <%= render partial: '/shared/stats', locals: { data_type: 'categories', user: @profile } %>
     <%= render partial: '/shared/stats', locals: { data_type: 'moods', user: @profile } %>
-    <%= render partial: '/shared/stats', locals: { data_type: 'strategy', user: @profile } %>
+    <%= render partial: '/shared/stats', locals: { data_type: 'strategies', user: @profile } %>
   </div>
   <div class="title">
     <%= t('pages.home.stories') %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,4 +1,4 @@
-<% if %w[categories moods strategy].include?(local_assigns[:data_type]) %>
+<% if %w[categories moods strategies].include?(local_assigns[:data_type]) %>
   <% most_focus_data = most_focus(local_assigns[:data_type], local_assigns[:user]) %>
   <% if most_focus_data.present? %>
     <div class="stats">
@@ -19,20 +19,20 @@
           <div class="someFocus">
             <div class="someFocusText">
               <% if local_assigns[:data_type] == 'categories' && local_assigns[:user] == current_user %>
-                <%= viewers_hover(get_viewers_for(Category.find(key), 'category'), Category.find(key)) %>
+                <%= viewers_hover(get_viewers_for(Category.find(key), 'categories'), Category.find(key)) %>
               <% elsif local_assigns[:data_type] == 'categories' && local_assigns[:user] %>
                 <div class="someFocusTextName">
                   <%= Category.find_by(id: key).name %>
                 </div>
               <% elsif local_assigns[:data_type] == 'moods' && local_assigns[:user] == current_user %>
-                <%= viewers_hover(get_viewers_for(Mood.where(id: key).first, 'mood'), Mood.where(id: key).first) %>
+                <%= viewers_hover(get_viewers_for(Mood.where(id: key).first, 'moods'), Mood.where(id: key).first) %>
               <% elsif local_assigns[:data_type] == 'moods' && local_assigns[:user] %>
                 <div class="someFocusTextName">
                   <%= Mood.find_by(id: key).name %>
                 </div>
-              <% elsif local_assigns[:data_type] == 'strategy' && local_assigns[:user] == current_user %>
-                <%= viewers_hover(get_viewers_for(Strategy.find(key), 'strategy'), Strategy.find(key)) %>
-              <% elsif local_assigns[:data_type] == 'strategy' && local_assigns[:user] %>
+              <% elsif local_assigns[:data_type] == 'strategies' && local_assigns[:user] == current_user %>
+                <%= viewers_hover(get_viewers_for(Strategy.find(key), 'strategies'), Strategy.find(key)) %>
+              <% elsif local_assigns[:data_type] == 'strategies' && local_assigns[:user] %>
                 <div class="someFocusTextName">
                   <%= Strategy.find(key).name %>
                 </div>

--- a/app/views/strategies/index.html.erb
+++ b/app/views/strategies/index.html.erb
@@ -6,7 +6,7 @@
 
 <% if @strategies.any? %>
   <%= render partial: '/search/posts', locals: { data_type: 'strategy' } %>
-  <%= render partial: '/shared/stats', locals: { data_type: 'strategy', user: current_user } %>
+  <%= render partial: '/shared/stats', locals: { data_type: 'strategies', user: current_user } %>
   <%= react_component('BaseContainer', props: {
     container: 'StoryContainer',
     data: moments_or_strategy_props(@strategies),

--- a/db/migrate/20200224234822_drop_moments_strategy_column.rb
+++ b/db/migrate/20200224234822_drop_moments_strategy_column.rb
@@ -1,0 +1,5 @@
+class DropMomentsStrategyColumn < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :moments, :strategy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_231844) do
+ActiveRecord::Schema.define(version: 2020_02_24_234822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,7 +139,6 @@ ActiveRecord::Schema.define(version: 2020_02_24_231844) do
     t.integer "user_id"
     t.text "viewers"
     t.boolean "comment"
-    t.text "strategy"
     t.string "slug"
     t.uuid "secret_share_identifier"
     t.datetime "secret_share_expires_at"

--- a/lib/tasks/cleaner.rake
+++ b/lib/tasks/cleaner.rake
@@ -13,9 +13,4 @@ namespace :cleaner do
       end
     end
   end
-
-  desc 'Convert existing Moment strategy IDs to join table records'
-  task populate_moments_strategies: :environment do
-    Moment.populate_moments_strategies
-  end
 end

--- a/spec/helpers/shared_examples.rb
+++ b/spec/helpers/shared_examples.rb
@@ -12,6 +12,8 @@ shared_examples :most_focus do |data_type|
     data_type_name = 'moods'
   elsif data_type == :category
     data_type_name = 'categories'
+  elsif data_type == :strategy
+    data_type_name = 'strategies'
   else
     data_type_name = data_type.to_s
   end

--- a/spec/helpers/viewers_helper_spec.rb
+++ b/spec/helpers/viewers_helper_spec.rb
@@ -98,7 +98,7 @@ describe ViewersHelper do
       new_user2 = create(:user2)
       new_strategy = create(:strategy, user_id: new_user1.id)
       new_moment = create(:moment, user_id: new_user1.id, strategy: Array.new(1, new_strategy.id), viewers: Array.new(1, new_user2.id))
-      result = get_viewers_for(new_strategy, 'strategy')
+      result = get_viewers_for(new_strategy, 'strategies')
       expect(result.length).to eq(1)
       expect(result[0]).to eq(new_user2.id)
     end
@@ -109,7 +109,7 @@ describe ViewersHelper do
       new_user3 = create(:user3)
       new_strategy = create(:strategy, user_id: new_user1.id)
       new_moment = create(:moment, user_id: new_user1.id, strategy: Array.new(1, new_strategy.id), viewers: [new_user2.id, new_user3.id])
-      result = get_viewers_for(new_strategy, 'strategy')
+      result = get_viewers_for(new_strategy, 'strategies')
       expect(result.length).to eq(2)
       expect(result[0]).to eq(new_user2.id)
       expect(result[1]).to eq(new_user3.id)


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This PR cleans up the category column from the Moment table and updates the UI to use `moment.strategies`. It also removes the rake task `populate_moments_strategies`.

Gonna fix the complexity issue raised in Code Climate in the PR for cleaning up Strategy Categories!

Everything has been manually tested!

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
