### PR TITLE
Refactor Strategies controller spec to strategy request spec

### DIFF
--- a/spec/requests/strategies_spec.rb
+++ b/spec/requests/strategies_spec.rb
@@ -87,19 +87,20 @@ describe 'Strategy', type: :request do
 
       context 'when the request format is html' do
         it 'redirects to the strategies_path' do
-          post :premade
+          post premade_strategies_path
           expect(response).to redirect_to(strategies_path)
         end
 
         it 'returns status code 204 for json format' do
-          post :premade, as: :json
+          headers = { "ACCEPT" => "application/json" }
+          post premade_strategies_path, headers: headers
           expect(response).to have_http_status(204)
         end
       end
     end
 
     context 'when the user is not logged in' do
-      before { post :premade }
+      before { post premade_strategies_path }
       it_behaves_like :with_no_logged_in_user
     end
   end

--- a/spec/requests/strategies_spec.rb
+++ b/spec/requests/strategies_spec.rb
@@ -8,9 +8,7 @@ describe 'Strategy', type: :request do
     let(:strategy) { create(:strategy, name: 'test', user: user) }
 
     context 'when the user is logged in' do
-      before do
-        sign_in user
-      end
+      before { sign_in user}
 
       context 'when search params are provided' do
         it 'assigns @strategies' do
@@ -47,43 +45,46 @@ describe 'Strategy', type: :request do
     end
   end
 
-  describe '#show', :focus do
+  describe '#show' do
     context 'when the user is logged in' do
-      context 'when the strategy exists' do
-        before { get :show, params: { id: strategy.id } }
+      before { sign_in user }
 
+      context 'when the strategy exists' do
         it 'sets the strategy' do
+          get strategy_path(strategy)
           expect(assigns(:strategy)).to eq(strategy)
         end
 
         it 'renders the show template' do
+          get strategy_path(strategy)
           expect(response).to render_template('show')
         end
       end
 
       context 'when the strategy does not exist' do
-        let(:id) { strategy.id + 1 }
-
         it 'redirects an html request' do
-          get :show, params: { id: id }
+          get strategy_path(strategy.id + 1)
           expect(response).to redirect_to(strategies_path)
         end
 
         it 'renders no content for a json request' do
-          get :show, format: 'json', params: { id: id }
+          headers = { "ACCEPT" => "application/json" }
+          get strategy_path(strategy.id + 1), headers: headers
           expect(response.body).to be_empty
         end
       end
     end
 
     context 'when the user is not logged in' do
-      before { get :show, params: { id: strategy.id } }
+      before { get strategies_path, params: { id: strategy.id } }
       it_behaves_like :with_no_logged_in_user
     end
   end
 
-  describe '#premade' do
+  describe '#premade', :focus do
     context 'when the user is logged in' do
+      before { sign_in user }
+
       context 'when the request format is html' do
         it 'redirects to the strategies_path' do
           post :premade

--- a/spec/requests/strategies_spec.rb
+++ b/spec/requests/strategies_spec.rb
@@ -11,9 +11,9 @@ describe 'Strategy', type: :request do
       before { sign_in user}
 
       context 'when search params are provided' do
-        it 'assigns @strategies' do
+        it 'displays the correct strategies' do
           get strategies_path, params: { search: 'test' }
-          expect(assigns(:strategies)).to eq([strategy])
+          expect(response.body).to include(strategy.name)
         end
 
         it 'renders the index template' do
@@ -52,7 +52,7 @@ describe 'Strategy', type: :request do
       context 'when the strategy exists' do
         it 'sets the strategy' do
           get strategy_path(strategy)
-          expect(assigns(:strategy)).to eq(strategy)
+          expect(response.body).to include(strategy.name)
         end
 
         it 'renders the show template' do
@@ -180,7 +180,7 @@ describe 'Strategy', type: :request do
 
         it 'redirects to the strategy show page for html requests' do
           post strategies_path, params: strategy_params
-          expect(response).to redirect_to(strategy_path(assigns(:strategy)))
+          expect(response).to redirect_to(strategy_path(Strategy.last))
         end
       end
 

--- a/spec/requests/strategies_spec.rb
+++ b/spec/requests/strategies_spec.rb
@@ -362,7 +362,7 @@ describe 'Strategy', type: :request do
     let(:user) { create(:user1) }
     let(:strategy) { create(:strategy, name: 'test', user: user) }
 
-    subject { controller.print_reminders(strategy) }
+    subject { StrategiesController.new.print_reminders(strategy) }
 
     describe 'when strategy has no reminders' do
       let(:strategy) { create(:strategy, user: user) }

--- a/spec/requests/strategies_spec.rb
+++ b/spec/requests/strategies_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe StrategiesController do
+describe 'Strategy', type: :request do
   let(:user) { create(:user) }
   let(:strategy) { create(:strategy, user: user) }
 
@@ -8,45 +8,47 @@ describe StrategiesController do
     let(:strategy) { create(:strategy, name: 'test', user: user) }
 
     context 'when the user is logged in' do
-      include_context :logged_in_user
+      before do
+        sign_in user
+      end
 
       context 'when search params are provided' do
-        before { get :index, params: { search: 'test' } }
-
         it 'assigns @strategies' do
+          get strategies_path, params: { search: 'test' }
           expect(assigns(:strategies)).to eq([strategy])
         end
 
         it 'renders the index template' do
+          get strategies_path
           expect(response).to render_template('index')
         end
       end
 
       context 'when no search params are provided' do
         it 'renders the index template' do
-          get :index
+          get strategies_path
           expect(response).to render_template('index')
         end
       end
 
       context 'when request type is JSON' do
-        before { get :index, params: { page: 1, id: strategy.id }, format: :json }
         it 'returns a response with the correct path' do
+          headers = { "ACCEPT" => "application/json" }
+          params = { page: 1, id: strategy.id }
+          get strategies_path, params: params, headers: headers
           expect(JSON.parse(response.body)['data'].first['link']).to eq strategy_path(strategy)
         end
       end
     end
 
     context 'when the user is not logged in' do
-      before { get :index }
+      before { get strategies_path }
       it_behaves_like :with_no_logged_in_user
     end
   end
 
-  describe '#show' do
+  describe '#show', :focus do
     context 'when the user is logged in' do
-      include_context :logged_in_user
-
       context 'when the strategy exists' do
         before { get :show, params: { id: strategy.id } }
 
@@ -82,8 +84,6 @@ describe StrategiesController do
 
   describe '#premade' do
     context 'when the user is logged in' do
-      include_context :logged_in_user
-
       context 'when the request format is html' do
         it 'redirects to the strategies_path' do
           post :premade
@@ -112,8 +112,6 @@ describe StrategiesController do
 
   describe '#new' do
     context 'when the user is logged in' do
-      include_context :logged_in_user
-
       it 'renders the new template' do
         get :new
         expect(response).to render_template('new')
@@ -132,8 +130,6 @@ describe StrategiesController do
     let!(:strategy2)   { create(:strategy, user: another_user) }
 
     context 'when the user is logged in' do
-      include_context :logged_in_user
-
       context 'when the strategy belongs to the current user' do
         it 'renders the edit template' do
           get :edit, params: { id: strategy1.id }
@@ -165,8 +161,6 @@ describe StrategiesController do
     let(:invalid_strategy_params) { valid_strategy_params.merge(name: nil) }
 
     context 'when the user is logged in' do
-      include_context :logged_in_user
-
       context 'when the params are valid' do
         let(:strategy_params) { { strategy: valid_strategy_params } }
 
@@ -230,8 +224,6 @@ describe StrategiesController do
     let(:invalid_strategy_params) { { description: nil } }
 
     context 'when the user is logged in' do
-      include_context :logged_in_user
-
       context 'when the params are valid' do
         before(:each) do
           patch :update, params: { id: strategy.id, strategy: valid_strategy_params }
@@ -275,8 +267,6 @@ describe StrategiesController do
       let!(:strategy) { create(:strategy, user: user) }
 
       context 'when the user is logged in' do
-        include_context :logged_in_user
-
         it 'destroys the strategy' do
           expect { delete :destroy, params: { id: strategy.id } }.to(
             change(Strategy, :count).by(-1)
@@ -307,7 +297,6 @@ describe StrategiesController do
       end
 
       context 'when the user is logged in' do
-        include_context :logged_in_user
 
         it 'destroys the strategy' do
           expect(PerformStrategyReminder.active.count).to eq(1)
@@ -370,7 +359,6 @@ describe StrategiesController do
     let!(:strategy) { create(:strategy, user_id: user.id, category: [category.id]) }
 
     context 'when the user is logged in' do
-      include_context :logged_in_user
       before do
         get :tagged, params: { page: 1, category_id: category.id }, format: :json
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before { ActionMailer::Base.deliveries.clear }
+  config.filter_run_when_matching :focus
 
   config.before(header: true) do
     config.include HiddenHeaderSupport


### PR DESCRIPTION
# Description

This refactors the tests associated with the `StrategiesController` to use RSpec `request` type tests instead of `controller`

## More Details

Couple things of note:
- I used the built-in Rails routes helpers
- Instead of `include_context :logged_in_user` -> `before { sign_in user }` is used
- I eliminated some of the `before` blocks but could bring them back (I prefer explicitness 😸 ) 
- Added the ability to set `:focus` on a test for running _only_ the test focused.
- Moved `tagged` above `print_reminders` as `tagged` is a route in the controller vs an `include` in the controller

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->
https://github.com/ifmeorg/ifme/issues/1815 <- parent issue
https://github.com/ifmeorg/ifme/issues/1840 <- directly related to this refactor

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
