### PR TITLE
Strategy Categories migration

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -20,4 +20,5 @@ class Category < ApplicationRecord
   belongs_to :user
 
   has_many :moments_categories, dependent: :destroy
+  has_many :strategies_categories, dependent: :destroy
 end

--- a/app/models/strategies_category.rb
+++ b/app/models/strategies_category.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: strategies_categories
+#
+#  id          :bigint           not null, primary key
+#  strategy_id :integer
+#  category_id :integer
+#
+
+class StrategiesCategory < ApplicationRecord
+  belongs_to :strategy
+  belongs_to :category
+
+  validates :strategy_id, uniqueness: { scope: :category_id }
+end

--- a/db/migrate/20200225003308_create_strategy_categories_join_table.rb
+++ b/db/migrate/20200225003308_create_strategy_categories_join_table.rb
@@ -1,0 +1,12 @@
+class CreateStrategyCategoriesJoinTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :strategies_categories do |t|
+      t.integer :strategy_id
+      t.integer :category_id
+    end
+
+    add_index :strategies_categories, [:strategy_id, :category_id], unique: true
+    add_foreign_key :strategies_categories, :strategies
+    add_foreign_key :strategies_categories, :categories
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_234822) do
+ActiveRecord::Schema.define(version: 2020_02_25_003308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,6 +226,12 @@ ActiveRecord::Schema.define(version: 2020_02_24_234822) do
     t.index ["slug"], name: "index_strategies_on_slug", unique: true
   end
 
+  create_table "strategies_categories", force: :cascade do |t|
+    t.integer "strategy_id"
+    t.integer "category_id"
+    t.index ["strategy_id", "category_id"], name: "index_strategies_categories_on_strategy_id_and_category_id", unique: true
+  end
+
   create_table "supports", force: :cascade do |t|
     t.integer "user_id"
     t.string "support_type"
@@ -295,4 +301,6 @@ ActiveRecord::Schema.define(version: 2020_02_24_234822) do
   add_foreign_key "moments_moods", "moods"
   add_foreign_key "moments_strategies", "moments"
   add_foreign_key "moments_strategies", "strategies"
+  add_foreign_key "strategies_categories", "categories"
+  add_foreign_key "strategies_categories", "strategies"
 end

--- a/lib/tasks/cleaner.rake
+++ b/lib/tasks/cleaner.rake
@@ -13,4 +13,9 @@ namespace :cleaner do
       end
     end
   end
+
+  desc 'Convert existing Straregy category IDs to join table records'
+  task populate_strategies_categories: :environment do
+    Strategy.populate_strategies_categories
+  end
 end

--- a/spec/factories/strategy.rb
+++ b/spec/factories/strategy.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     name { 'Test Strategy' }
     description { 'Test Description' }
     comment { true }
-    user_id { 1 }
+    user { create(:user1) }
 
     after(:create) do |strategy|
       create :perform_strategy_reminder, strategy: strategy, active: false


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This PR creates a migration for Strategies Categories and a rake task called `populate_strategies_categories` to move existing data from a `strategy.category` to the new table. It follows the same structure as what @leeacto did for Moods!

We'll need to run this task in production once this PR is deployed.

The next PR will handle cleanup and update the UI.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
