### PR TITLE
fix: #1909 autosuggest behavior on keydown

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -45,7 +45,6 @@ class CommentsController < ApplicationController
     comment.id
   end
 
-  # rubocop:disable Metrics/MethodLength
   def handle_delete(comment)
     if %w[moment strategy].include?(comment.commentable_type)
       raise RuntimeError unless CommentViewersService.deletable?(
@@ -61,5 +60,4 @@ class CommentsController < ApplicationController
       remove_meeting_notification(comment, meeting)
     end
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/client/app/components/Input/InputTag.jsx
+++ b/client/app/components/Input/InputTag.jsx
@@ -68,7 +68,7 @@ export function InputTag({
     return newSuggestions;
   };
 
-  const getSuggestionValue = (checkbox: Checkbox) => (checkbox.label === autocompleteLabel ? checkbox.label : '');
+  const getSuggestionValue = ({ label }: Checkbox) => (label === autocompleteLabel ? label : '');
 
   const onSuggestionsFetchRequested = (valueProp: { value: string }) => {
     const { value } = valueProp;
@@ -102,6 +102,7 @@ export function InputTag({
   ) => {
     if (method === 'enter') {
       event.preventDefault();
+      event.stopPropagation();
     }
     const inputId = labelExistsUnchecked(suggestion.label);
     if (inputId) {
@@ -127,7 +128,7 @@ export function InputTag({
   const shouldRenderSuggestions = () => true;
 
   const onKeyDown = (e: SyntheticKeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && onChange) {
+    if (!e.isPropagationStopped() && e.key === 'Enter' && onChange) {
       e.preventDefault();
       onChange({ label: autocompleteLabel, checkboxes });
     }
@@ -152,7 +153,7 @@ export function InputTag({
       theme={css}
       inputProps={{
         onChange: onAutocompleteChange,
-        value: autocompleteLabel || '',
+        value: autocompleteLabel,
         className: `tagAutocomplete ${inputCss.tagAutocomplete}`,
         onKeyDown,
         placeholder,

--- a/client/app/components/Input/InputTag.jsx
+++ b/client/app/components/Input/InputTag.jsx
@@ -26,9 +26,7 @@ export function InputTag({
 }: Props) {
   const [checkboxes, setCheckboxes] = useState<Checkbox[]>(defaultCheckboxes);
   const [suggestions, setSuggestions] = useState<Checkbox[]>(defaultCheckboxes);
-  const [autocompleteLabel, setAutocompleteLabel] = useState<
-    string | void | null,
-  >(undefined);
+  const [autocompleteLabel, setAutocompleteLabel] = useState<string>('');
 
   const check = (inputId: string, checked: boolean) => {
     const newCheckboxes = checkboxes.map((checkbox: Checkbox) => {
@@ -43,7 +41,7 @@ export function InputTag({
     });
 
     if (checked) {
-      setAutocompleteLabel(undefined);
+      setAutocompleteLabel('');
     }
     setCheckboxes(newCheckboxes);
   };

--- a/client/app/components/Input/__tests__/InputTag.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTag.spec.jsx
@@ -3,24 +3,43 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { InputMocks } from 'mocks/InputMocks';
 
-const component = InputMocks.createInput(InputMocks.inputTagProps);
-const { checkboxes } = InputMocks.inputTagProps;
+const { inputTagProps, createInput } = InputMocks;
+const getComponent = (extraProps = {}) => createInput(inputTagProps, extraProps);
+// baseline for most tests
+const component = getComponent();
+const { checkboxes } = inputTagProps;
 
 describe('InputTag', () => {
-  it('type in value and select it', () => {
-    const [, { label: checkboxLabelTwo }] = checkboxes;
+  it('renders input correctly', () => {
     render(component);
 
     const combobox = screen.getByRole('combobox');
     const input = screen.getByRole('textbox');
+    const listbox = screen.getByRole('listbox');
 
     expect(combobox).toBeInTheDocument();
     expect(input).toBeInTheDocument();
+    expect(listbox).toBeInTheDocument();
+  });
+
+  it('toggles menu options correctly', () => {
+    render(component);
+    const input = screen.getByRole('textbox');
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+    // toggle options by focusing on input
+    userEvent.click(input);
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('type in value and select it', () => {
+    const [, { label: labelTwo }] = checkboxes;
+    render(component);
+    const input = screen.getByRole('textbox');
 
     // simulate searching for an option
     userEvent.type(input, 'Two');
 
-    const queryOptions = { name: checkboxLabelTwo };
+    const queryOptions = { name: labelTwo };
     let checkbox = screen.queryByRole('checkbox', queryOptions);
     // at this point the checkbox for the option should still not be visible
     expect(checkbox).not.toBeInTheDocument();
@@ -34,16 +53,12 @@ describe('InputTag', () => {
   });
 
   it('un-check existing value and retype and select it', () => {
-    const [{ label: checkboxLabelOne }] = checkboxes;
+    const [{ label: labelOne }] = checkboxes;
     render(component);
 
-    const combobox = screen.getByRole('combobox');
     const input = screen.getByRole('textbox');
 
-    expect(combobox).toBeInTheDocument();
-    expect(input).toBeInTheDocument();
-
-    const queryOptions = { name: checkboxLabelOne };
+    const queryOptions = { name: labelOne };
     // toggle off the target option's checkbox, so we can test re-selecting it below
     let checkbox = screen.getByRole('checkbox', queryOptions);
     expect(checkbox).toBeInTheDocument();
@@ -61,5 +76,53 @@ describe('InputTag', () => {
     userEvent.click(option);
     checkbox = screen.getByRole('checkbox', queryOptions);
     expect(checkbox).toBeInTheDocument();
+  });
+
+  it('selects a value with keydown without specifying text', () => {
+    const [{ label: labelOne }] = checkboxes;
+    render(component);
+
+    const input = screen.getByRole('textbox');
+
+    const queryOptions = { name: labelOne };
+    let checkbox = screen.getByRole('checkbox', queryOptions);
+    // unselect checkbox for the test first
+    userEvent.click(checkbox);
+    checkbox = screen.queryByRole('checkbox', queryOptions);
+    expect(checkbox).not.toBeInTheDocument();
+
+    userEvent.click(input);
+    // expect first item to be highlighted, so it can be selected
+    expect(screen.getByRole('option', queryOptions)).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    userEvent.type(input, '{enter}');
+
+    checkbox = screen.getByRole('checkbox', queryOptions);
+    expect(checkbox).toBeInTheDocument();
+  });
+
+  it('does not select value if no match exists and calls onChange prop if defined', () => {
+    const onChange = jest.fn();
+    render(getComponent({ onChange }));
+
+    const input = screen.getByRole('textbox');
+    // unselect selected checkbox value first
+    userEvent.click(screen.getByRole('checkbox'));
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+
+    userEvent.click(input);
+    userEvent.type(input, 'Three');
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+
+    userEvent.type(input, '{enter}');
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'Three',
+      }),
+    );
   });
 });

--- a/client/app/components/Input/__tests__/InputTag.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTag.spec.jsx
@@ -31,32 +31,9 @@ describe('InputTag', () => {
     expect(screen.getAllByRole('option')).toHaveLength(2);
   });
 
-  it('type in value and select it', () => {
-    const [, { label: labelTwo }] = checkboxes;
-    render(component);
-    const input = screen.getByRole('textbox');
-
-    // simulate searching for an option
-    userEvent.type(input, 'Two');
-
-    const queryOptions = { name: labelTwo };
-    let checkbox = screen.queryByRole('checkbox', queryOptions);
-    // at this point the checkbox for the option should still not be visible
-    expect(checkbox).not.toBeInTheDocument();
-
-    // but after selecting the option, its associated checkbox should exist
-    const option = screen.getByRole('option', queryOptions);
-    userEvent.click(option);
-
-    checkbox = screen.getByRole('checkbox', queryOptions);
-    expect(checkbox).toBeInTheDocument();
-  });
-
-  it('un-check existing value and retype and select it', () => {
+  it('un-check existing value', () => {
     const [{ label: labelOne }] = checkboxes;
     render(component);
-
-    const input = screen.getByRole('textbox');
 
     const queryOptions = { name: labelOne };
     // toggle off the target option's checkbox, so we can test re-selecting it below
@@ -66,14 +43,26 @@ describe('InputTag', () => {
     // after toggling it, the checkbox should disappear
     checkbox = screen.queryByRole('checkbox', queryOptions);
     expect(checkbox).not.toBeInTheDocument();
+  });
 
-    // search for the option and re-select it
-    userEvent.type(input, 'One');
+  it('type in value and select it', () => {
+    const [{ label: labelOne }] = checkboxes;
+    render(component);
 
-    checkbox = screen.queryByRole('checkbox', queryOptions);
+    const queryOptions = { name: labelOne };
+    let checkbox = screen.getByRole('checkbox', queryOptions);
+    // un-check selected value so we can re-select it
+    userEvent.click(checkbox);
+    // at this point the checkbox for the option should not be visible
     expect(checkbox).not.toBeInTheDocument();
+
+    // simulate searching for an option
+    const input = screen.getByRole('textbox');
+    userEvent.type(input, 'One');
+    // after selecting the option, its associated checkbox should exist
     const option = screen.getByRole('option', queryOptions);
     userEvent.click(option);
+
     checkbox = screen.getByRole('checkbox', queryOptions);
     expect(checkbox).toBeInTheDocument();
   });

--- a/client/app/widgets/QuickCreate/__tests__/QuickCreate.spec.jsx
+++ b/client/app/widgets/QuickCreate/__tests__/QuickCreate.spec.jsx
@@ -104,13 +104,31 @@ describe('QuickCreate', () => {
     });
 
     it('does not open the modal if the checkbox already exists', () => {
+      const [{ label }] = checkboxes;
       // open accordion
       userEvent.click(screen.getByRole('button'));
       // type a value that already exists
-      userEvent.type(
-        screen.getByRole('textbox'),
-        `${checkboxes[0].label}{enter}`,
-      );
+      userEvent.type(screen.getByRole('textbox'), `${label}{enter}`);
+      // modal should not be open
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('does not open modal if input matches an unselected option', () => {
+      const [, { label }] = checkboxes;
+      // open accordion
+      userEvent.click(screen.getByRole('button'));
+      expect(
+        screen.queryByRole('checkbox', {
+          name: label,
+        }),
+      ).not.toBeInTheDocument();
+      // type a value that already exists
+      userEvent.type(screen.getByRole('textbox'), `${label}{enter}`);
+      expect(
+        screen.getByRole('checkbox', {
+          name: label,
+        }),
+      ).toBeInTheDocument();
       // modal should not be open
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });


### PR DESCRIPTION
# Description

Fixes 2 issues with InputTag behavior inside a parent component, e.g. in this case QuickCreate:

1. The default value of `autocompleteLabel` has been [reverted](https://github.com/ifmeorg/ifme/commit/4a31511966790a844d96a65a7f4d1021804f1c24#diff-009b07c356e1317043bd5c8c0ff3e0c76c03144bce19a23fc8a514afdb27f1eaL30) to an empty string to avoid an error
2. `onKeyDown` is now being prevented when `onSuggestionSelected` fires, i.e. when a suggestion from the list is selected.

## More Details

1. The `undefined` value of `autocompleteLabel` in InputTag would [throw an error](https://github.com/ifmeorg/ifme/blob/main/client/app/widgets/QuickCreate/index.jsx#L51) when passed into the `onChange` prop on 'Enter' keydown: >Cannot read property 'toLowerCase' of undefined. The helper `labelExists` expects the value to be a string.

2. Recently, the deprecated `onKeyPress` event handler was renamed to use `onKeyDown` instead. But that caused an unexpected issue. It gets called [alongside](https://github.com/ifmeorg/ifme/blob/main/client/app/components/Input/InputTag.jsx#L105) `onSuggestionSelected` from Autosuggest, which also derives from `onKeyDown`.
Previously `onKeyPress` would be ignored any time `onSuggestionSelected` was fired. So this fix re-includes that expectation with `onKeyDown`.

(New tests have been added to validate the behavior.)

## Corresponding Issue

#1909 

## Screenshots

Showing three expected behaviors of QuickCreate/InputTag:

![after_fix](https://user-images.githubusercontent.com/11330558/96330279-e99b8b80-1008-11eb-8eb8-511b12ec3904.gif)

- Selecting a highlighted list option on 'Enter' keydown when there is no input, e.g. 'Test Category'
- Selecting a matching list option with 'Enter' keydown, e.g. 'Public Speaking'
- Opening the create form modal on 'Enter' keydown when there is no match, e.g. 'New Category'

_(Apologies for the tiny gif made for ants!)_

If anything looks missing or out of place, please LMK and I'll make the changes.

Thanks! :coffee:

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
