### PR TITLE
feat: #1803 Migrate client/app/widgets/Resources/__tests__ to RTL

### DIFF
--- a/client/app/components/Input/__tests__/InputTag.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTag.spec.jsx
@@ -19,7 +19,6 @@ describe('InputTag', () => {
 
     // simulate searching for an option
     userEvent.type(input, 'Two');
-    userEvent.click(input);
 
     const queryOptions = { name: checkboxLabelTwo };
     let checkbox = screen.queryByRole('checkbox', queryOptions);
@@ -55,7 +54,7 @@ describe('InputTag', () => {
 
     // search for the option and re-select it
     userEvent.type(input, 'One');
-    userEvent.click(input);
+
     checkbox = screen.queryByRole('checkbox', queryOptions);
     expect(checkbox).not.toBeInTheDocument();
     const option = screen.getByRole('option', queryOptions);

--- a/client/app/widgets/Resources/__tests__/Resources.spec.jsx
+++ b/client/app/widgets/Resources/__tests__/Resources.spec.jsx
@@ -1,128 +1,203 @@
 // @flow
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import Resources from 'widgets/Resources';
+
+const resourcesData = [
+  {
+    name: '7 Cups',
+    link: 'https://www.7cups.com',
+    tags: [
+      'therapy',
+      'counseling',
+      'paid',
+      'free',
+      'texting',
+      'android',
+      'ios',
+    ],
+    languages: ['en', 'es'],
+  },
+  {
+    name: 'A Canvas of the Minds',
+    link: 'https://acanvasoftheminds.com/',
+    tags: ['free', 'blog'],
+    languages: ['en'],
+  },
+  {
+    name: 'Bloom',
+    link: 'http://www.getbloom.net/',
+    tags: ['ios', 'paid', 'game', 'colouring', 'stress'],
+    languages: ['en'],
+  },
+];
 
 // eslint-disable-next-line react/prop-types
 const getComponent = ({ history } = {}) => (
-  <Resources
-    keywords={[]}
-    resources={[
-      {
-        name: '7 Cups',
-        link: 'https://www.7cups.com',
-        tags: [
-          'therapy',
-          'counseling',
-          'paid',
-          'free',
-          'texting',
-          'android',
-          'ios',
-        ],
-        languages: ['en', 'es'],
-      },
-      {
-        name: 'A Canvas of the Minds',
-        link: 'https://acanvasoftheminds.com/',
-        tags: ['free', 'blog'],
-        languages: ['en'],
-      },
-      {
-        name: 'Bloom',
-        link: 'http://www.getbloom.net/',
-        tags: ['ios', 'paid', 'game', 'colouring', 'stress'],
-        languages: ['en'],
-      },
-    ]}
-    history={history}
-  />
+  <Resources keywords={[]} resources={resourcesData} history={history} />
 );
 
+/**
+ * Each resource can have multiple associated tags,
+ * and each tag can be clicked to filter related resources.
+ * So to test we:
+  - pick a tag at random to test, i.e. 'therapy'
+  - query the occurrences of that tag
+  - select the tag, which applies a filter
+  - and check that the view updates
+ */
 describe('Resources', () => {
   it('adds tags to filter when tag labels are clicked', () => {
-    const wrapper = mount(getComponent());
-    expect(wrapper.find('.resource').length).toEqual(3);
-    expect(wrapper.find('.tags').exists()).toEqual(true);
-    expect(wrapper.text()).toContain('3 of 3');
-    let id = wrapper.find('.tag').at(2).text();
-    expect(id).toEqual('therapy');
-    wrapper.find('.tag').at(2).simulate('click');
-    expect(wrapper.find('.checkboxLabel').text()).toEqual(id);
-    expect(wrapper.find('.resource').length).toEqual(1);
-    expect(wrapper.text()).toContain('1 of 1');
-    expect(
-      wrapper
-        .find('.tag')
-        .findWhere((t) => t.text() === id)
-        .exists(),
-    ).toEqual(true);
-    id = wrapper.find('.tag').at(8).text();
-    expect(id).toEqual('ios');
-    wrapper.find('.tag').at(8).simulate('click');
-    expect(wrapper.find('.checkboxLabel').at(0).text()).toEqual(id);
-    expect(wrapper.find('.resource').length).toEqual(2);
-    expect(wrapper.text()).toContain('2 of 2');
-    expect(
-      wrapper
-        .find('.tag')
-        .findWhere((t) => t.text() === id)
-        .exists(),
-    ).toEqual(true);
+    render(getComponent());
+
+    // Check that an article exists for each resource in the initial render
+    let resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(3);
+    // results count/pagination
+    expect(screen.getByText(new RegExp(`${3} of ${3}`))).toBeInTheDocument();
+
+    // Check that all the expected tags from resourcesData are rendered:
+    // both resource.languages and resource.tags are displayed among related tags
+    resourcesData
+      .flatMap(({ languages, tags }) => [...languages, ...tags])
+      .forEach((tag) => {
+        expect(screen.getAllByText(tag)).not.toHaveLength(0);
+      });
+
+    let tagText = 'therapy';
+    let queryOptions = { name: tagText };
+
+    // only expect 1 'therapy' tag from initial resourcesData
+    let selectedTags = screen.getAllByRole('button', queryOptions);
+    expect(selectedTags).toHaveLength(1);
+    // select the tag to filter resources
+    let [selectedTag] = selectedTags;
+    userEvent.click(selectedTag);
+
+    /*
+     * Expected view updates:
+     * - resources are filtered down around the selected tag
+     * - the selected tag is listed among the filtered resources
+     * - a corresponding checkbox is shown for the selected tag
+     */
+    resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(1);
+    // results count/pagination
+    expect(screen.getByText(new RegExp(`${1} of ${1}`))).toBeInTheDocument();
+    selectedTag = screen.getByRole('button', queryOptions);
+    expect(selectedTag).toBeInTheDocument();
+    let checkbox = screen.getByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
+    /*
+     * From among the already filtered tags, pick another tag at random
+     * and repeat the above test
+     */
+    tagText = 'ios';
+    queryOptions = { name: tagText };
+    // only 1 resource with 'ios' tag when 'therapy' filter is applied
+    selectedTags = screen.getAllByRole('button', queryOptions);
+    expect(selectedTags).toHaveLength(1);
+    [selectedTag] = selectedTags;
+    // select the new tag
+    userEvent.click(selectedTag);
+
+    // observe the expected view updates for the newly selected 'ios' tag
+    resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(2);
+    // results count/pagination
+    expect(screen.getByText(new RegExp(`${2} of ${2}`))).toBeInTheDocument();
+    // with the new filter applied, expect 2 'ios' tags
+    selectedTags = screen.getAllByRole('button', queryOptions);
+    expect(selectedTags).toHaveLength(2);
+    // new checkbox also exists
+    checkbox = screen.getByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
   });
 
   it('filters when tags are selected', () => {
-    const wrapper = mount(getComponent());
-    expect(wrapper.find('.resource').length).toEqual(3);
-    expect(wrapper.text()).toContain('3 of 3');
-    wrapper.find('.tagAutocomplete').simulate('focus');
-    expect(wrapper.find('.tagMenu').exists()).toEqual(true);
-    let id = wrapper.find('.tagLabel').at(0).text();
-    expect(id).toEqual('android');
-    wrapper.find('.tagLabel').at(0).simulate('click');
-    expect(wrapper.find('.checkboxLabel').text()).toEqual(id);
-    expect(wrapper.find('.resource').length).toEqual(1);
-    expect(wrapper.text()).toContain('1 of 1');
-    expect(
-      wrapper
-        .find('.tag')
-        .findWhere((t) => t.text() === id)
-        .exists(),
-    ).toEqual(true);
-    wrapper.find('.tagAutocomplete').simulate('focus');
-    id = wrapper.find('.tagLabel').at(1).text();
-    expect(id).toEqual('colouring');
-    wrapper.find('.tagLabel').at(1).simulate('click');
-    expect(wrapper.find('.checkboxLabel').at(1).text()).toEqual(id);
-    expect(wrapper.find('.resource').length).toEqual(2);
-    expect(wrapper.text()).toContain('2 of 2');
-    expect(
-      wrapper
-        .find('.tag')
-        .findWhere((t) => t.text() === id)
-        .exists(),
-    ).toEqual(true);
+    render(getComponent());
+    // initial render has select menu and resources
+    const combobox = screen.getByRole('combobox');
+    expect(combobox).toBeInTheDocument();
+    let resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(3);
+    // results count/pagination
+    expect(screen.getByText(new RegExp(`${3} of ${3}`))).toBeInTheDocument();
+
+    // focuses the InputTag select
+    let input = screen.getByRole('textbox');
+    userEvent.click(input);
+
+    // first tag selection
+    let tagText = 'android';
+    let queryOptions = { name: tagText };
+
+    // click tag option
+    let option = screen.getByRole('option', queryOptions);
+    userEvent.click(option);
+
+    // expected view updates:
+    // test resources count
+    resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(1);
+    expect(screen.getByText(new RegExp(`${1} of ${1}`))).toBeInTheDocument();
+    // test tag buttons count
+    let selectedTag = screen.getByRole('button', queryOptions);
+    expect(selectedTag).toBeInTheDocument();
+    // test checkbox exists
+    let checkbox = screen.queryByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
+    // re-query input as its key prop has been refreshed
+    input = screen.getByRole('textbox');
+    userEvent.click(input);
+
+    // check second tag selection
+    // and expected view updates
+    tagText = 'colouring';
+    queryOptions = { name: tagText };
+    option = screen.getByRole('option', queryOptions);
+    userEvent.click(option);
+
+    resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(2);
+    expect(screen.getByText(new RegExp(`${2} of ${2}`))).toBeInTheDocument();
+    selectedTag = screen.getByRole('button', queryOptions);
+    expect(selectedTag).toBeInTheDocument();
+    checkbox = screen.queryByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
   });
 
   it('unfilters when a tag is unselected', () => {
-    const wrapper = mount(getComponent());
-    expect(wrapper.find('.resource').length).toEqual(3);
-    expect(wrapper.text()).toContain('3 of 3');
-    wrapper.find('.tagAutocomplete').simulate('focus');
-    const id = wrapper.find('.tagLabel').at(0).text();
-    expect(id).toEqual('android');
-    wrapper.find('.tagLabel').at(0).simulate('click');
-    expect(wrapper.find('.resource').length).toEqual(1);
-    expect(wrapper.text()).toContain('1 of 1');
-    act(() => {
-      wrapper.find(`input#${id}`).prop('onChange')({
-        currentTarget: { checked: false },
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find('.resource').length).toEqual(3);
-    expect(wrapper.text()).toContain('3 of 3');
+    render(getComponent());
+    let resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(3);
+    expect(screen.getByText(new RegExp(`${3} of ${3}`))).toBeInTheDocument();
+
+    const input = screen.getByRole('textbox');
+    userEvent.click(input);
+
+    // tag selection and expected view updates
+    const tagText = 'android';
+    const queryOptions = { name: tagText };
+
+    const option = screen.getByRole('option', queryOptions);
+    userEvent.click(option);
+
+    resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(1);
+    expect(screen.getByText(new RegExp(`${1} of ${1}`))).toBeInTheDocument();
+    const selectedTag = screen.getByRole('button', queryOptions);
+    expect(selectedTag).toBeInTheDocument();
+    const checkbox = screen.queryByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
+
+    // unselect selected tag via its checkbox
+    userEvent.click(checkbox);
+
+    resourcesArticles = screen.getAllByRole('article');
+    expect(resourcesArticles).toHaveLength(3);
+    expect(screen.getByText(new RegExp(`${3} of ${3}`))).toBeInTheDocument();
   });
 
   describe('when the component updates', () => {
@@ -139,11 +214,11 @@ describe('Resources', () => {
 
     describe('and the resources are being filtered', () => {
       it('sends the selected tags to the URL', () => {
-        const wrapper = mount(getComponent({ history }));
+        render(getComponent({ history }));
 
-        wrapper.find('.tag').at(8).simulate('click');
-
-        wrapper.find('.tag').at(2).simulate('click');
+        // choose two filters at once and expect the search string to update accordingly
+        userEvent.click(screen.getAllByRole('button', { name: 'ios' })[0]);
+        userEvent.click(screen.getByRole('button', { name: 'therapy' }));
 
         expect(historyMock).toHaveBeenCalledWith({
           pathname: '/resources',
@@ -154,7 +229,7 @@ describe('Resources', () => {
 
     describe('and there is no filters selected', () => {
       it('resets the search query parameter', () => {
-        mount(getComponent({ history }));
+        render(getComponent({ history }));
 
         expect(historyMock).toHaveBeenCalledWith({
           pathname: '/resources',


### PR DESCRIPTION
# Description

Migrates test suite from enzyme to RTL

## More Details

I was wondering about the repetition in the tests. While trying to understand the functionality and test code, I thought maybe there was a way to simplify things. So I experimented with abstracting some reusable helpers.

For example, instead of:

```
resourcesArticles = screen.getAllByRole('article');
expect(resourcesArticles).toHaveLength(1);
// results count/pagination
expect(screen.getByText(/1 of 1/)).toBeInTheDocument();
```

I tried moving it into a helper that could be reused across the tests:

```
const testResourcesCount = (count) => {
  resourcesArticles = screen.getAllByRole('article');
  expect(resourcesArticles).toHaveLength(count);
  // results count/pagination
  expect(screen.getByText(new RegExp(`${count} of ${count}`))).toBeInTheDocument();
};

...

testResourcesCount(3);
```

Wasn't feeling too sure about it though, so only pushing the refactor at first without any abstractions 👍 

## Corresponding Issue

#1803 

Would appreciate any thoughts on that issue. And as always, if any changes are needed please LMK and I'll follow up with the updates.

Thanks! :coffee:

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
