### PR TITLE
feat: #1792 Migrate 'components/Inputs/' tests to React Testing Library

### DIFF
--- a/client/app/components/Input/InputCheckboxGroup.jsx
+++ b/client/app/components/Input/InputCheckboxGroup.jsx
@@ -6,7 +6,7 @@ import type { Checkbox } from './utils';
 export type Props = {
   checkboxes: Checkbox[],
   required?: boolean, // At least one checkbox must be checked
-  hasError?: Function,
+  hasError?: (errorPresent: boolean) => void,
 };
 
 export function InputCheckboxGroup({

--- a/client/app/components/Input/InputSwitch.jsx
+++ b/client/app/components/Input/InputSwitch.jsx
@@ -37,7 +37,7 @@ export function InputSwitch({
     setKey(Utils.randomString());
   };
 
-  const onKeyPress = (e: SyntheticKeyboardEvent<HTMLInputElement>) => {
+  const onKeyDown = (e: SyntheticKeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       toggleChecked();
     }
@@ -48,7 +48,6 @@ export function InputSwitch({
       <InputCheckbox
         id={id}
         key={key}
-        type="checkbox"
         name={name}
         label={label}
         value={value}
@@ -70,7 +69,7 @@ export function InputSwitch({
       id={`${id}_switch`}
       className={`switchToggle ${css.switchToggle}`}
       onClick={toggleChecked}
-      onKeyPress={onKeyPress}
+      onKeyDown={onKeyDown}
       role="switch"
       aria-checked={checked}
       tabIndex={0}

--- a/client/app/components/Input/InputTag.jsx
+++ b/client/app/components/Input/InputTag.jsx
@@ -128,7 +128,7 @@ export function InputTag({
 
   const shouldRenderSuggestions = () => true;
 
-  const onKeyPress = (e: SyntheticKeyboardEvent<HTMLInputElement>) => {
+  const onKeyDown = (e: SyntheticKeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && onChange) {
       e.preventDefault();
       onChange({ label: autocompleteLabel, checkboxes });
@@ -156,7 +156,7 @@ export function InputTag({
         onChange: onAutocompleteChange,
         value: autocompleteLabel || '',
         className: `tagAutocomplete ${inputCss.tagAutocomplete}`,
-        onKeyPress,
+        onKeyDown,
         placeholder,
       }}
     />

--- a/client/app/components/Input/__tests__/Input.spec.jsx
+++ b/client/app/components/Input/__tests__/Input.spec.jsx
@@ -1,27 +1,40 @@
 // @flow
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InputMocks } from 'mocks/InputMocks';
+import css from '../Input.scss';
+
+/**
+ * TODO: Follow up on an issue when using the matcher `.toBeVisible()` on the inputs directly.
+ * The components behave correctly, but the computed styles don't seem to correspond.
+ * Even if the accordion is closed, and uses the class 'accordionClosed', the actual style returns
+ * a visible value for the 'display' property, as opposed to the expected value 'none'.
+ * This is also seen with the helper `.toHaveStyle()` (in @testing-library/jest-dom@5.11.4).
+ * For now, checking whether div["role='region'"] from Accordion has the class 'accordionClosed'.
+ */
 
 describe('Input', () => {
   describe('InputDefault', () => {
     describe('with accordion prop', () => {
       it('toggles correctly', () => {
-        const wrapper = mount(
+        const { label } = InputMocks.inputTextProps;
+        render(
           InputMocks.createInput(InputMocks.inputTextProps, {
             accordion: true,
           }),
         );
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(false);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(true);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(false);
+
+        const input = screen.getByRole('textbox');
+        const button = screen.getByRole('button', { name: new RegExp(label) });
+        const accordionContainer = screen.getByRole('region');
+
+        expect(input).toBeInTheDocument();
+
+        expect(accordionContainer).toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).not.toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).toHaveClass(css.accordionClose);
       });
     });
   });
@@ -29,22 +42,27 @@ describe('Input', () => {
   describe('CheckboxGroup', () => {
     describe('with accordion prop', () => {
       it('toggles correctly', () => {
-        const wrapper = mount(
+        const {
+          label: groupLabel,
+          checkboxes: [{ label }],
+        } = InputMocks.inputCheckboxGroupProps;
+        render(
           InputMocks.createInput(InputMocks.inputCheckboxGroupProps, {
             accordion: true,
           }),
         );
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(false);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(true);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(false);
+
+        const checkbox = screen.getByRole('checkbox', { name: label });
+        const button = screen.getByRole('button', { name: groupLabel });
+        const accordionContainer = screen.getByRole('region');
+
+        expect(checkbox).toBeInTheDocument();
+
+        expect(accordionContainer).toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).not.toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).toHaveClass(css.accordionClose);
       });
     });
   });
@@ -52,22 +70,24 @@ describe('Input', () => {
   describe('Select', () => {
     describe('with accordion prop', () => {
       it('toggles correctly', () => {
-        const wrapper = mount(
+        const { label } = InputMocks.inputSelectProps;
+        render(
           InputMocks.createInput(InputMocks.inputSelectProps, {
             accordion: true,
           }),
         );
-        expect(
-          wrapper.find('.accordionContent').find('select').exists(),
-        ).toEqual(false);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('select').exists(),
-        ).toEqual(true);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('select').exists(),
-        ).toEqual(false);
+
+        const combobox = screen.getByRole('combobox');
+        const button = screen.getByRole('button', { name: label });
+        const accordionContainer = screen.getByRole('region');
+
+        expect(combobox).toBeInTheDocument();
+
+        expect(accordionContainer).toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).not.toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).toHaveClass(css.accordionClose);
       });
     });
   });
@@ -75,22 +95,24 @@ describe('Input', () => {
   describe('Tag', () => {
     describe('with accordion prop', () => {
       it('toggles correctly', () => {
-        const wrapper = mount(
+        const { label } = InputMocks.inputTagProps;
+        render(
           InputMocks.createInput(InputMocks.inputTagProps, {
             accordion: true,
           }),
         );
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(false);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(true);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('input').exists(),
-        ).toEqual(false);
+
+        const combobox = screen.getByRole('combobox');
+        const button = screen.getByRole('button', { name: new RegExp(label) });
+        const accordionContainer = screen.getByRole('region');
+
+        expect(combobox).toBeInTheDocument();
+
+        expect(accordionContainer).toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).not.toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).toHaveClass(css.accordionClose);
       });
     });
   });
@@ -98,22 +120,24 @@ describe('Input', () => {
   describe('Switch', () => {
     describe('with accordion prop', () => {
       it('toggles correctly', () => {
-        const wrapper = mount(
+        const { label } = InputMocks.inputSwitchProps;
+        render(
           InputMocks.createInput(InputMocks.inputSwitchProps, {
             accordion: true,
           }),
         );
-        expect(
-          wrapper.find('.accordionContent').find('.switch').exists(),
-        ).toEqual(false);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('.switch').exists(),
-        ).toEqual(true);
-        wrapper.find('.accordion').simulate('click');
-        expect(
-          wrapper.find('.accordionContent').find('.switch').exists(),
-        ).toEqual(false);
+
+        const switchInput = screen.getByRole('switch');
+        const button = screen.getByRole('button', { name: new RegExp(label) });
+        const accordionContainer = screen.getByRole('region');
+
+        expect(switchInput).toBeInTheDocument();
+
+        expect(accordionContainer).toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).not.toHaveClass(css.accordionClose);
+        userEvent.click(button);
+        expect(accordionContainer).toHaveClass(css.accordionClose);
       });
     });
   });

--- a/client/app/components/Input/__tests__/Input.spec.jsx
+++ b/client/app/components/Input/__tests__/Input.spec.jsx
@@ -7,10 +7,10 @@ import css from '../Input.scss';
 /**
  * TODO: Follow up on an issue when using the matcher `.toBeVisible()` on the inputs directly.
  * The components behave correctly, but the computed styles don't seem to correspond.
- * Even if the accordion is closed, and uses the class 'accordionClosed', the actual style returns
+ * Even if the accordion is closed, and uses the class 'accordionClose', the actual style returns
  * a visible value for the 'display' property, as opposed to the expected value 'none'.
  * This is also seen with the helper `.toHaveStyle()` (in @testing-library/jest-dom@5.11.4).
- * For now, checking whether div["role='region'"] from Accordion has the class 'accordionClosed'.
+ * For now, checking whether div["role='region'"] from Accordion has the class 'accordionClose'.
  */
 
 describe('Input', () => {

--- a/client/app/components/Input/__tests__/InputCheckbox.spec.jsx
+++ b/client/app/components/Input/__tests__/InputCheckbox.spec.jsx
@@ -1,5 +1,6 @@
 // @flow
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { InputCheckbox } from 'components/Input/InputCheckbox';
 
@@ -18,9 +19,13 @@ describe('InputCheckbox', () => {
     jest.spyOn(window, 'alert');
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('has no uncheckedValue prop', () => {
     it('toggles checkbox correctly', () => {
-      const wrapper = shallow(
+      render(
         <InputCheckbox
           id={id}
           name={name}
@@ -31,21 +36,18 @@ describe('InputCheckbox', () => {
           onChange={someEvent}
         />,
       );
-      expect(wrapper.find('input').props().value).toEqual(value);
-      wrapper
-        .find('input')
-        .simulate('change', { currentTarget: { checked: false } });
+      const checkbox = screen.getByRole('checkbox', { name: label });
+      expect(checkbox).toBeChecked();
+      userEvent.click(checkbox);
       expect(window.alert).toHaveBeenCalledWith('Checkbox some-id is false');
-      wrapper
-        .find('input')
-        .simulate('change', { currentTarget: { checked: true } });
+      userEvent.click(checkbox);
       expect(window.alert).toHaveBeenCalledWith('Checkbox some-id is true');
     });
   });
 
   describe('has a uncheckedValue prop', () => {
     it('toggles checkbox correctly', () => {
-      const wrapper = shallow(
+      const { container } = render(
         <InputCheckbox
           id={id}
           name={name}
@@ -57,19 +59,20 @@ describe('InputCheckbox', () => {
           onChange={someEvent}
         />,
       );
-      expect(wrapper.find('input[type="hidden"]').props().value).toEqual(
-        uncheckedValue,
-      );
-      expect(wrapper.find('input[type="checkbox"]').props().value).toEqual(
-        value,
-      );
-      wrapper
-        .find('input[type="checkbox"]')
-        .simulate('change', { currentTarget: { checked: false } });
+
+      // ensures the input for the uncheckedValue is hidden
+      expect(screen.queryByRole('input')).not.toBeInTheDocument();
+      // Since '@testing-library/react' does not get hidden inputs,
+      // it can be queried directly from the container for this test.
+      const hiddenInput = container.querySelector('input[type="hidden"]');
+      expect(hiddenInput.value).toEqual(uncheckedValue);
+
+      // validates checkbox behavior
+      const checkbox = screen.getByRole('checkbox', { name: label });
+      expect(checkbox).toBeChecked();
+      userEvent.click(checkbox);
       expect(window.alert).toHaveBeenCalledWith('Checkbox some-id is false');
-      wrapper
-        .find('input[type="checkbox"]')
-        .simulate('change', { currentTarget: { checked: true } });
+      userEvent.click(checkbox);
       expect(window.alert).toHaveBeenCalledWith('Checkbox some-id is true');
     });
   });

--- a/client/app/components/Input/__tests__/InputCheckbox.spec.jsx
+++ b/client/app/components/Input/__tests__/InputCheckbox.spec.jsx
@@ -65,7 +65,7 @@ describe('InputCheckbox', () => {
       // Since '@testing-library/react' does not get hidden inputs,
       // it can be queried directly from the container for this test.
       const hiddenInput = container.querySelector('input[type="hidden"]');
-      expect(hiddenInput.value).toEqual(uncheckedValue);
+      expect(hiddenInput).toHaveValue(uncheckedValue);
 
       // validates checkbox behavior
       const checkbox = screen.getByRole('checkbox', { name: label });

--- a/client/app/components/Input/__tests__/InputCheckboxGroup.spec.jsx
+++ b/client/app/components/Input/__tests__/InputCheckboxGroup.spec.jsx
@@ -50,8 +50,9 @@ describe('InputCheckboxGroup', () => {
 
       // toggle both checkboxes false
       userEvent.click(checkbox);
-      userEvent.dblClick(otherCheckbox);
 
+      expect(checkbox).not.toBeChecked();
+      expect(otherCheckbox).not.toBeChecked();
       expect(window.alert).not.toHaveBeenCalled();
     });
   });
@@ -70,8 +71,9 @@ describe('InputCheckboxGroup', () => {
 
       // toggle both checkboxes false
       userEvent.click(checkbox);
-      userEvent.dblClick(otherCheckbox);
 
+      expect(checkbox).not.toBeChecked();
+      expect(otherCheckbox).not.toBeChecked();
       expect(window.alert).toHaveBeenCalledWith('Error');
     });
   });

--- a/client/app/components/Input/__tests__/InputCheckboxGroup.spec.jsx
+++ b/client/app/components/Input/__tests__/InputCheckboxGroup.spec.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import { mount } from 'enzyme';
-import { act } from 'react-dom/test-utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InputCheckboxGroup } from 'components/Input/InputCheckboxGroup';
 
 const id = 'some-id';
@@ -10,7 +10,8 @@ const label = 'Some Label';
 const idTwo = 'some-other-id';
 const nameTwo = 'some-other-name';
 const labelTwo = 'Some Other Label';
-const someEvent = () => {
+const someEvent = (hasError) => {
+  if (!hasError) return;
   window.alert('Error');
 };
 const checkboxes = [
@@ -35,44 +36,42 @@ describe('InputCheckboxGroup', () => {
     jest.spyOn(window, 'alert');
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('has no required prop', () => {
     it('does not call hasError prop when all checkboxes are unchecked', () => {
-      const wrapper = mount(
+      render(
         <InputCheckboxGroup checkboxes={checkboxes} hasError={someEvent} />,
       );
-      act(() => {
-        wrapper
-          .find(`input[name="${name}"][type="checkbox"]`)
-          .prop('onChange')({ currentTarget: { checked: false } });
-      });
-      act(() => {
-        wrapper.find(`input[name="${nameTwo}"]`).prop('onChange')({
-          currentTarget: { checked: false },
-        });
-      });
+      const checkbox = screen.getByRole('checkbox', { name: label });
+      const otherCheckbox = screen.getByRole('checkbox', { name: labelTwo });
+
+      // toggle both checkboxes false
+      userEvent.click(checkbox);
+      userEvent.dblClick(otherCheckbox);
+
       expect(window.alert).not.toHaveBeenCalled();
     });
   });
 
   describe('has required prop', () => {
     it('does calls hasError prop when all checkboxes are unchecked', () => {
-      const wrapper = mount(
+      render(
         <InputCheckboxGroup
           checkboxes={checkboxes}
           hasError={someEvent}
           required
         />,
       );
-      act(() => {
-        wrapper
-          .find(`input[name="${name}"][type="checkbox"]`)
-          .prop('onChange')({ currentTarget: { checked: false } });
-      });
-      act(() => {
-        wrapper.find(`input[name="${nameTwo}"]`).prop('onChange')({
-          currentTarget: { checked: false },
-        });
-      });
+      const checkbox = screen.getByRole('checkbox', { name: label });
+      const otherCheckbox = screen.getByRole('checkbox', { name: labelTwo });
+
+      // toggle both checkboxes false
+      userEvent.click(checkbox);
+      userEvent.dblClick(otherCheckbox);
+
       expect(window.alert).toHaveBeenCalledWith('Error');
     });
   });

--- a/client/app/components/Input/__tests__/InputDefault.spec.jsx
+++ b/client/app/components/Input/__tests__/InputDefault.spec.jsx
@@ -1,5 +1,6 @@
 // @flow
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { InputMocks } from 'mocks/InputMocks';
 import { InputDefault } from 'components/Input/InputDefault';
@@ -18,9 +19,13 @@ describe('InputDefault', () => {
     jest.spyOn(window, 'alert');
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('has invalid type prop', () => {
     it('does not render', () => {
-      const wrapper = shallow(
+      render(
         <InputDefault
           id={id}
           type="invalid"
@@ -32,13 +37,13 @@ describe('InputDefault', () => {
           hasError={someEvent}
         />,
       );
-      expect(wrapper.find('input').exists()).toEqual(false);
+      expect(screen.queryByLabelText(label)).not.toBeInTheDocument();
     });
   });
 
   describe('has valid type prop', () => {
     it('calls hasError prop when value prop is empty', () => {
-      const wrapper = shallow(
+      render(
         <InputDefault
           id={id}
           type="text"
@@ -50,34 +55,33 @@ describe('InputDefault', () => {
           hasError={someEvent}
         />,
       );
-      wrapper
-        .find('input')
-        .simulate('blur', { currentTarget: { value: 'Some Value' } });
+      const textInput = screen.getByRole('textbox', { name: label });
+      expect(textInput).toBeInTheDocument();
+      userEvent.type(textInput, 'Some Value');
+      userEvent.tab();
       expect(window.alert).toHaveBeenCalledWith('Error is false');
-      wrapper.find('input').simulate('blur', { currentTarget: { value: '' } });
+      userEvent.clear(textInput);
+      userEvent.tab();
       expect(window.alert).toHaveBeenCalledWith('Error is true');
     });
   });
 
   describe('has valid copyOnClick prop', () => {
     it('copies to clipboard when input is clicked', () => {
-      jest.spyOn(window, 'alert');
       jest.spyOn(window.document, 'execCommand');
       const copyOnClick = 'Some message';
-      const wrapper = shallow(
+      render(
         <InputDefault
           id={id}
           type="text"
           name={name}
+          label={label}
           copyOnClick={copyOnClick}
         />,
       );
-      wrapper.find('input').simulate('click', {
-        currentTarget: {
-          value: 'test',
-          select: () => {},
-        },
-      });
+      const textInput = screen.getByRole('textbox', { name: label });
+      userEvent.type(textInput, 'test');
+      userEvent.click(textInput);
       expect(window.document.execCommand).toHaveBeenCalledWith('copy');
       expect(window.alert).toHaveBeenCalledWith(copyOnClick);
     });

--- a/client/app/components/Input/__tests__/InputDefault.spec.jsx
+++ b/client/app/components/Input/__tests__/InputDefault.spec.jsx
@@ -20,7 +20,7 @@ describe('InputDefault', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    window.alert.mockClear();
   });
 
   describe('has invalid type prop', () => {

--- a/client/app/components/Input/__tests__/InputDefault.spec.jsx
+++ b/client/app/components/Input/__tests__/InputDefault.spec.jsx
@@ -67,8 +67,15 @@ describe('InputDefault', () => {
   });
 
   describe('has valid copyOnClick prop', () => {
-    it('copies to clipboard when input is clicked', () => {
+    beforeEach(() => {
       jest.spyOn(window.document, 'execCommand');
+    });
+
+    afterEach(() => {
+      window.document.execCommand.mockRestore();
+    });
+
+    it('copies to clipboard when input is clicked', () => {
       const copyOnClick = 'Some message';
       render(
         <InputDefault

--- a/client/app/components/Input/__tests__/InputError.spec.jsx
+++ b/client/app/components/Input/__tests__/InputError.spec.jsx
@@ -1,16 +1,16 @@
 // @flow
-import { shallow } from 'enzyme';
 import React from 'react';
+import { render, screen } from '@testing-library/react';
 import { InputError } from 'components/Input/InputError';
 
 describe('InputError', () => {
   it('renders correctly when error does not exist', () => {
-    const wrapper = shallow(<InputError />);
-    expect(wrapper.find('.labelError').exists()).toEqual(false);
+    render(<InputError />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('renders correctly when error exists', () => {
-    const wrapper = shallow(<InputError error="true" />);
-    expect(wrapper.find('.labelError').exists()).toEqual(true);
+    render(<InputError error="true" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 });

--- a/client/app/components/Input/__tests__/InputLabel.spec.jsx
+++ b/client/app/components/Input/__tests__/InputLabel.spec.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { InputLabel } from 'components/Input/InputLabel';
 
@@ -8,9 +8,9 @@ const info = 'Some Info';
 
 describe('InputLabel', () => {
   it('renders correctly', () => {
-    const wrapper = shallow(
+    render(
       <InputLabel label={label} required info={info} error htmlFor="id" />,
     );
-    expect(wrapper.find('.labelText').exists()).toEqual(true);
+    expect(screen.getByText(label)).toBeInTheDocument();
   });
 });

--- a/client/app/components/Input/__tests__/InputLocation.spec.jsx
+++ b/client/app/components/Input/__tests__/InputLocation.spec.jsx
@@ -13,7 +13,7 @@ describe('InputLocation', () => {
       const value = 'Test Location';
       const autocomplete = screen.getByRole('textbox');
       userEvent.type(autocomplete, value);
-      expect(autocomplete.value).toEqual(value);
+      expect(autocomplete).toHaveValue(value);
     });
   });
 
@@ -33,7 +33,7 @@ describe('InputLocation', () => {
       userEvent.clear(autocomplete);
       const value = 'Test Location';
       userEvent.type(autocomplete, value);
-      expect(autocomplete.value).toEqual(value);
+      expect(autocomplete).toHaveValue(value);
     });
   });
 });

--- a/client/app/components/Input/__tests__/InputLocation.spec.jsx
+++ b/client/app/components/Input/__tests__/InputLocation.spec.jsx
@@ -1,26 +1,26 @@
 // @flow
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { InputLocation } from 'components/Input/InputLocation';
 
 describe('InputLocation', () => {
   describe('has no initialized value', () => {
     it('updates the value of the input', () => {
-      const wrapper = shallow(
+      render(
         <InputLocation placeholder="Location" apiKey="fakeKey" id="fakeId" />,
       );
       const value = 'Test Location';
-      wrapper
-        .find('LocationAutocomplete')
-        .simulate('change', { target: { value } });
-      expect(wrapper.find('LocationAutocomplete').props().value).toEqual(value);
+      const autocomplete = screen.getByRole('textbox');
+      userEvent.type(autocomplete, value);
+      expect(autocomplete.value).toEqual(value);
     });
   });
 
   describe('has an initialized value', () => {
     it('updates the value of the input', () => {
       const initializedValue = 'Hey';
-      const wrapper = shallow(
+      render(
         <InputLocation
           placeholder="Location"
           apiKey="fakeKey"
@@ -28,14 +28,12 @@ describe('InputLocation', () => {
           value={initializedValue}
         />,
       );
-      expect(wrapper.find('LocationAutocomplete').props().value).toEqual(
-        initializedValue,
-      );
+      const autocomplete = screen.getByDisplayValue(initializedValue);
+      expect(autocomplete).toBeInTheDocument();
+      userEvent.clear(autocomplete);
       const value = 'Test Location';
-      wrapper
-        .find('LocationAutocomplete')
-        .simulate('change', { target: { value } });
-      expect(wrapper.find('LocationAutocomplete').props().value).toEqual(value);
+      userEvent.type(autocomplete, value);
+      expect(autocomplete.value).toEqual(value);
     });
   });
 });

--- a/client/app/components/Input/__tests__/InputPassword.spec.jsx
+++ b/client/app/components/Input/__tests__/InputPassword.spec.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import { mount, shallow } from 'enzyme';
-import { act } from 'react-dom/test-utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InputMocks } from 'mocks/InputMocks';
 import { InputPassword } from 'components/Input/InputPassword';
 
@@ -10,16 +10,19 @@ const { id, name, label } = InputMocks.inputPasswordProps;
 describe('InputPassword', () => {
   it('toggles show password button correctly', () => {
     const component = InputMocks.createInput(InputMocks.inputPasswordProps);
-    const wrapper = mount(component);
-    expect(wrapper.find('input').props().type).toEqual('password');
-    expect(wrapper.find('button').props()['aria-label']).toEqual(
-      'Show password',
-    );
-    wrapper.find('button').simulate('click');
-    expect(wrapper.find('input').props().type).toEqual('text');
-    expect(wrapper.find('button').props()['aria-label']).toEqual(
-      'Hide password',
-    );
+    render(component);
+
+    const input = screen.getByLabelText(label);
+    expect(input).toBeInTheDocument();
+    expect(input.type).toEqual('password');
+
+    const button = screen.getByRole('button', { name: 'Show password' });
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
+    expect(input.type).toEqual('text');
+    expect(
+      screen.getByRole('button', { name: 'Hide password' }),
+    ).toBeInTheDocument();
   });
 
   describe('when input is not required', () => {
@@ -38,38 +41,36 @@ describe('InputPassword', () => {
       jest.spyOn(window, 'alert');
     });
 
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
     describe('on input focus', () => {
       it('has no error', () => {
-        const wrapper = shallow(component);
-        act(() => {
-          wrapper.find('input').simulate('focus');
-        });
+        render(component);
+        userEvent.click(screen.getByLabelText(label));
         expect(window.alert).not.toHaveBeenCalled();
       });
     });
 
     describe('on input blur', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
       it('has an error when there is no value', () => {
-        const wrapper = shallow(component);
-        act(() => {
-          wrapper.find('input').simulate('blur', {
-            currentTarget: {
-              value: null,
-            },
-          });
-        });
+        render(component);
+        const input = screen.getByLabelText(label);
+        userEvent.clear(input);
+        userEvent.tab();
         expect(window.alert).not.toHaveBeenCalled();
       });
 
       it('has no error when there is a value', () => {
-        const wrapper = shallow(component);
-        act(() => {
-          wrapper.find('input').simulate('blur', {
-            currentTarget: {
-              value: 'Some value',
-            },
-          });
-        });
+        render(component);
+        const input = screen.getByLabelText(label);
+        userEvent.type(input, 'Some value');
+        userEvent.tab();
         expect(window.alert).not.toHaveBeenCalled();
       });
     });
@@ -92,38 +93,35 @@ describe('InputPassword', () => {
       jest.spyOn(window, 'alert');
     });
 
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
     describe('on input focus', () => {
       it('has no error', () => {
-        const wrapper = shallow(component);
-        act(() => {
-          wrapper.find('input').simulate('focus');
-        });
+        render(component);
+        userEvent.click(screen.getByLabelText(label));
         expect(window.alert).toHaveBeenCalledWith(false);
       });
     });
 
     describe('on input blur', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
       it('has an error when there is no value', () => {
-        const wrapper = shallow(component);
-        act(() => {
-          wrapper.find('input').simulate('blur', {
-            currentTarget: {
-              value: null,
-            },
-          });
-        });
+        render(component);
+        userEvent.clear(screen.getByLabelText(label));
+        userEvent.tab();
         expect(window.alert).toHaveBeenCalledWith(true);
       });
 
       it('has no error when there is a value', () => {
-        const wrapper = shallow(component);
-        act(() => {
-          wrapper.find('input').simulate('blur', {
-            currentTarget: {
-              value: 'Some value',
-            },
-          });
-        });
+        render(component);
+        const input = screen.getByLabelText(label);
+        userEvent.type(input, 'Some value');
+        userEvent.tab();
         expect(window.alert).toHaveBeenCalledWith(false);
       });
     });

--- a/client/app/components/Input/__tests__/InputPassword.spec.jsx
+++ b/client/app/components/Input/__tests__/InputPassword.spec.jsx
@@ -14,12 +14,13 @@ describe('InputPassword', () => {
 
     const input = screen.getByLabelText(label);
     expect(input).toBeInTheDocument();
-    expect(input.type).toEqual('password');
+    expect(input).toHaveAttribute('type', 'password');
 
     const button = screen.getByRole('button', { name: 'Show password' });
     expect(button).toBeInTheDocument();
+
     userEvent.click(button);
-    expect(input.type).toEqual('text');
+    expect(input).toHaveAttribute('type', 'text');
     expect(
       screen.getByRole('button', { name: 'Hide password' }),
     ).toBeInTheDocument();
@@ -48,7 +49,8 @@ describe('InputPassword', () => {
     describe('on input focus', () => {
       it('has no error', () => {
         render(component);
-        userEvent.click(screen.getByLabelText(label));
+        const input = screen.getByLabelText(label);
+        userEvent.click(input);
         expect(window.alert).not.toHaveBeenCalled();
       });
     });
@@ -100,7 +102,8 @@ describe('InputPassword', () => {
     describe('on input focus', () => {
       it('has no error', () => {
         render(component);
-        userEvent.click(screen.getByLabelText(label));
+        const input = screen.getByLabelText(label);
+        userEvent.click(input);
         expect(window.alert).toHaveBeenCalledWith(false);
       });
     });
@@ -112,7 +115,8 @@ describe('InputPassword', () => {
 
       it('has an error when there is no value', () => {
         render(component);
-        userEvent.clear(screen.getByLabelText(label));
+        const input = screen.getByLabelText(label);
+        userEvent.clear(input);
         userEvent.tab();
         expect(window.alert).toHaveBeenCalledWith(true);
       });

--- a/client/app/components/Input/__tests__/InputRadioGroup.spec.jsx
+++ b/client/app/components/Input/__tests__/InputRadioGroup.spec.jsx
@@ -13,9 +13,10 @@ describe('InputRadioGroup', () => {
     render(
       <InputRadioGroup name={name} id={id} value={value} options={options} />,
     );
-    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toBeInTheDocument();
     const defaultOption = screen.getByRole('radio', { name: `${value}` });
     expect(defaultOption).toBeInTheDocument();
-    expect(defaultOption.defaultChecked).toBe(true);
+    expect(defaultOption.defaultChecked).toEqual(true);
   });
 });

--- a/client/app/components/Input/__tests__/InputRadioGroup.spec.jsx
+++ b/client/app/components/Input/__tests__/InputRadioGroup.spec.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { InputMocks } from 'mocks/InputMocks';
 import { InputRadioGroup } from 'components/Input/InputRadioGroup';
 
@@ -9,17 +9,13 @@ const {
 } = InputMocks.inputRadioProps;
 
 describe('InputRadioGroup', () => {
-  beforeEach(() => {
-    jest.spyOn(window, 'alert');
-  });
-
   it('sets default radio button to first option', () => {
-    const wrapper = shallow(
+    render(
       <InputRadioGroup name={name} id={id} value={value} options={options} />,
     );
-    expect(
-      wrapper.find('input[id="some-option-one-id"][type="radio"]').props()
-        .defaultChecked,
-    ).toBe(true);
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    const defaultOption = screen.getByRole('radio', { name: `${value}` });
+    expect(defaultOption).toBeInTheDocument();
+    expect(defaultOption.defaultChecked).toBe(true);
   });
 });

--- a/client/app/components/Input/__tests__/InputSelect.spec.jsx
+++ b/client/app/components/Input/__tests__/InputSelect.spec.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
-import { shallow } from 'enzyme';
-import { act } from 'react-dom/test-utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InputMocks } from 'mocks/InputMocks';
 import { InputSelect } from 'components/Input/InputSelect';
 
@@ -15,8 +15,12 @@ describe('InputSelect', () => {
     jest.spyOn(window, 'alert');
   });
 
-  it('toggles options correctly', () => {
-    const wrapper = shallow(
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    render(
       <InputSelect
         name={name}
         id={id}
@@ -26,17 +30,38 @@ describe('InputSelect', () => {
         onChange={someEvent}
       />,
     );
-    act(() => {
-      wrapper
-        .find('select')
-        .simulate('change', { currentTarget: { value: options[1].value } });
-    });
+    const select = screen.getByRole('combobox', { name: ariaLabel });
+    expect(select).toBeInTheDocument();
+    expect(screen.getAllByRole('option').length).toEqual(2);
+    expect(screen.getByRole('presentation')).toBeInTheDocument();
+  });
+
+  it('toggles options correctly', () => {
+    render(
+      <InputSelect
+        name={name}
+        id={id}
+        ariaLabel={ariaLabel}
+        value={value}
+        options={options}
+        onChange={someEvent}
+      />,
+    );
+    // initial value
+    const select = screen.getByRole('combobox', { name: ariaLabel });
+    userEvent.selectOptions(
+      select,
+      screen.getByRole('option', { name: options[0].label }),
+    );
     expect(window.alert).toHaveBeenCalled();
-    act(() => {
-      wrapper
-        .find('select')
-        .simulate('change', { currentTarget: { value: options[0].value } });
-    });
+    expect(select.value).toEqual(`${options[0].value}`);
+
+    // update value
+    userEvent.selectOptions(
+      select,
+      screen.getByRole('option', { name: options[1].label }),
+    );
     expect(window.alert).toHaveBeenCalled();
+    expect(select.value).toEqual(`${options[1].value}`);
   });
 });

--- a/client/app/components/Input/__tests__/InputSelect.spec.jsx
+++ b/client/app/components/Input/__tests__/InputSelect.spec.jsx
@@ -47,7 +47,7 @@ describe('InputSelect', () => {
         onChange={someEvent}
       />,
     );
-    // initial value
+    // toggle the first value
     const select = screen.getByRole('combobox', { name: ariaLabel });
     userEvent.selectOptions(
       select,
@@ -56,7 +56,7 @@ describe('InputSelect', () => {
     expect(window.alert).toHaveBeenCalled();
     expect(select.value).toEqual(`${options[0].value}`);
 
-    // update value
+    // update the value
     userEvent.selectOptions(
       select,
       screen.getByRole('option', { name: options[1].label }),

--- a/client/app/components/Input/__tests__/InputSubmit.spec.jsx
+++ b/client/app/components/Input/__tests__/InputSubmit.spec.jsx
@@ -1,5 +1,6 @@
 // @flow
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { InputMocks } from 'mocks/InputMocks';
 import { InputSubmit } from 'components/Input/InputSubmit';
@@ -13,13 +14,23 @@ describe('InputSubmit', () => {
     jest.spyOn(window, 'alert');
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('toggles clicking correctly', () => {
-    const wrapper = shallow(
-      <InputSubmit id={id} onClick={someEvent} value={value} />,
-    );
-    wrapper.find('input').simulate('click');
+    render(<InputSubmit id={id} onClick={someEvent} value={value} />);
+    const button = screen.getByRole('button', { name: value });
+    userEvent.click(button);
     expect(window.alert).toHaveBeenCalled();
-    wrapper.find('input').simulate('click');
+    userEvent.click(button);
     expect(window.alert).toHaveBeenCalled();
+  });
+
+  it('does not toggle if disabled', () => {
+    render(<InputSubmit id={id} onClick={someEvent} value={value} disabled />);
+    const button = screen.getByRole('button', { name: value });
+    userEvent.click(button);
+    expect(window.alert).not.toHaveBeenCalled();
   });
 });

--- a/client/app/components/Input/__tests__/InputSwitch.spec.jsx
+++ b/client/app/components/Input/__tests__/InputSwitch.spec.jsx
@@ -9,9 +9,7 @@ describe('InputSwitch', () => {
   it('renders correctly', () => {
     render(component);
     expect(screen.getByRole('switch')).toBeInTheDocument();
-    expect(
-      screen.getByRole('checkbox', { hidden: true }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
   });
 
   describe('with mouse', () => {
@@ -36,6 +34,11 @@ describe('InputSwitch', () => {
 
       expect(screen.getByRole('checkbox')).not.toBeChecked();
 
+      /**
+       * TODO: Follow up on `userEvent.type(inputSwitch, '{enter}')` in v12.1.7.
+       * Temporarily including `fireEvent` from RTL, for which the switch must have focus first:
+       * https://github.com/testing-library/react-testing-library/issues/376#issuecomment-541242684
+       */
       fireEvent.focus(inputSwitch);
       fireEvent.keyDown(inputSwitch, { key: 'Enter' });
       expect(screen.getByRole('checkbox')).toBeChecked();

--- a/client/app/components/Input/__tests__/InputSwitch.spec.jsx
+++ b/client/app/components/Input/__tests__/InputSwitch.spec.jsx
@@ -1,30 +1,47 @@
 // @flow
-import { mount } from 'enzyme';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InputMocks } from 'mocks/InputMocks';
 
 const component = InputMocks.createInput(InputMocks.inputSwitchProps);
-const input = `input#${InputMocks.inputSwitchProps.id}`;
 
 describe('InputSwitch', () => {
+  it('renders correctly', () => {
+    render(component);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { hidden: true }),
+    ).toBeInTheDocument();
+  });
+
   describe('with mouse', () => {
     it('toggles correctly', () => {
-      const wrapper = mount(component);
-      expect(wrapper.find(input).props().defaultChecked).toEqual(false);
-      wrapper.find('.switchToggle').simulate('click');
-      expect(wrapper.find(input).props().defaultChecked).toEqual(true);
-      wrapper.find('.switchToggle').simulate('click');
-      expect(wrapper.find(input).props().defaultChecked).toEqual(false);
+      render(component);
+      const inputSwitch = screen.getByRole('switch');
+
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+
+      userEvent.click(inputSwitch);
+      expect(screen.getByRole('checkbox')).toBeChecked();
+
+      userEvent.click(inputSwitch);
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
     });
   });
 
   describe('with keyboard', () => {
     it('toggles correctly', () => {
-      const wrapper = mount(component);
-      expect(wrapper.find(input).props().defaultChecked).toEqual(false);
-      wrapper.find('.switchToggle').simulate('keypress', { key: 'Enter' });
-      expect(wrapper.find(input).props().defaultChecked).toEqual(true);
-      wrapper.find('.switchToggle').simulate('keypress', { key: 'Enter' });
-      expect(wrapper.find(input).props().defaultChecked).toEqual(false);
+      render(component);
+      const inputSwitch = screen.getByRole('switch');
+
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+
+      fireEvent.focus(inputSwitch);
+      fireEvent.keyDown(inputSwitch, { key: 'Enter' });
+      expect(screen.getByRole('checkbox')).toBeChecked();
+
+      fireEvent.keyDown(inputSwitch, { key: 'Enter' });
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
     });
   });
 });

--- a/client/app/components/Input/__tests__/InputTag.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTag.spec.jsx
@@ -1,42 +1,65 @@
 // @flow
-import { mount } from 'enzyme';
-import { act } from 'react-dom/test-utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InputMocks } from 'mocks/InputMocks';
 
 const component = InputMocks.createInput(InputMocks.inputTagProps);
+const { checkboxes } = InputMocks.inputTagProps;
 
 describe('InputTag', () => {
   it('type in value and select it', () => {
-    const wrapper = mount(component);
-    const id = `#${InputMocks.inputTagProps.checkboxes[1].id}`;
-    const value = { value: 'Two' };
-    expect(wrapper.find('.tagMenu').exists()).toEqual(true);
-    act(() => {
-      wrapper.find('.tagAutocomplete').simulate('change', { target: value });
-    });
-    wrapper.find('.tagAutocomplete').simulate('focus');
-    expect(wrapper.find(id).exists()).toEqual(false);
-    wrapper.find('.tagLabel').at(0).simulate('click');
-    expect(wrapper.find(id).exists()).toEqual(true);
+    const [, { label: checkboxLabelTwo }] = checkboxes;
+    render(component);
+
+    const combobox = screen.getByRole('combobox');
+    const input = screen.getByRole('textbox');
+
+    expect(combobox).toBeInTheDocument();
+    expect(input).toBeInTheDocument();
+
+    // simulate searching for an option
+    userEvent.type(input, 'Two');
+    userEvent.click(input);
+
+    // at this point the checkbox for the option should still not be visible
+    expect(
+      screen.queryByRole('checkbox', { name: checkboxLabelTwo }),
+    ).not.toBeInTheDocument();
+    // but after selecting the option, its associated checkbox should exist
+    userEvent.click(screen.getByRole('option', { name: checkboxLabelTwo }));
+    expect(
+      screen.getByRole('checkbox', { name: checkboxLabelTwo }),
+    ).toBeInTheDocument();
   });
 
   it('un-check existing value and retype and select it', () => {
-    const wrapper = mount(component);
-    const id = `input#${InputMocks.inputTagProps.checkboxes[0].id}`;
-    const value = { value: 'One' };
-    expect(wrapper.find(id).exists()).toEqual(true);
-    act(() => {
-      wrapper.find(id).prop('onChange')({ currentTarget: { checked: false } });
-    });
-    wrapper.update();
-    expect(wrapper.find(id).exists()).toEqual(false);
-    act(() => {
-      wrapper.find('.tagAutocomplete').simulate('change', { target: value });
-    });
-    wrapper.find('.tagAutocomplete').simulate('focus');
-    expect(wrapper.find('.tagMenu').exists()).toEqual(true);
-    expect(wrapper.find(id).exists()).toEqual(false);
-    wrapper.find('.tagLabel').at(0).simulate('click');
-    expect(wrapper.find(id).exists()).toEqual(true);
+    const [{ label: checkboxLabelOne }] = checkboxes;
+    render(component);
+
+    const combobox = screen.getByRole('combobox');
+    const input = screen.getByRole('textbox');
+
+    expect(combobox).toBeInTheDocument();
+    expect(input).toBeInTheDocument();
+
+    // toggle off the target option's checkbox, so we can test re-selecting it below
+    const checkbox = screen.getByRole('checkbox', { name: checkboxLabelOne });
+    expect(checkbox).toBeInTheDocument();
+    userEvent.click(checkbox);
+    // after toggling it, the checkbox should disappear
+    expect(
+      screen.queryByRole('checkbox', { name: checkboxLabelOne }),
+    ).not.toBeInTheDocument();
+
+    // search for the option and re-select it
+    userEvent.type(input, 'One');
+    userEvent.click(input);
+    expect(
+      screen.queryByRole('checkbox', { name: checkboxLabelOne }),
+    ).not.toBeInTheDocument();
+    userEvent.click(screen.getByRole('option', { name: checkboxLabelOne }));
+    expect(
+      screen.getByRole('checkbox', { name: checkboxLabelOne }),
+    ).toBeInTheDocument();
   });
 });

--- a/client/app/components/Input/__tests__/InputTag.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTag.spec.jsx
@@ -21,15 +21,17 @@ describe('InputTag', () => {
     userEvent.type(input, 'Two');
     userEvent.click(input);
 
+    const queryOptions = { name: checkboxLabelTwo };
+    let checkbox = screen.queryByRole('checkbox', queryOptions);
     // at this point the checkbox for the option should still not be visible
-    expect(
-      screen.queryByRole('checkbox', { name: checkboxLabelTwo }),
-    ).not.toBeInTheDocument();
+    expect(checkbox).not.toBeInTheDocument();
+
     // but after selecting the option, its associated checkbox should exist
-    userEvent.click(screen.getByRole('option', { name: checkboxLabelTwo }));
-    expect(
-      screen.getByRole('checkbox', { name: checkboxLabelTwo }),
-    ).toBeInTheDocument();
+    const option = screen.getByRole('option', queryOptions);
+    userEvent.click(option);
+
+    checkbox = screen.getByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
   });
 
   it('un-check existing value and retype and select it', () => {
@@ -42,24 +44,23 @@ describe('InputTag', () => {
     expect(combobox).toBeInTheDocument();
     expect(input).toBeInTheDocument();
 
+    const queryOptions = { name: checkboxLabelOne };
     // toggle off the target option's checkbox, so we can test re-selecting it below
-    const checkbox = screen.getByRole('checkbox', { name: checkboxLabelOne });
+    let checkbox = screen.getByRole('checkbox', queryOptions);
     expect(checkbox).toBeInTheDocument();
     userEvent.click(checkbox);
     // after toggling it, the checkbox should disappear
-    expect(
-      screen.queryByRole('checkbox', { name: checkboxLabelOne }),
-    ).not.toBeInTheDocument();
+    checkbox = screen.queryByRole('checkbox', queryOptions);
+    expect(checkbox).not.toBeInTheDocument();
 
     // search for the option and re-select it
     userEvent.type(input, 'One');
     userEvent.click(input);
-    expect(
-      screen.queryByRole('checkbox', { name: checkboxLabelOne }),
-    ).not.toBeInTheDocument();
-    userEvent.click(screen.getByRole('option', { name: checkboxLabelOne }));
-    expect(
-      screen.getByRole('checkbox', { name: checkboxLabelOne }),
-    ).toBeInTheDocument();
+    checkbox = screen.queryByRole('checkbox', queryOptions);
+    expect(checkbox).not.toBeInTheDocument();
+    const option = screen.getByRole('option', queryOptions);
+    userEvent.click(option);
+    checkbox = screen.getByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
   });
 });

--- a/client/app/components/Input/__tests__/InputTextarea.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTextarea.spec.jsx
@@ -1,0 +1,173 @@
+// @flow
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as pell from 'pell';
+import { InputMocks } from 'mocks/InputMocks';
+
+describe('InputTextarea', () => {
+  beforeAll(() => {
+    // mocks obsolete method used internally in Pell
+    document.queryCommandState = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.spyOn(pell, 'init');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const component = InputMocks.createInput(InputMocks.inputTextareaProps);
+    const { container } = render(component);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toBeInTheDocument();
+
+    // Since '@testing-library/react' does not get hidden inputs,
+    // it can be queried directly from the container for this test.
+    const hiddenInput = container.querySelector('input[type="hidden"]');
+    expect(hiddenInput).toBeInTheDocument();
+
+    const editor = container.querySelector('.editor');
+    expect(editor).toBeInTheDocument();
+  });
+
+  describe('editor', () => {
+    it('initializes on mount', () => {
+      const component = InputMocks.createInput(InputMocks.inputTextareaProps);
+      const { container } = render(component);
+      const editor = container.querySelector('.editor');
+      expect(pell.init).toHaveBeenCalledWith(
+        expect.objectContaining({ element: editor }),
+      );
+    });
+
+    it('has a tab index and focuses', () => {
+      const component = InputMocks.createInput(InputMocks.inputTextareaProps);
+      render(component);
+      // first tab should focus the editor textarea
+      const textarea = screen.getByRole('textbox');
+      userEvent.tab();
+      expect(textarea).toHaveFocus();
+    });
+
+    describe('if required', () => {
+      const { id } = InputMocks.inputTextareaProps;
+      const onError = jest.fn();
+
+      afterEach(() => {
+        onError.mockClear();
+      });
+
+      describe('on blurring', () => {
+        afterEach(() => {
+          onError.mockClear();
+        });
+
+        it('handles error when empty', () => {
+          const component = InputMocks.createInput(
+            InputMocks.inputTextareaProps,
+            { required: true, onError },
+          );
+          render(component);
+          const textarea = screen.getByRole('textbox');
+          userEvent.click(textarea);
+          userEvent.tab();
+
+          expect(onError).toHaveBeenCalledWith(id, true);
+        });
+
+        it('does not handle error when a value exists', () => {
+          const component = InputMocks.createInput(
+            InputMocks.inputTextareaProps,
+            { required: true, onError, value: 'Some value' },
+          );
+          render(component);
+          const textarea = screen.getByRole('textbox');
+          userEvent.click(textarea);
+          userEvent.tab();
+
+          expect(onError).toHaveBeenCalledWith(id, false);
+        });
+      });
+
+      it('on focusing resets error', () => {
+        const component = InputMocks.createInput(
+          InputMocks.inputTextareaProps,
+          { required: true, onError },
+        );
+        render(component);
+        // triggers focus
+        const textarea = screen.getByRole('textbox');
+        userEvent.click(textarea);
+        expect(onError).toHaveBeenCalledWith(id, false);
+      });
+    });
+
+    describe('if not required', () => {
+      const onError = jest.fn();
+
+      afterEach(() => {
+        onError.mockClear();
+      });
+
+      describe('on blurring', () => {
+        afterEach(() => {
+          onError.mockClear();
+        });
+
+        it('does not handle error', () => {
+          const component = InputMocks.createInput(
+            InputMocks.inputTextareaProps,
+            { required: false, onError },
+          );
+          render(component);
+          // triggers focus, then blur
+          const textarea = screen.getByRole('textbox');
+          userEvent.click(textarea);
+          userEvent.tab();
+          expect(onError).not.toHaveBeenCalled();
+        });
+      });
+
+      it('on focusing does not reset error', () => {
+        const component = InputMocks.createInput(
+          InputMocks.inputTextareaProps,
+          { required: false, onError },
+        );
+        render(component);
+        // triggers focus
+        const textarea = screen.getByRole('textbox');
+        userEvent.click(textarea);
+        expect(onError).not.toHaveBeenCalled();
+      });
+    });
+
+    it('handles formatting actions', () => {
+      const sampleUrl = 'sample-url';
+      jest.spyOn(pell, 'exec');
+      // mocks prompting the user for link url
+      jest.spyOn(window, 'prompt').mockImplementationOnce(() => sampleUrl);
+      render(InputMocks.createInput(InputMocks.inputTextareaProps));
+
+      const buttons = [
+        // default actions
+        { title: 'Bold', expectedArgs: ['bold'] },
+        // overridden actions
+        { title: 'Link', expectedArgs: ['createLink', sampleUrl] },
+        { title: 'Ordered List', expectedArgs: ['insertOrderedList'] },
+        { title: 'Unordered List', expectedArgs: ['insertUnorderedList'] },
+      ];
+
+      buttons.forEach(({ title, expectedArgs }) => {
+        const button = screen.getByTitle(title);
+        userEvent.click(button);
+        expect(pell.exec).toHaveBeenCalledWith(...expectedArgs);
+      });
+
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/client/app/components/Input/__tests__/InputTextarea.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTextarea.spec.jsx
@@ -8,14 +8,7 @@ describe('InputTextarea', () => {
   beforeAll(() => {
     // mocks obsolete method used internally in Pell
     document.queryCommandState = jest.fn();
-  });
-
-  beforeEach(() => {
     jest.spyOn(pell, 'init');
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   it('renders correctly', () => {
@@ -166,8 +159,6 @@ describe('InputTextarea', () => {
         userEvent.click(button);
         expect(pell.exec).toHaveBeenCalledWith(...expectedArgs);
       });
-
-      jest.restoreAllMocks();
     });
   });
 });

--- a/client/package.json
+++ b/client/package.json
@@ -69,7 +69,7 @@
     "@storybook/addons": "^6.0.21",
     "@storybook/react": "^6.0.21",
     "@testing-library/jest-dom": "^5.10.0",
-    "@testing-library/react": "^11.0.2",
+    "@testing-library/react": "^11.0.4",
     "@testing-library/user-event": "^12.1.7",
     "babel-cli": "^6.24.1",
     "babel-eslint": "^10.0.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2446,10 +2446,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@testing-library/dom@^7.23.0":
-  version "7.24.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.1.tgz#0e8acd042070f2c1b183fbfe5c0d38b3194ad3c0"
-  integrity sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==
+"@testing-library/dom@^7.24.2":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.5.tgz#862124eec8c37ad184716379f09742476b23815d"
+  integrity sha512-oyOp8R2rhmnkOjgrySb4iYc2q73dzvQUAGddpbmicGJdCf4jkLmf5U9zOyobLMLWXbIHHK4UUHHjDTH8tSPLsA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.10.3"
@@ -2473,13 +2473,13 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^11.0.2":
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.2.tgz#4588cc537085907bd1d98b531eb247dbbf57b1cc"
-  integrity sha512-iOuNNHt4ZgMH5trSKC4kaWDcKzUOf7e7KQIcu7xvGCd68/w1EegbW89F9T5sZ4IjS0gAXdvOfZbG9ESZ7YjOug==
+"@testing-library/react@^11.0.4":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.4.tgz#c84082bfe1593d8fcd475d46baee024452f31dee"
+  integrity sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@testing-library/dom" "^7.23.0"
+    "@testing-library/dom" "^7.24.2"
 
 "@testing-library/user-event@^12.1.7":
   version "12.1.7"


### PR DESCRIPTION
# Description

Updates the tests in ‘components/Input/’ to use React Testing Library instead of Enzyme.

## More Details

(1) I added comments where I ran into a couple of issues using `userEvent` and jest-dom matchers. I updated the dependencies to see if it would help (Narrator: it didn’t). But that amounted to just a minor version bump in '@testing-library/react' so I left it in.

(2) I also added some coverage for the Textarea component. I noticed a TODO there about stubbing the Pell editor methods. I can always revert the newly added tests, or make the necessary changes if it should be done a better way.

(3) Also, I was wondering whether to add more coverage to a couple of the Input components. I decided just to migrate the existing ones for starters, but I can definitely add more if time permits.

(4) Lastly, I updated minor details in a couple components themselves. They still work the same (including screenshots below).

Of course, if anything looks out of place (or missing), please LMK and I'll make the necessary changes.

Thanks! :coffee:

## Corresponding Issue

#1792

# Screenshots

Switch (updated):
<img width="397" alt="Screen Shot 2020-10-08 at 7 02 46 PM" src="https://user-images.githubusercontent.com/11330558/95550180-51285a00-09bd-11eb-97a1-6f003976cf21.png">

Tag (updated):
<img width="332" alt="Screen Shot 2020-10-08 at 11 28 12 PM" src="https://user-images.githubusercontent.com/11330558/95550596-0529e500-09be-11eb-9b23-76b6d721e239.png">

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!