### PR TITLE
Fix PasswordHistory uniqueness bug

### DIFF
--- a/db/migrate/20200513052758_add_user_id_index_to_password_histories.rb
+++ b/db/migrate/20200513052758_add_user_id_index_to_password_histories.rb
@@ -1,0 +1,6 @@
+class AddUserIdIndexToPasswordHistories < ActiveRecord::Migration[6.0]
+  def change
+    add_index :password_histories, [:encrypted_password, :user_id], unique: true
+    add_foreign_key :password_histories, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_09_110917) do
+ActiveRecord::Schema.define(version: 2020_05_13_052758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,6 +191,7 @@ ActiveRecord::Schema.define(version: 2020_05_09_110917) do
     t.integer "user_id", null: false
     t.string "encrypted_password"
     t.datetime "created_at", null: false
+    t.index ["encrypted_password", "user_id"], name: "index_password_histories_on_encrypted_password_and_user_id", unique: true
   end
 
   create_table "perform_strategy_reminders", id: :serial, force: :cascade do |t|
@@ -306,6 +307,7 @@ ActiveRecord::Schema.define(version: 2020_05_09_110917) do
   add_foreign_key "moments_moods", "moods"
   add_foreign_key "moments_strategies", "moments"
   add_foreign_key "moments_strategies", "strategies"
+  add_foreign_key "password_histories", "users"
   add_foreign_key "strategies_categories", "categories"
   add_foreign_key "strategies_categories", "strategies"
 end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

The following warning from Rubocop actually uncovered a bug with our `PasswordHistory` model:

```
app/models/password_history.rb:16:3: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.
validates :encrypted_password, presence: true, uniqueness: { scope: :user_id }
```

We need to add an index to the model on `encrypted_password` and `user_id`. Then add a foreign key on `users`.

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

#1746

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!

![GIF of Stitch going to bed cause we're all tired](https://media.giphy.com/media/Mdf5yBfAciSGc/giphy.gif)