### PR TITLE
Fixes grammar issue on empty moments page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,8 +325,8 @@ en:
       instructions: >-
         You haven't written about any moments yet.<br><br> Don't know where to
         start? What's something that happened today that you would like to share
-        and discuss with a loved one? It can be positive or negative! You can
-        don't have to share it right away - only when you're ready to! Here's an
+        and discuss with a loved one? It can be positive or negative! You don't
+        have to share it right away - only when you're ready to! Here's an
         example of a Moment.
       example_name: Panicking over interview tomorrow!
       example_category: Career


### PR DESCRIPTION
# Description
Removes an extra, out-of-place word on the empty moments page

# Screenshots
### Before
![image](https://user-images.githubusercontent.com/8563846/85905477-c2564f80-b7c8-11ea-8d34-3b3a30d231ad.png)

### After
![image](https://user-images.githubusercontent.com/8563846/85905187-f7ae6d80-b7c7-11ea-910c-b5825d9edc0a.png)


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
