### PR TITLE
Update Resources to filter by OR instead of AND

### DIFF
--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -50,7 +50,7 @@
     <% @resources.take(3).each do |item|  %>
       <li><%= link_to item['name'], item['link'] %></li>
     <%end %>
-    <li><%= link_to  "#{t('load_more')}", "/resources?#{@resources_tags}" %></li>
+    <li><%= link_to  "#{t('load_more')}...", "/resources?#{@resources_tags}" %></li>
   </ul>
 </div>
 <% end %>

--- a/client/app/widgets/Resources/__tests__/Resources.spec.jsx
+++ b/client/app/widgets/Resources/__tests__/Resources.spec.jsx
@@ -19,15 +19,21 @@ const getComponent = ({ history } = {}) => (
           'free',
           'texting',
           'android',
-          'iOS',
+          'ios',
         ],
-        languages: ['English', 'Español'],
+        languages: ['en', 'es'],
       },
       {
         name: 'A Canvas of the Minds',
         link: 'https://acanvasoftheminds.com/',
         tags: ['free', 'blog'],
-        languages: ['English'],
+        languages: ['en'],
+      },
+      {
+        name: 'Bloom',
+        link: 'http://www.getbloom.net/',
+        tags: ['ios', 'paid', 'game', 'colouring', 'stress'],
+        languages: ['en'],
       },
     ]}
     history={history}
@@ -35,12 +41,12 @@ const getComponent = ({ history } = {}) => (
 );
 
 describe('Resources', () => {
-  it('adds tag to filter when tag label clicked', () => {
+  it('adds tags to filter when tag labels are clicked', () => {
     const wrapper = mount(getComponent());
-    expect(wrapper.find('.resource').length).toEqual(2);
+    expect(wrapper.find('.resource').length).toEqual(3);
     expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.text()).toContain('2 of 2');
-    const id = wrapper
+    expect(wrapper.text()).toContain('3 of 3');
+    let id = wrapper
       .find('.tag')
       .at(2)
       .text();
@@ -58,15 +64,38 @@ describe('Resources', () => {
         .findWhere((t) => t.text() === id)
         .exists(),
     ).toEqual(true);
-  });
-
-  it('filters when tag selected', () => {
-    const wrapper = mount(getComponent());
+    id = wrapper
+      .find('.tag')
+      .at(8)
+      .text();
+    expect(id).toEqual('ios');
+    wrapper
+      .find('.tag')
+      .at(8)
+      .simulate('click');
+    expect(
+      wrapper
+        .find('.checkboxLabel')
+        .at(0)
+        .text(),
+    ).toEqual(id);
     expect(wrapper.find('.resource').length).toEqual(2);
     expect(wrapper.text()).toContain('2 of 2');
+    expect(
+      wrapper
+        .find('.tag')
+        .findWhere((t) => t.text() === id)
+        .exists(),
+    ).toEqual(true);
+  });
+
+  it('filters when tags are selected', () => {
+    const wrapper = mount(getComponent());
+    expect(wrapper.find('.resource').length).toEqual(3);
+    expect(wrapper.text()).toContain('3 of 3');
     wrapper.find('.tagAutocomplete').simulate('focus');
     expect(wrapper.find('.tagMenu').exists()).toEqual(true);
-    const id = wrapper
+    let id = wrapper
       .find('.tagLabel')
       .at(0)
       .text();
@@ -84,12 +113,36 @@ describe('Resources', () => {
         .findWhere((t) => t.text() === id)
         .exists(),
     ).toEqual(true);
-  });
-
-  it('unfilters when tag unselected', () => {
-    const wrapper = mount(getComponent());
+    wrapper.find('.tagAutocomplete').simulate('focus');
+    id = wrapper
+      .find('.tagLabel')
+      .at(1)
+      .text();
+    expect(id).toEqual('colouring');
+    wrapper
+      .find('.tagLabel')
+      .at(1)
+      .simulate('click');
+    expect(
+      wrapper
+        .find('.checkboxLabel')
+        .at(1)
+        .text(),
+    ).toEqual(id);
     expect(wrapper.find('.resource').length).toEqual(2);
     expect(wrapper.text()).toContain('2 of 2');
+    expect(
+      wrapper
+        .find('.tag')
+        .findWhere((t) => t.text() === id)
+        .exists(),
+    ).toEqual(true);
+  });
+
+  it('unfilters when a tag is unselected', () => {
+    const wrapper = mount(getComponent());
+    expect(wrapper.find('.resource').length).toEqual(3);
+    expect(wrapper.text()).toContain('3 of 3');
     wrapper.find('.tagAutocomplete').simulate('focus');
     const id = wrapper
       .find('.tagLabel')
@@ -108,8 +161,8 @@ describe('Resources', () => {
       });
     });
     wrapper.update();
-    expect(wrapper.find('.resource').length).toEqual(2);
-    expect(wrapper.text()).toContain('2 of 2');
+    expect(wrapper.find('.resource').length).toEqual(3);
+    expect(wrapper.text()).toContain('3 of 3');
   });
 
   describe('when the component updates', () => {

--- a/client/app/widgets/Resources/index.jsx
+++ b/client/app/widgets/Resources/index.jsx
@@ -134,7 +134,7 @@ export class Resources extends React.Component<Props, State> {
       const tagCheck = selectedCheckboxes.map((checkbox: Checkbox) =>
         // eslint-disable-next-line implicit-arrow-linebreak
         resource.tags.concat(resource.languages).includes(checkbox.id));
-      return !tagCheck.includes(false);
+      return selectedCheckboxes.length > 0 ? tagCheck.includes(true) : true;
     });
   };
 


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

The Recommended Resources feature is looking wonderful out in the wild. I notice sometimes when I click the "Load more" link, certain combinations of tags don't yield results. This is cause we're doing an AND when filtering. In order to yield more results for our users, I updated it to an OR. I updated our tests accordingly. We can do some more advanced ranking to order relevant results in another pull request/task.

In addition to this main change, I also added ellipsis after the "Load more" link to improve the look and feel.

# Screenshots

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

Currently in production:

![image](https://user-images.githubusercontent.com/3010728/80454112-5fd2f700-88de-11ea-9ccf-e7571ccb9208.png)

With my changes:

![image](https://user-images.githubusercontent.com/3010728/80454151-74af8a80-88de-11ea-9049-a1cbb804d3fd.png)

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!

![GIF of an animated dinosaur watering some flowers](https://media.giphy.com/media/WPtzVOKMymmZrJv8fO/giphy.gif)