### PR TITLE
Adjust rubocop MethodLength rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,7 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Metrics/MethodLength:
+  Enabled: true
+  Max: 25

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -57,7 +57,6 @@ class GroupsController < ApplicationController
 
   # PATCH/PUT /groups/1
   # PATCH/PUT /groups/1.json
-  # rubocop:disable Metrics/MethodLength
   def update
     if @group.update(group_params)
       update_leaders
@@ -71,7 +70,6 @@ class GroupsController < ApplicationController
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   # DELETE /groups/1
   # DELETE /groups/1.json

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -17,7 +17,6 @@ module Users
     end
 
     # PUT /resource/invitation
-    # rubocop:disable Metrics/MethodLength
     def update
       raw_invitation_token = update_resource_params[:invitation_token]
       self.resource = accept_resource
@@ -44,7 +43,6 @@ module Users
         respond_with_navigational(resource) { render :edit }
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/helpers/groups_form_helper.rb
+++ b/app/helpers/groups_form_helper.rb
@@ -17,7 +17,6 @@ module GroupsFormHelper
     edit_inputs || common_inputs
   end
 
-  # rubocop:disable Metrics/MethodLength
   def common_inputs
     [
       {
@@ -40,9 +39,7 @@ module GroupsFormHelper
       }
     ]
   end
-  # rubocop:enable Metrics/MethodLength
 
-  # rubocop:disable Metrics/MethodLength
   def edit_inputs
     return unless action_name == 'edit' || action_name == 'update'
 
@@ -68,5 +65,4 @@ module GroupsFormHelper
       required: true
     )
   end
-  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Changes the rubocop `Metrics/MethodLength` rule to a max of 25 lines. This will allow for a little more flexibility for methods with longer if/else statements, error handling, or similar circumstances.

## More Details

May affect https://github.com/ifmeorg/ifme/pull/1860

## Corresponding Issue

closes: #1863 

# Screenshots

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
