### PR TITLE
[Issue #1839] Refactor secret_shares controller spec to request spec

### DIFF
--- a/spec/requests/secret_shares_spec.rb
+++ b/spec/requests/secret_shares_spec.rb
@@ -1,110 +1,116 @@
 # frozen_string_literal: true
 
-describe SecretSharesController, type: :controller do
+describe 'SecretShares', type: :request do
   def raise_record_not_found
     raise_error(ActiveRecord::RecordNotFound)
   end
 
   describe 'POST create' do
-    def do_post_create
-      post :create, params: { moment: moment }
-    end
     let(:moment) { create(:moment, :with_user) }
+
     context 'signed in as creator of the moment' do
-      before do
-        sign_in moment.user
-        do_post_create
-      end
+      before { sign_in moment.user }
 
       it 'Creates Secret Share Identifier' do
+        post secret_shares_path, params: { moment: moment.slug }
+
         expect(moment.reload.secret_share_identifier).not_to be_nil
         expect(response).to redirect_to moment_path(moment, anchor: 'secretShare')
       end
     end
 
     context 'signed in as another user' do
-      before do
-        new_user = create(:user)
-        sign_in new_user
-      end
+      let(:user) { create(:user) }
 
-      specify { expect { do_post_create }.to raise_record_not_found }
+      before { sign_in user }
+
+      it 'returns not found status' do
+        post secret_shares_path, params: { moment: moment.slug }
+
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
     context 'not signed in' do
-      before do
-        do_post_create
-      end
-
       it 'does not create Secret Share Identifier' do
+        post secret_shares_path, params: { moment: moment.slug }
+
         expect(moment.reload.secret_share_identifier).to be_nil
       end
 
       it 'redirects to sign in page' do
+        post secret_shares_path, params: { moment: moment.slug }
+
         expect(response).to redirect_to new_user_session_path
       end
     end
   end
 
   describe 'GET show' do
-    def do_get_show(secret_share_identifier = moment.secret_share_identifier)
-      get :show, params: { id: secret_share_identifier }
-    end
     context 'secret share is valid' do
-      before { do_get_show }
       let(:moment) { create(:moment, :with_user, :with_secret_share) }
-      specify { expect(response).to render_template(:show) }
+
+      it 'renders page' do
+        get secret_share_path(id: moment.secret_share_identifier)
+
+        expect(response).to be_successful
+      end
     end
 
     context 'no secret share' do
-      specify do
-        expect { do_get_show('foobar') }
-          .to raise_record_not_found
+      it 'returns not found status' do
+        get secret_share_path(id: 'foobar')
+
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     # TODO: temporarily disable
     # context 'when secret share has expired' do
     #   let(:moment) { create(:moment, :with_user, :with_expired_secret_share) }
-    #   specify { expect { do_get_show }.to raise_record_not_found }
+    #   it 'returns not found' do
+    #     get secret_share_path(id: moment.secret_share_identifier)
+
+    #     expect(response).to have_http_status(:not_found)
+    #   end
     # end
   end
 
   describe 'DELETE' do
-    def do_delete_destroy
-      delete :destroy, params: { id: moment.id }
-    end
     let(:moment) { create(:moment, :with_user, :with_secret_share) }
+
     context 'signed in as creator of the moment' do
-      before do
-        sign_in moment.user
-        do_delete_destroy
-      end
+      before { sign_in moment.user }
 
       it 'deletes Secret Share Identifier' do
+        delete secret_share_path(id: moment.id)
+
         expect(moment.reload.secret_share_identifier).to be_nil
       end
     end
 
     context 'signed in as another user' do
-      before do
-        new_user = create(:user)
-        sign_in new_user
-      end
+      let(:user) { create(:user) }
 
-      specify { expect { do_delete_destroy }.to raise_record_not_found }
+      before { sign_in user }
+
+      it 'returns not found status' do
+        delete secret_share_path(id: moment.id)
+
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
     context 'not signed in' do
-      before do
-        do_delete_destroy
-      end
-
       it 'redirects to sign in page' do
+        delete secret_share_path(id: moment.id)
+
         expect(response).to redirect_to new_user_session_path
       end
 
       it 'does not delete Secret Share Identifier' do
+        delete secret_share_path(id: moment.id)
+
         expect(moment.reload.secret_share_identifier).not_to be_nil
       end
     end


### PR DESCRIPTION
# Description

This refactors the tests associated with the SecretSharesController to use RSpec request type tests instead of controller

## Corresponding Issue

Fixes #1839
Parent issue: https://github.com/ifmeorg/ifme/issues/1815

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
