### PR TITLE
Strategy Categories cleanup

### DIFF
--- a/app/controllers/concerns/moments_concern.rb
+++ b/app/controllers/concerns/moments_concern.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module MomentsConcern
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :publishing?, :saving_as_draft?,
+                  :empty_array_for
+  end
+
+  def publishing?
+    params[:publishing] == '1'
+  end
+
+  def saving_as_draft?
+    !publishing?
+  end
+
+  def empty_array_for(*symbols)
+    symbols.each do |symbol|
+      if moment_params[symbol].nil? && @moment.has_attribute?(symbol)
+        @moment[symbol] = []
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/shared.rb
+++ b/app/controllers/concerns/shared.rb
@@ -34,22 +34,20 @@ module Shared
   end
 
   def shared_destroy(model_object)
-    temp_remove_model_objects(model_object)
-    if model_object.class == Category
-      current_user.strategies.each do |s|
-        update_object(model_object, s)
-      end
-    end
+    remove_model_objects(model_object)
     model_object.destroy
     redirect_to_path(index_path(model_object))
   end
 
   private
 
-  def temp_remove_model_objects(model_object)
+  def remove_model_objects(model_object)
     return if [Mood, Category, Strategy].include?(model_object.class)
 
     current_user.moments.each { |m| update_object(model_object, m) }
+    current_user.strategies.each do |s|
+      update_object(model_object, s) if model_object.class == Category
+    end
   end
 
   def index_path(model_object)

--- a/app/controllers/concerns/strategies_concern.rb
+++ b/app/controllers/concerns/strategies_concern.rb
@@ -22,7 +22,9 @@ module StrategiesConcern
 
   def empty_array_for(*symbols)
     symbols.each do |symbol|
-      @strategy[symbol] = [] if strategy_params[symbol].nil?
+      if strategy_params[symbol].nil? && @strategy.has_attribute?(symbol)
+        @strategy[symbol] = []
+      end
     end
   end
 

--- a/app/controllers/moments_controller.rb
+++ b/app/controllers/moments_controller.rb
@@ -2,6 +2,7 @@
 class MomentsController < ApplicationController
   include CollectionPageSetupConcern
   include MomentsHelper
+  include MomentsConcern
   include MomentsStatsHelper
   include MomentsFormHelper
   include Shared
@@ -120,19 +121,5 @@ class MomentsController < ApplicationController
       strategy_ids << strategy.id if strategy.viewer?(current_user)
     end
     Strategy.where(id: strategy_ids).order(created_at: :desc)
-  end
-
-  def publishing?
-    params[:publishing] == '1'
-  end
-
-  def saving_as_draft?
-    !publishing?
-  end
-
-  def empty_array_for(*symbols)
-    symbols.each do |symbol|
-      @moment[symbol] = [] if moment_params[symbol].nil?
-    end
   end
 end

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -123,8 +123,8 @@ class StrategiesController < ApplicationController
 
   def strategy_params
     params.require(:strategy).permit(
-      :name, :description, :published_at, :draft, :comment, { category: [] },
-      { viewers: [] }, perform_strategy_reminder_attributes: %i[active id]
+      :name, :description, :published_at, :draft, :comment, category: [],
+      viewers: [], perform_strategy_reminder_attributes: %i[active id]
     )
   end
 

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -123,8 +123,8 @@ class StrategiesController < ApplicationController
 
   def strategy_params
     params.require(:strategy).permit(
-      :name, :description, :published_at, :draft, :comment, category: [],
-      viewers: [], perform_strategy_reminder_attributes: %i[active id]
+      :name, :description, :published_at, :draft, :comment, { category: [] },
+      { viewers: [] }, perform_strategy_reminder_attributes: %i[active id]
     )
   end
 

--- a/app/helpers/most_focus_helper.rb
+++ b/app/helpers/most_focus_helper.rb
@@ -26,12 +26,10 @@ module MostFocusHelper
   def get_data_objs(item, data_type)
     if data_type == 'moods'
       item.moods.pluck(:id)
-    elsif data_type == 'categories' && item.is_a?(Moment)
+    elsif data_type == 'categories'
       item.categories.pluck(:id)
     elsif data_type == 'strategies'
       item.strategies.pluck(:id)
-    else
-      item[data_type]
     end
   end
 

--- a/app/helpers/strategies_form_helper.rb
+++ b/app/helpers/strategies_form_helper.rb
@@ -100,7 +100,7 @@ module StrategiesFormHelper
         id: item.slug,
         label: item.name,
         value: item.id,
-        checked: @strategy.category.include?(item.id)
+        checked: @strategy.categories.include?(item)
       )
     end
     checkboxes

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -70,12 +70,10 @@ module TagsHelper
   def tagged_data_result(tag, data)
     if tag.is_a?(Mood)
       get_moods_from_data(data, tag)
-    elsif tag.is_a?(Category) && data.first.is_a?(Moment)
+    elsif tag.is_a?(Category)
       get_categories_from_data(data, tag)
     elsif tag.is_a?(Strategy)
       get_strategies_from_data(data, tag)
-    else
-      get_attribute_from_data(data, tag)
     end
   end
 

--- a/app/helpers/viewers_helper.rb
+++ b/app/helpers/viewers_helper.rb
@@ -43,13 +43,9 @@ module ViewersHelper
   end
 
   def get_viewers(data, data_type, obj)
-    data_types = %w[moods categories strategies]
     objs = obj.where(user_id: data.user_id).all.order('created_at DESC')
     objs.each do |ob|
-      item = ob.send(ob.is_a?(Strategy) ? data_type.singularize : data_type)
-      if !ob.is_a?(Strategy) && data_types.include?(data_type)
-        item = item.pluck(:id)
-      end
+      item = ob.send(data_type).pluck(:id)
       return ob.viewers if item.include?(data.id)
     end
     []

--- a/app/models/concerns/common_methods.rb
+++ b/app/models/concerns/common_methods.rb
@@ -5,22 +5,13 @@ module CommonMethods
   def mood_names_and_slugs
     return unless self.class.reflect_on_association(:moods)
 
-    names_and_slugs_hash(
-      moods.pluck(:name, :slug),
-      'moods'
-    )
+    names_and_slugs_hash(moods.pluck(:name, :slug), 'moods')
   end
 
   def category_names_and_slugs
-    # TODO: Remove usage of Category when Strategy Categories is created
-    if is_a?(Strategy) && attribute(:category)
-      names_and_slugs_hash(
-        Category.where(id: category).pluck(:name, :slug),
-        'categories'
-      )
-    elsif self.class.reflect_on_association(:categories)
-      names_and_slugs_hash(categories.pluck(:name, :slug), 'categories')
-    end
+    return unless self.class.reflect_on_association(:categories)
+
+    names_and_slugs_hash(categories.pluck(:name, :slug), 'categories')
   end
 
   private

--- a/db/migrate/20200225010346_drop_strategies_category_column.rb
+++ b/db/migrate/20200225010346_drop_strategies_category_column.rb
@@ -1,0 +1,5 @@
+class DropStrategiesCategoryColumn < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :strategies, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_25_003308) do
+ActiveRecord::Schema.define(version: 2020_02_25_010346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -214,7 +214,6 @@ ActiveRecord::Schema.define(version: 2020_02_25_003308) do
 
   create_table "strategies", force: :cascade do |t|
     t.integer "user_id"
-    t.text "category"
     t.text "description"
     t.text "viewers"
     t.boolean "comment"

--- a/lib/tasks/cleaner.rake
+++ b/lib/tasks/cleaner.rake
@@ -13,9 +13,4 @@ namespace :cleaner do
       end
     end
   end
-
-  desc 'Convert existing Straregy category IDs to join table records'
-  task populate_strategies_categories: :environment do
-    Strategy.populate_strategies_categories
-  end
 end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -198,13 +198,14 @@ RSpec.describe CategoriesController, type: :controller do
       end
       it 'removes categories from existing strategies' do
         delete :destroy, params: { id: category.id }
-        expect(strategy.reload.category).not_to include(category.id)
+        expect(strategy.reload.categories).not_to include(category.id)
       end
       it 'redirects to the category index page' do
         delete :destroy, params: { id: category.id }
         expect(response).to redirect_to categories_path
       end
     end
+
     context 'when the user is not logged in' do
       before { delete :destroy, params: { id: category.id } }
       it_behaves_like :with_no_logged_in_user

--- a/spec/controllers/strategies_controller_spec.rb
+++ b/spec/controllers/strategies_controller_spec.rb
@@ -233,25 +233,29 @@ describe StrategiesController do
       include_context :logged_in_user
 
       context 'when the params are valid' do
-        it 'updates the strategy record' do
+        before(:each) do
           patch :update, params: { id: strategy.id, strategy: valid_strategy_params }
+        end
+
+        it 'updates the strategy record' do
           expect(strategy.reload.description).to eq('updated description')
         end
 
         it 'redirects to the show page' do
-          patch :update, params: { id: strategy.id, strategy: valid_strategy_params }
           expect(response).to redirect_to(strategy_path(strategy))
         end
       end
 
       context 'when the params are invalid' do
-        it 'does not update the record' do
+        before(:each) do
           patch :update, params: { id: strategy.id, strategy: invalid_strategy_params }
+        end
+
+        it 'does not update the record' do
           expect(strategy.reload.description).to eq('Test Description')
         end
 
         it 'renders the edit view' do
-          patch :update, params: { id: strategy.id, strategy: invalid_strategy_params }
           expect(response).to render_template('edit')
         end
       end

--- a/spec/helpers/shared_examples.rb
+++ b/spec/helpers/shared_examples.rb
@@ -14,8 +14,6 @@ shared_examples :most_focus do |data_type|
     data_type_name = 'categories'
   elsif data_type == :strategy
     data_type_name = 'strategies'
-  else
-    data_type_name = data_type.to_s
   end
 
   before do

--- a/spec/models/strategy_spec.rb
+++ b/spec/models/strategy_spec.rb
@@ -25,7 +25,6 @@ describe Strategy do
   end
 
   context 'with serialize' do
-    it { is_expected.to serialize(:category) }
     it { is_expected.to serialize(:viewers) }
   end
 
@@ -100,58 +99,9 @@ describe Strategy do
     end
   end
 
-  describe '.populate_strategies_categories' do
-    let(:user) { create(:user) }
-    let(:user_two) { create(:user) }
-
-    let(:category) { create(:category, user: user) }
-    let(:category_two) { create(:category, user: user) }
-    let(:category_three) { create(:category, user: user_two) }
-
-    let!(:strategy) { create(:strategy, user: user, category: [category.id]) }
-    let!(:strategy_two) {
-      create(:strategy, user: user, category: [category.id, category_two.id]) }
-    let!(:strategy_three) {
-      create(:strategy, user: user_two, category: [category_three.id]) }
-    let!(:strategy_four) { create(:strategy, user: user_two) }
-
-    it 'creates join table records' do
-      # Must delete join table records because they're automatically saved
-      ActiveRecord::Base.connection.execute("DELETE from strategies_categories")
-      expect(strategy.categories.count).to eq(0)
-      expect(strategy_two.categories.count).to eq(0)
-      expect(strategy_three.categories.count).to eq(0)
-      expect(strategy_four.categories.count).to eq(0)
-
-      Strategy.populate_strategies_categories
-
-      expect(strategy.categories.count).to eq(1)
-      expect(strategy.categories).to include category
-
-      expect(strategy_two.categories.count).to eq(2)
-      expect(strategy_two.categories).to include category
-      expect(strategy_two.categories).to include category_two
-
-      expect(strategy_three.categories.count).to eq(1)
-      expect(strategy_three.categories).to include category_three
-
-      expect(strategy_four.categories.count).to eq(0)
-    end
-  end
-
   describe '#category_array_data' do
     let!(:strategy) { create(:strategy) }
     let!(:category) { create(:category, user: strategy.user) }
-
-    context 'saving categories as IDs' do
-      it 'sets categories on field upon save' do
-        expect(strategy.category).to eq([])
-        strategy.category = [category.id.to_s]
-        expect {
-          strategy.save
-        }.to change{ strategy.category }.to([category.id])
-      end
-    end
 
     context 'saving categories via relation' do
       let!(:category_two) { create(:category, user: strategy.user) }


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This PR cleans up the category column from the Strategy table and updates the UI to use `strategy.categories`. It also removes the rake task `populate_strategies_categories`.

Everything has been manually tested!

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
