### PR TITLE
chore: fixed devise deprecation warnings

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,7 +1,8 @@
 <h2><%= t('devise.confirmations.resend_confirmation')  %></h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
 
   <%= react_component 'Input', props: {
     type: 'email',

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
   <%= react_component 'Input', props: {

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,5 +1,6 @@
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
 
   <%= react_component 'Input', props: {
     type: 'email',

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,6 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
 
   <%= react_component 'Input', props: {
     type: 'text',

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="subtitle"><%= t('devise.registrations.new.subtitle') %></div>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <div class="marginTop">
     <%= react_component 'Input', props: {
       type: 'text',

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend unlock instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <%= react_component 'Input', props: {
     type: 'email',

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -1,5 +1,5 @@
 <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :invitation_token %>
 
   <% if f.object.class.require_password_on_accepting %>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -1,5 +1,5 @@
 <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { id: 'invitations', method: :post } do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <%= react_component 'Input', props: {
     type: 'text',
     name: 'user[email]',


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->
Removed deprecation warning for `DeviseHelper.devise_error_messages!`

## More Details
Based on the message I've changed the way we are calling and rendering the devise error messaging from `<%= devise_error_messages! %>` to `<%= render "devise/shared/error_messages", resource: resource %>`
<!--[More details on your changes, remove if not applicable]-->

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->
#1851 

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
