### PR TITLE
Enhance clarity in a few specs

### DIFF
--- a/spec/concerns/ally_concern_spec.rb
+++ b/spec/concerns/ally_concern_spec.rb
@@ -19,7 +19,7 @@ describe AllyConcern, type: :model do
       context 'ally is banned' do
         let(:banned) { true }
 
-        it 'returns true' do
+        it 'returns false' do
           expect(user1.ally?(user2)).to eq(false)
         end
       end

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -24,7 +24,7 @@ describe CommentsHelper, type: :controller do
           sign_in user1
         end
 
-        it 'generates a valid comment object when visbility is all' do
+        it 'generates a valid comment object when visibility is all' do
           new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user1.id, visibility: 'all')
           expect(controller.generate_comments(Comment.where(id: new_comment.id))).to eq([{
                                                                                           id: new_comment.id,
@@ -60,7 +60,7 @@ describe CommentsHelper, type: :controller do
           sign_in user2
         end
 
-        it 'generates a valid comment object when visbility is all' do
+        it 'generates a valid comment object when visibility is all' do
           new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user2.id, visibility: 'all')
           expect(controller.generate_comments(Comment.where(id: new_comment.id))).to eq([{
                                                                                           id: new_comment.id,
@@ -75,7 +75,7 @@ describe CommentsHelper, type: :controller do
                                                                                         }])
         end
 
-        it 'generates a valid comment object when visbility is private' do
+        it 'generates a valid comment object when visibility is private' do
           new_comment = create(:comment, comment: comment, commentable_type: 'moment', commentable_id: new_moment.id, comment_by: user2.id, visibility: 'private', viewers: [user1.id])
           expect(controller.generate_comments(Comment.where(id: new_comment.id))).to eq([{
                                                                                           id: new_comment.id,
@@ -100,7 +100,7 @@ describe CommentsHelper, type: :controller do
           sign_in user1
         end
 
-        it 'generates a valid comment object when visbility is all' do
+        it 'generates a valid comment object when visibility is all' do
           new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user1.id, visibility: 'all')
           expect(controller.generate_comments(Comment.where(id: new_comment.id))).to eq([{
                                                                                           id: new_comment.id,
@@ -115,7 +115,7 @@ describe CommentsHelper, type: :controller do
                                                                                         }])
         end
 
-        it 'generates a valid comment object when visbility is private' do
+        it 'generates a valid comment object when visibility is private' do
           new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user1.id, visibility: 'private', viewers: [user2.id])
           expect(controller.generate_comments(Comment.where(id: new_comment.id))).to eq([{
                                                                                           id: new_comment.id,
@@ -136,7 +136,7 @@ describe CommentsHelper, type: :controller do
           sign_in user2
         end
 
-        it 'generates a valid comment object when visbility is all' do
+        it 'generates a valid comment object when visibility is all' do
           new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user2.id, visibility: 'all')
           expect(controller.generate_comments(Comment.where(id: new_comment.id))).to eq([{
                                                                                           id: new_comment.id,
@@ -151,7 +151,7 @@ describe CommentsHelper, type: :controller do
                                                                                         }])
         end
 
-        it 'generates a valid comment object when visbility is private' do
+        it 'generates a valid comment object when visibility is private' do
           new_comment = create(:comment, comment: comment, commentable_type: 'strategy', commentable_id: new_strategy.id, comment_by: user2.id, visibility: 'private', viewers: [user1.id])
           expect(controller.generate_comments(Comment.where(id: new_comment.id))).to eq([{
                                                                                           id: new_comment.id,


### PR DESCRIPTION
# Description

As I often like to do with a new project, these changes are strictly to comments and their ilk.

The specs touched have been updated in the following way:

1) A misidentified test has gone from 'returns true' to 'returns false'

2) A spec's pervasive typo has been updated, and said typo's presence elsewhere in the project ruled out

3) A third spec has had several small typos and errors in grammar or vocabulary corrected, in addition to some finessing of language in its detailed failure messages for clarity's sake

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
