### PR TITLE
Refactor Invitation controller spec to invitation request spec

### DIFF
--- a/spec/requests/users/invitation_spec.rb
+++ b/spec/requests/users/invitation_spec.rb
@@ -1,24 +1,20 @@
 # frozen_string_literal: true
 
-RSpec.describe ::Users::InvitationsController, type: :controller do
+RSpec.describe 'Invitation', type: :request do
   let(:user) { create(:user, name: 'Jane') }
   let(:invitee1) { 'invited_friend@gmail.com' }
   let(:invitee2) { 'other_friend@gmail.com' }
   let(:invalid_email) { 'invalid_email.com' }
-  let(:invite_one_friend) { post :create, params: { user: { email: invitee1 } } }
-
-  before(:each) {
-    @request.env['devise.mapping'] = Devise.mappings[:user]
-  }
+  let(:invite_one_friend) { post user_invitation_path, params: { user: { email: invitee1 } } }
 
   describe '#create' do
     context 'when a user is not signed in' do
-      before { post :create }
+      before { post user_invitation_path }
       it_behaves_like :with_no_logged_in_user
     end
 
     context 'when a user is signed in' do
-      include_context :logged_in_user
+      before { sign_in user }
 
       context 'when valid params are given' do
         it 'creates a new user if the user does not exist' do
@@ -40,7 +36,7 @@ RSpec.describe ::Users::InvitationsController, type: :controller do
         context 'when the user has invited multiple friends' do
           let(:friends_array) { [invitee1, invitee2] }
           before(:each) do
-            post :create, params: { user: { email: "#{invitee1}, #{invitee2}" } }
+            post user_invitation_path, params: { user: { email: "#{invitee1}, #{invitee2}" } }
           end
 
           it 'creates a new user for each supplied email address' do
@@ -66,7 +62,9 @@ RSpec.describe ::Users::InvitationsController, type: :controller do
       end
 
       context 'when invalid params are given' do
-        let(:invalid_invite) { post :create, params: { user: { email: invalid_email } } }
+        let(:invalid_invite) {
+          post user_invitation_path, params: { user: { email: invalid_email } }
+        }
 
         it 're-renders the invitation form' do
           invalid_invite
@@ -82,7 +80,7 @@ RSpec.describe ::Users::InvitationsController, type: :controller do
 
       context 'when both valid and invalid params are given' do
         before(:each) do
-          post :create, params: { user: { email: "#{invitee1}, #{invalid_email}" } }
+          post user_invitation_path, params: { user: { email: "#{invitee1}, #{invalid_email}" } }
         end
 
         it 'only creates a new User for the valid email' do
@@ -105,35 +103,24 @@ RSpec.describe ::Users::InvitationsController, type: :controller do
   end
 
   describe '#update' do
-    include_context :logged_in_user
     let(:password) { 'passworD@99' }
-
-    before(:each) do
-      invite_one_friend
-    end
+    let(:name) { 'New Person' }
+    let(:invited_user) { User.invite!({ email: invitee1 }, user) }
 
     context 'when valid params are given' do
-      let(:name) { 'New Person' }
-
       it 'creates allyship with pending_from_ally status when a user accepts an invitation' do
-        User.stub(:find_by_invitation_token) do
-          User.last
-        end
-        update_params = { name: name, password: password, password_confirmation: password, invitation_token: User.last.invitation_token }
+        update_params = { name: name, password: password, password_confirmation: password, invitation_token: invited_user.raw_invitation_token }
         allow_any_instance_of(::Users::InvitationsController).to receive(:update_resource_params).and_return(update_params)
-        put :update, params: update_params
-        expect(user.allies_by_status(:pending_from_ally).first).to eq(User.last)
+        put user_invitation_path, params: update_params
+        expect(user.allies_by_status(:pending_from_ally).first).to eq(invited_user)
         expect(response).to have_http_status(302)
       end
     end
 
     context 'when invalid params are given' do
       it 'does not create an allyship' do
-        User.stub(:find_by_invitation_token) do
-          User.last
-        end
         allow_any_instance_of(::Users::InvitationsController).to receive(:update_resource_params).and_return({})
-        put :update, params: {}
+        put user_invitation_path, params: {}
         expect(user.allies_by_status(:pending_from_ally).length).to eq(0)
         expect(response).to have_http_status(200)
       end
@@ -141,12 +128,9 @@ RSpec.describe ::Users::InvitationsController, type: :controller do
 
     context 'when both valid and invalid params are given' do
       it 'does not create an allyship' do
-        User.stub(:find_by_invitation_token) do
-          User.last
-        end
-        update_params = { password: password, password_confirmation: password, invitation_token: User.last.invitation_token }
+        update_params = { password: password, password_confirmation: password, invitation_token: invited_user.raw_invitation_token }
         allow_any_instance_of(::Users::InvitationsController).to receive(:update_resource_params).and_return(update_params)
-        put :update, params: update_params
+        put user_invitation_path, params: update_params
         expect(user.allies_by_status(:pending_from_ally).length).to eq(0)
         expect(response).to have_http_status(200)
       end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Refactored `spec/controllers/users/invitations_controller_spec.rb` to `spec/requests/users/invitation_spec.rb`.

Based on [Stackoverflow discussion in regards to Controller Specs vs Request Specs](https://stackoverflow.com/questions/40851705/controller-specs-vs-request-specs) and the [medium article discussing request and controller specs](https://medium.com/just-tech/rspec-controller-or-request-specs-d93ef563ef11). Controller specs are obsolete since Rails 5 and request specs are in favored over controller specs.

## More Details

- cleans up some of the tests with other RSpec matcher 
- adds some **Assume** steps in case false positives happen
- moves `let` variables into context blocks that uses it
- fixes `describe '#update' do` block by using `raw_invitation` token
- adds **Arrange**, **Act**, **Assume**, **Assert** comments to easier see each steps of the [AAA unit test pattern](http://wiki.c2.com/?ArrangeActAssert)

## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1818

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
