### PR TITLE
[Issue #1920] Devise configuration for locking account after failed password attempts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,8 @@
 #  banned                 :boolean          default(FALSE)
 #  admin                  :boolean          default(FALSE)
 #  third_party_avatar     :text
+#  failed_attempts        :integer          default(0), not null
+#  locked_at              :datetime
 #
 
 class User < ApplicationRecord
@@ -51,8 +53,8 @@ class User < ApplicationRecord
   OAUTH_TOKEN_URL = 'https://accounts.google.com/o/oauth2/token'
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :invitable, :database_authenticatable, :registerable, :uid,
+  # :confirmable, :timeoutable and :omniauthable
+  devise :invitable, :database_authenticatable, :registerable, :uid, :lockable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable,
          omniauth_providers: %i[google_oauth2 facebook]
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -206,7 +206,7 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
   # config.unlock_keys = [ :email ]
@@ -216,17 +216,17 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :time
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 20
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = false
+  config.last_attempt_warning = false
 
   # ==> Configuration for :recoverable
   #

--- a/db/migrate/20201019231628_add_lockable_attributes_to_user.rb
+++ b/db/migrate/20201019231628_add_lockable_attributes_to_user.rb
@@ -1,0 +1,6 @@
+class AddLockableAttributesToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_185200) do
+ActiveRecord::Schema.define(version: 2020_10_19_231628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -294,6 +294,8 @@ ActiveRecord::Schema.define(version: 2020_10_09_185200) do
     t.boolean "banned", default: false
     t.boolean "admin", default: false
     t.text "third_party_avatar"
+    t.integer "failed_attempts", default: 0, null: false
+    t.datetime "locked_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"


### PR DESCRIPTION

# Description

As stated at #1920, [current NIST guidelines](https://pages.nist.gov/800-63-3/sp800-63b.html#throttle) recommend no more than 100 failed login attempts as an upper bound before locking accounts. This PR implements devise lockable configuration for users.

## More Details

The values I used here are totally discussable, but I stuck mostly to default options.
### Lock Strategy
**Failed Attempts:** After 20 failed attempts, user will be locked (20 is the default value)

### Unlock Strategy
**Time:** If user is locked, he/she can try to log-in again after 1 hour (1 hour is the default)

_PS. We could also have an option to unlock by email, but I'm not sure if we need to configure something to set it up_

## Corresponding Issue

Fixes https://github.com/ifmeorg/ifme/issues/1920

# Screenshots

![Screen Recording 2020-10-19 at 20 49 40](https://user-images.githubusercontent.com/2309096/96523783-fc060700-124c-11eb-8be7-56177a77857e.gif)


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
