### PR TITLE
Refactor google calendar event controller spec to google calendar event request spec

### DIFF
--- a/spec/requests/meetings/google_calendar_event_spec.rb
+++ b/spec/requests/meetings/google_calendar_event_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
   let(:user) { create(:user_oauth) }
   let(:meeting) { create(:meeting) }
   let(:calendar_uploader) { double }
-  let!(:calendar_event) { double(id: 'someid') }
-  let!(:exception_message) { 'Exception message' }
+  let(:calendar_event) { double(id: 'someid') }
+  let(:exception_message) { 'Exception message' }
 
   before do
     sign_in user
@@ -63,7 +63,6 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
 
   describe '#destroy' do
     let!(:meeting_member) { create(:meeting_member, user_id: user.id, meeting_id: meeting.id, google_cal_event_id: calendar_event.id) }
-    let!(:remove_response) { double }
 
     context 'success' do
       it 'calls calendar_uploader#delete_event' do

--- a/spec/requests/meetings/google_calendar_event_spec.rb
+++ b/spec/requests/meetings/google_calendar_event_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
 
     context 'success' do
       it 'calls calendar_uploader#upload_event' do
+        # Assume
         expect(calendar_uploader).to receive(:upload_event).with(meeting.name, meeting.date_time)
                                                            .and_return(calendar_event)
 
+        # Act
         post meeting_google_calendar_event_path(meeting_id: meeting.id)
 
+        # Assert
         expect(meeting_member.reload.google_cal_event_id).to eq(calendar_event.id)
-
         expect(response).to redirect_to(group_path(meeting.group_id))
         expect(flash[:notice]).to eq(I18n.t('meetings.google_cal.create.success'))
       end
@@ -32,11 +34,14 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
     context 'error' do
       context 'raises client_error_exception' do
         it 'returns client_error_exception message' do
+          # Assume
           expect(calendar_uploader).to receive(:upload_event).with(meeting.name, meeting.date_time)
                                                              .and_raise(Google::Apis::ClientError.new(exception_message))
 
+          # Act
           post meeting_google_calendar_event_path(meeting_id: meeting.id)
 
+          # Assert
           expect(meeting_member.reload.google_cal_event_id).to eq(nil)
           expect(response).to redirect_to(group_path(meeting.group_id))
 
@@ -46,11 +51,14 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
       end
       context 'raises server_error_exception' do
         it 'returns server_error_exception message' do
+          # Assume
           expect(calendar_uploader).to receive(:upload_event).with(meeting.name, meeting.date_time)
                                                              .and_raise(Google::Apis::ServerError.new(exception_message))
 
+          # Act
           post meeting_google_calendar_event_path(meeting_id: meeting.id)
 
+          # Assert
           expect(meeting_member.reload.google_cal_event_id).to eq(nil)
           expect(response).to redirect_to(group_path(meeting.group_id))
 
@@ -66,11 +74,14 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
 
     context 'success' do
       it 'calls calendar_uploader#delete_event' do
+        # Assume
         expect(calendar_uploader).to receive(:delete_event).with(calendar_event.id)
                                                            .and_return('')
 
+        # Act
         delete meeting_google_calendar_event_path(meeting_id: meeting.id)
 
+        # Assert
         expect(meeting_member.reload.google_cal_event_id).to eq(nil)
         expect(response).to redirect_to(group_path(meeting.group_id))
 
@@ -81,11 +92,14 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
     context 'error' do
       context 'raises client_error_exception' do
         it 'calls returns client_error_exception message' do
+          # Assume
           expect(calendar_uploader).to receive(:delete_event).with(calendar_event.id)
                                                              .and_raise(Google::Apis::ClientError.new(exception_message))
 
+          # Act
           delete meeting_google_calendar_event_path(meeting_id: meeting.id)
 
+          # Assert
           expect(meeting_member.reload.google_cal_event_id).to eq(calendar_event.id)
           expect(response).to redirect_to(group_path(meeting.group_id))
 
@@ -95,11 +109,14 @@ RSpec.describe 'GoogleCalendarEvent', type: :request do
       end
       context 'raises server_error_exception' do
         it 'calls returns server_error_exception message' do
+          # Assume
           expect(calendar_uploader).to receive(:delete_event).with(calendar_event.id)
                                                              .and_raise(Google::Apis::ServerError.new(exception_message))
 
+          # Act
           delete meeting_google_calendar_event_path(meeting_id: meeting.id)
 
+          # Assert
           expect(meeting_member.reload.google_cal_event_id).to eq(calendar_event.id)
           expect(response).to redirect_to(group_path(meeting.group_id))
 


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Refactored `spec/controllers/meetings/google_calendar_event_controller_spec.rb` to `spec/request/meetings/google_calendar_event_spec.rb`.

Based on [Stackoverflow discussion in regards to Controller Specs vs Request Specs](https://stackoverflow.com/questions/40851705/controller-specs-vs-request-specs) and the [medium article discussing request and controller specs](https://medium.com/just-tech/rspec-controller-or-request-specs-d93ef563ef11). Controller specs are obsolete since Rails 5 and request specs are in favored over controller specs.

## More Details

- replaces 2 `let!` in `describe` block to just regular `let`
  - doesn't seem like `calendar_event` or `exception_message` needs to be initialized before the test starts (unless I'm missing something and ended up making the test flaky without knowing it after refactoring)
- removes `let!(:remove_response) { double }` since it seems to be dead code
- adds **Arrange**, **Act**, **Assert** comments to easier see each steps of the [AAA unit test pattern](http://wiki.c2.com/?ArrangeActAssert)

## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1817

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
