### PR TITLE
Fix strategy and medication reminders bug

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -92,6 +92,8 @@ class MedicationsController < ApplicationController
   # DELETE /medications/1.json
   def destroy
     @medication.destroy
+    TakeMedicationReminder.where(medication_id: @medication.id).destroy_all
+    RefillReminder.where(medication_id: @medication.id).destroy_all
     redirect_to_path(medications_path)
   end
 
@@ -124,12 +126,10 @@ class MedicationsController < ApplicationController
 
   def medication_params
     params.require(:medication).permit(
-      :name, :dosage, :refill, :total, :strength,
-      :dosage_unit, :total_unit, :strength_unit,
-      :comments, :add_to_google_cal,
+      :name, :dosage, :refill, :total, :strength, :dosage_unit,
+      :total_unit, :strength_unit, :comments, :add_to_google_cal,
       take_medication_reminder_attributes: %i[active id],
-      refill_reminder_attributes: %i[active id],
-      weekly_dosage: []
+      refill_reminder_attributes: %i[active id], weekly_dosage: []
     )
   end
 end

--- a/app/controllers/strategies_controller.rb
+++ b/app/controllers/strategies_controller.rb
@@ -34,8 +34,7 @@ class StrategiesController < ApplicationController
   def quick_create
     # Assume all viewers and comments allowed
     viewers = current_user.allies_by_status(:accepted).pluck(:id)
-    strategy = Strategy.new(quick_create_params(viewers))
-    shared_quick_create(strategy)
+    shared_quick_create(Strategy.new(quick_create_params(viewers)))
   end
 
   # GET /strategies/new
@@ -101,6 +100,7 @@ class StrategiesController < ApplicationController
   # DELETE /strategies/1.json
   def destroy
     shared_destroy(@strategy)
+    PerformStrategyReminder.where(strategy_id: @strategy.id).destroy_all
   end
 
   def tagged

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,6 +12,8 @@ class NotificationMailer < ApplicationMailer
   end
 
   def perform_strategy(reminder)
+    return if reminder.strategy.blank?
+
     reminder_mailer(reminder.strategy, 'strategies.reminder_mailer.subject')
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -4,10 +4,14 @@ class NotificationMailer < ApplicationMailer
   default from: ENV['SMTP_ADDRESS']
 
   def take_medication(reminder)
+    return if reminder.medication.blank?
+
     reminder_mailer(reminder.medication, 'medications.reminder_mailer.subject')
   end
 
   def refill_medication(reminder)
+    return if reminder.medication.blank?
+
     reminder_mailer(reminder.medication, 'medications.refill_mailer.subject')
   end
 

--- a/spec/controllers/medications_controller_spec.rb
+++ b/spec/controllers/medications_controller_spec.rb
@@ -266,4 +266,106 @@ describe MedicationsController do
       it_behaves_like :with_no_logged_in_user
     end
   end
+
+  describe '#destroy' do
+    let(:user) { create(:user) }
+
+    context 'when medication has no reminders' do
+      let!(:medication) { create(:medication, user: user) }
+
+      context 'when the user is logged in' do
+        include_context :logged_in_user
+
+        it 'destroys the medication' do
+          expect { delete :destroy, params: { id: medication.id } }.to(
+            change(Medication, :count).by(-1)
+          )
+        end
+
+        it 'redirects to the medications path for html requests' do
+          delete :destroy, params: { id: medication.id }
+          expect(response).to redirect_to(medications_path)
+        end
+
+        it 'responds with no content to json requests' do
+          delete :destroy, format: 'json', params: { id: medication.id }
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the user is not logged in' do
+        before { delete :destroy, params: { id: medication.id } }
+
+        it_behaves_like :with_no_logged_in_user
+      end
+    end
+
+    context 'when medication has a daily reminder' do
+      let!(:medication) do
+        create(:medication, :with_daily_reminder, user: user)
+      end
+
+      context 'when the user is logged in' do
+        include_context :logged_in_user
+
+        it 'destroys the medication' do
+          expect(TakeMedicationReminder.active.count).to eq(1)
+          expect { delete :destroy, params: { id: medication.id } }.to(
+            change(Medication, :count).by(-1)
+          )
+          expect(TakeMedicationReminder.active.count).to eq(0)
+        end
+
+        it 'redirects to the medications path for html requests' do
+          delete :destroy, params: { id: medication.id }
+          expect(response).to redirect_to(medications_path)
+        end
+
+        it 'responds with no content to json requests' do
+          delete :destroy, format: 'json', params: { id: medication.id }
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the user is not logged in' do
+        before { delete :destroy, params: { id: medication.id } }
+
+        it_behaves_like :with_no_logged_in_user
+      end
+    end
+
+    context 'when medication has a refill reminder' do
+      let!(:medication) do
+        create(:medication, :with_refill_reminder, user: user)
+      end
+
+      context 'when the user is logged in' do
+        include_context :logged_in_user
+
+        it 'destroys the medication' do
+          expect(RefillReminder.active.count).to eq(1)
+          expect { delete :destroy, params: { id: medication.id } }.to(
+            change(Medication, :count).by(-1)
+          )
+          expect(RefillReminder.active.count).to eq(0)
+        end
+
+        it 'redirects to the medications path for html requests' do
+          delete :destroy, params: { id: medication.id }
+          expect(response).to redirect_to(medications_path)
+        end
+
+        it 'responds with no content to json requests' do
+          delete :destroy, format: 'json', params: { id: medication.id }
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the user is not logged in' do
+        before { delete :destroy, params: { id: medication.id } }
+
+        it_behaves_like :with_no_logged_in_user
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->
In production, we're getting the following error from our `
scheduler:send_perform_strategy_reminders` rake task.

```
NoMethodError
undefined method `user' for nil:NilClass
Did you mean?  super
```

This is happening when a reminder is being created for a strategy that no longer exists. 

## More Details

<!--[More details on your changes, remove if not applicable]-->

This PR fixes this by doing two things:
* Deleting corresponding `PerformStrategyReminder`s when a strategy is deleted
* Does not run `reminder_mailer` in `perform_strategy` if `reminder.strategy` does not exist

This PR also fixes a similar bug for `Medications`.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
