### PR TITLE
 Fix test warning in DynamicForm.spec.jsx

### DIFF
--- a/client/app/components/Form/__tests__/DynamicForm.spec.jsx
+++ b/client/app/components/Form/__tests__/DynamicForm.spec.jsx
@@ -7,7 +7,7 @@ import { InputMocks } from '../../../mocks/InputMocks';
 
 // TODO (julianguyen): Include InputTextarea after writing stubs for pell editor
 
-const mockInputs = [
+const defualtMockInputs = [
   { ...InputMocks.inputTextProps, required: true },
   InputMocks.inputSelectProps,
   { ...InputMocks.inputCheckboxGroupProps, required: true },
@@ -16,18 +16,26 @@ const mockInputs = [
   InputMocks.inputSubmitProps,
 ];
 
-const getComponent = (options = {}) => {
-  if (options.nameValue) {
-    mockInputs.unshift({
-      id: 'name-id',
-      type: 'text',
-      name: 'name',
-      label: 'Name',
-      placeholder: 'Some Name Placeholder',
-      info: 'Some Name Info',
-      required: true,
-    });
+const getMockInputs = (nameValue) => {
+  if (nameValue) {
+    return [
+      {
+        id: 'name-id',
+        type: 'text',
+        name: 'name',
+        label: 'Name',
+        placeholder: 'Some Name Placeholder',
+        info: 'Some Name Info',
+        required: true,
+      },
+      ...defualtMockInputs,
+    ];
   }
+  return defualtMockInputs;
+};
+
+const getComponent = (options = {}) => {
+  const mockInputs = getMockInputs(options.nameValue);
   return (
     <DynamicForm
       nameValue={options.nameValue}

--- a/client/app/components/Form/__tests__/DynamicForm.spec.jsx
+++ b/client/app/components/Form/__tests__/DynamicForm.spec.jsx
@@ -7,7 +7,7 @@ import { InputMocks } from '../../../mocks/InputMocks';
 
 // TODO (julianguyen): Include InputTextarea after writing stubs for pell editor
 
-const defualtMockInputs = [
+const defaultMockInputs = [
   { ...InputMocks.inputTextProps, required: true },
   InputMocks.inputSelectProps,
   { ...InputMocks.inputCheckboxGroupProps, required: true },
@@ -28,10 +28,10 @@ const getMockInputs = (nameValue) => {
         info: 'Some Name Info',
         required: true,
       },
-      ...defualtMockInputs,
+      ...defaultMockInputs,
     ];
   }
-  return defualtMockInputs;
+  return defaultMockInputs;
 };
 
 const getComponent = (options = {}) => {


### PR DESCRIPTION
# Description
The test was giving a warning Warning: Encountered two children with the same key, `name-id`. This was caused by the mutation of mockInputs by unshift operation, if the nameValue property is available. Fixed the issue by adding the new input data to the defaultMockInputs without mutating using spread.
## More Details
Minor refactor , created a getMockInputs() to separate out the logic of retrieving the correct mockInput( based on the nameValue property) and creating the component.

## Corresponding Issue
https://github.com/ifmeorg/ifme/issues/1724

# Screenshots

<img width="1021" alt="Screen Shot 2020-04-21 at 00 25 32" src="https://user-images.githubusercontent.com/33631080/79808748-aa94c200-8366-11ea-9c32-f0f50f3a4bfc.png">


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
