### PR TITLE
Fix resources secret share bug

### DIFF
--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -43,7 +43,7 @@
   </div>
 <% end %>
 
-<% if @resources.any? %>
+<% if @resources.present? %>
 <div class="smallMarginTop">
   <div class="label"><%= label_tag t('moments.show.resources') %></div>
   <ul>

--- a/doc/pages/resources.json
+++ b/doc/pages/resources.json
@@ -850,5 +850,11 @@
     "link": "https://www.tenpercent.com/",
     "tags": ["meditation", "paid", "android", "ios", "podcast"],
     "languages": ["en"]
+  },
+  {
+    "name": "Huddle.care",
+    "link": "https://www.huddle.care/",
+    "tags": ["ocd", "anxiety", "therapy", "counseling", "paid", "support_groups", "communities"],
+    "languages": ["en"]
   }
 ]


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

I discovered a bug introduced by the Resource Recommendations feature that's breaking on Secret Share Moments pages. 

## More Details

<!--[More details on your changes, remove if not applicable]-->

```
ActionView::Template::Error
undefined method `any?' for nil:NilClass
NoMethodError
undefined method `any?' for nil:NilClass
app/views/moments/show.html.erb in _app_views_moments_show_html_erb__167856425740617014_69922722058200 at line 46
  </div>
<% end %>

<% if @resources.any? %>
<div class="smallMarginTop">
  <div class="label"><%= label_tag t('moments.show.resources') %></div>
  <ul>
```

`@resources` will be nil on these pages as we don't want to show them to non-logged in users. So we should be using `present?` instead of `any?` to also do a `nil` check.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
