### PR TITLE
Fix Resources bug on Secret Share pages from latest Resource Recommendations toggle

### DIFF
--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -43,7 +43,7 @@
   </div>
 <% end %>
 
-<% if @moment.resource_recommendations? && @resources.any? %>
+<% if @moment.resource_recommendations? && @resources.present? %>
   <div class="smallMarginTop">
     <div class="label"><%= label_tag t('moments.show.resources') %></div>
     <ul>


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

We need to use `present?` instead of `any?` when determining whether or not to display Resource Recommendations. On Secret Share pages, we do not display `@resources` at all so it will be `nil` and throw an error when `any?` is called.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
