### PR TITLE
Migrate Resource from enzyme to RTL #1795

### DIFF
--- a/client/app/components/Resource/__tests__/Resource.spec.jsx
+++ b/client/app/components/Resource/__tests__/Resource.spec.jsx
@@ -1,6 +1,6 @@
 // @flow
-import { shallow } from 'enzyme';
 import React from 'react';
+import { render, screen } from '@testing-library/react';
 import { Resource } from '../index';
 
 const TAGS = [
@@ -17,68 +17,71 @@ const AUTHOR = 'Desi Rottman';
 const URL = 'http://www.lifesigns.org.uk/';
 
 describe('Resource', () => {
-  it('renders with neither tags nor author', () => {
-    let wrapper = shallow(<Resource title={TITLE} link={URL} />);
-    expect(wrapper.find('.author').exists()).toEqual(false);
-    expect(wrapper.find('.tags').exists()).toEqual(false);
-
-    wrapper = shallow(<Resource title={TITLE} link={URL} tags={TAGS} />);
-    expect(wrapper.find('.author').exists()).toEqual(false);
-    expect(wrapper.find('.tags').exists()).toEqual(false);
-
-    wrapper = shallow(<Resource title={TITLE} link={URL} author={AUTHOR} />);
-    expect(wrapper.find('.author').exists()).toEqual(false);
-    expect(wrapper.find('.tags').exists()).toEqual(false);
-
-    wrapper = shallow(
-      <Resource title={TITLE} link={URL} tags={TAGS} author={AUTHOR} />,
-    );
-    expect(wrapper.find('.author').exists()).toEqual(false);
-    expect(wrapper.find('.tags').exists()).toEqual(false);
+  const {
+    getByRole, getByText, getByTestId, queryByTestId,
+  } = screen;
+  test('it renders with neither tags nor author', () => {
+    render(<Resource title={TITLE} link={URL} />);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(queryByTestId('author-div')).toBeNull();
+    expect(queryByTestId('tags-div')).toBeNull();
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByRole('link')).toBeInTheDocument();
   });
-
-  it('renders with only tags', () => {
-    let wrapper = shallow(
-      <Resource title={TITLE} link={URL} tagged tags={TAGS} />,
-    );
-    expect(wrapper.find('.author').exists()).toEqual(false);
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(TAGS.length);
-
-    wrapper = shallow(
-      <Resource title={TITLE} link={URL} tagged tags={EMPTY_TAGS} />,
-    );
-    expect(wrapper.find('.author').exists()).toEqual(false);
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(0);
+  test('it renders when given tags with no tagged prop', () => {
+    render(<Resource title={TITLE} link={URL} tags={TAGS} />);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(queryByTestId('author-div')).toBeNull();
+    expect(queryByTestId('tags-div')).toBeNull();
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByRole('link')).toBeInTheDocument();
   });
-
-  it('renders with only author', () => {
-    const wrapper = shallow(
-      <Resource title={TITLE} link={URL} external author={AUTHOR} />,
-    );
-    expect(wrapper.find('.author').exists()).toEqual(true);
-    expect(wrapper.find('.tags').exists()).toEqual(false);
+  test('it renders with only tags={TAGS}', () => {
+    render(<Resource title={TITLE} link={URL} tagged tags={TAGS} />);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toHaveTextContent(...TAGS);
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByRole('link')).toBeInTheDocument();
   });
-
-  it('renders with tags and author', () => {
-    let wrapper = shallow(
-      <Resource title={TITLE} link={URL} external tagged />,
-    );
-    expect(wrapper.find('.author').exists()).toEqual(true);
-    expect(wrapper.find('.author').text()).toEqual('');
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(0);
-
-    wrapper = shallow(
+  test('it renders with tags={EMPTY_TAGS} and no author ', () => {
+    render(<Resource title={TITLE} link={URL} tagged tags={EMPTY_TAGS} />);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(queryByTestId('tags-div')).toBeInTheDocument();
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByText(TITLE)).toBeInTheDocument();
+  });
+  test('it renders with external and author={AUTHOR}', () => {
+    render(<Resource title={TITLE} link={URL} external author={AUTHOR} />);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('author-div')).toBeInTheDocument();
+    expect(queryByTestId('tags-div')).toBeNull();
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByTestId('author-div')).toHaveTextContent(AUTHOR);
+    expect(getByText(TITLE)).toBeInTheDocument();
+  });
+  test('it renders with external tagged', () => {
+    render(<Resource title={TITLE} link={URL} external tagged />);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toBeInTheDocument();
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByTestId('author-div')).toHaveClass('author');
+    expect(getByTestId('author-div')).toHaveTextContent('');
+  });
+  test('it renders with external, tagged and author={AUTHOR}', () => {
+    render(
       <Resource title={TITLE} link={URL} external author={AUTHOR} tagged />,
     );
-    expect(wrapper.find('.author').exists()).toEqual(true);
-    expect(wrapper.find('.author').text()).toEqual(AUTHOR);
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(0);
-
-    wrapper = shallow(
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toHaveClass('tags');
+    expect(getByTestId('author-div')).toHaveClass('author');
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByText(AUTHOR)).toBeInTheDocument();
+  });
+  test('it renders with external, tags={TAGS}, tagged, and author={AUTHOR}', () => {
+    render(
       <Resource
         title={TITLE}
         link={URL}
@@ -88,12 +91,16 @@ describe('Resource', () => {
         tags={TAGS}
       />,
     );
-    expect(wrapper.find('.author').exists()).toEqual(true);
-    expect(wrapper.find('.author').text()).toEqual(AUTHOR);
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(TAGS.length);
-
-    wrapper = shallow(
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toHaveClass('tags');
+    expect(getByTestId('tags-div')).toHaveTextContent(...TAGS);
+    expect(getByTestId('author-div')).toHaveClass('author');
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByText(AUTHOR)).toBeInTheDocument();
+  });
+  test('it renders with external, tags={EMPTY_TAGS}, tagged and author={AUTHOR}', () => {
+    render(
       <Resource
         title={TITLE}
         link={URL}
@@ -103,25 +110,34 @@ describe('Resource', () => {
         tags={EMPTY_TAGS}
       />,
     );
-    expect(wrapper.find('.author').exists()).toEqual(true);
-    expect(wrapper.find('.author').text()).toEqual(AUTHOR);
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(0);
-
-    wrapper = shallow(
-      <Resource title={TITLE} link={URL} external tagged tags={TAGS} />,
-    );
-    expect(wrapper.find('.author').exists()).toEqual(true);
-    expect(wrapper.find('.author').text()).toEqual('');
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(TAGS.length);
-
-    wrapper = shallow(
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toHaveClass('tags');
+    expect(getByTestId('tags-div')).toHaveTextContent('');
+    expect(getByTestId('author-div')).toHaveClass('author');
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByText(AUTHOR)).toBeInTheDocument();
+  });
+  test('it renders with external, tagged, and tags={TAGS}', () => {
+    render(<Resource title={TITLE} link={URL} external tagged tags={TAGS} />);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toHaveClass('tags');
+    expect(getByTestId('tags-div')).toHaveTextContent(...TAGS);
+    expect(getByTestId('author-div')).toHaveClass('author');
+    expect(getByTestId('author-div')).toHaveTextContent('');
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByText(TITLE)).toBeInTheDocument();
+  });
+  test('it renders with external, tagged, and tags={EMPTY_TAGS}', () => {
+    render(
       <Resource title={TITLE} link={URL} external tagged tags={EMPTY_TAGS} />,
     );
-    expect(wrapper.find('.author').exists()).toEqual(true);
-    expect(wrapper.find('.author').text()).toEqual('');
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.find('Tag').length).toEqual(0);
+    expect(getByTestId('resource-div')).toBeInTheDocument();
+    expect(getByTestId('tags-div')).toHaveClass('tags');
+    expect(getByTestId('tags-div')).toHaveTextContent('');
+    expect(getByTestId('author-div')).toHaveClass('author');
+    expect(getByTestId('author-div')).toHaveTextContent('');
+    expect(getByRole('link')).toBeInTheDocument();
+    expect(getByText(TITLE)).toBeInTheDocument();
   });
 });

--- a/client/app/components/Resource/index.jsx
+++ b/client/app/components/Resource/index.jsx
@@ -25,7 +25,7 @@ const taggedResources = (
 ) => {
   if (tagged && tags) {
     return (
-      <div className="tags">
+      <div className="tags" data-testid="tags-div">
         {tags.map((tag) => (
           <Tag
             normal
@@ -49,7 +49,11 @@ const taggedResources = (
 
 const authorRes = (external: ?boolean, author: ?string) => {
   if (!external) return null;
-  return <div className={`author ${css.author}`}>{author}</div>;
+  return (
+    <div className={`author ${css.author}`} data-testid="author-div">
+      {author}
+    </div>
+  );
 };
 
 export const Resource = (props: Props) => {
@@ -63,7 +67,7 @@ export const Resource = (props: Props) => {
     updateTagFilter,
   } = props;
   return (
-    <div className={`resource ${css.resource}`}>
+    <div className={`resource ${css.resource}`} data-testid="resource-div">
       <a
         className={css.link}
         href={link}

--- a/doc/pages/contributors.json
+++ b/doc/pages/contributors.json
@@ -308,5 +308,9 @@
   {
     "name": "Aline Ribeiro",
     "link": "https://github.com/AlineRibeiro"
+  },
+  {
+    "name": "Cory Catherall",
+    "link": "https://github.com/Tera15"
   }
 ]


### PR DESCRIPTION

# Description
Refactored tests for Resource component to use React Testing Library

## More Details

Added data-testid to more easily target the div elements for 'resource', 'author', and 'tags' classnames for testing purposes.
 
## Corresponding Issue

[1795](https://github.com/ifmeorg/ifme/issues/1795)

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
