### PR TITLE
Update layout for Devise confirmation pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,6 +57,12 @@ module ApplicationHelper
       devise_page?(path, 'devise/passwords', 'update')
   end
 
+  def new_user_confirmation_path?
+    path = new_user_confirmation_path
+    devise_page?(path, 'devise/confirmations', 'new') ||
+      devise_page?(path, 'devise/confirmations', 'create')
+  end
+
   def secret_share_path?
     params[:controller] == 'secret_shares' && action_name == 'show'
   end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,5 +1,3 @@
-<h2><%= t('devise.confirmations.resend_confirmation')  %></h2>
-
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p><%= t('salutation', name: @email) %>!</p>
+<p><%= t('salutation', name: @email) %></p>
 
 <p><%= t('devise.mailer.confirmation.link_instructions') %>:</p>
 

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,4 +1,4 @@
-<p><%= t('salutation', name: @email) %>!</p>
+<p><%= t('salutation', name: @email) %></p>
 
 <p><%= t('devise.mailer.confirmation.link_instructions')  %></p>
 

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,4 +1,4 @@
-<p><%= t('salutation', name: @email) %>!</p>
+<p><%= t('salutation', name: @email) %></p>
 
 <p><%=t('devise.mailer.unlock.info') %></p>
 

--- a/app/views/layouts/_title.html.erb
+++ b/app/views/layouts/_title.html.erb
@@ -15,6 +15,8 @@
   - <%= t('devise.invitations.edit.header') %>
 <% elsif reset_password_path? %>
   - <%= t('layouts.title.reset_password') %>
+<% elsif new_user_confirmation_path? %>
+  - <%= t('devise.confirmations.resend_confirmation') %>
 <% else %>
   - <%= yield(:title) %>
 <% end %>

--- a/app/views/shared/_page_title.html.erb
+++ b/app/views/shared/_page_title.html.erb
@@ -14,6 +14,8 @@
     <%= t('devise.invitations.edit.header') %>
   <% elsif reset_password_path? %>
     <%= t('layouts.title.reset_password') %>
+  <% elsif new_user_confirmation_path? %>
+    <%= t('devise.confirmations.resend_confirmation') %>
   <% elsif yield(:page_new).present? && @page_new %>
     <div class="pageTitleLeft">
       <%= yield(:title) %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -316,6 +316,36 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'new_user_confirmation_path?' do
+    let(:page) { '' }
+    let(:current_controller) { '' }
+    let(:action_name) { '' }
+    subject { new_user_confirmation_path? }
+
+    before(:each) do
+      params[:controller] = current_controller
+      allow(self).to receive('action_name').and_return(action_name)
+      allow(self).to receive('current_page?').and_return(false)
+      allow(self).to receive('current_page?').with(page).and_return(true)
+    end
+
+    context 'when the path matches' do
+      let(:page) { new_user_confirmation_path }
+      it { is_expected.to be true }
+    end
+
+    context 'when the controller and action match the path' do
+      let(:current_controller) { 'devise/confirmations' }
+      let(:action_name) { 'new' }
+      it { is_expected.to be true }
+    end
+
+    context 'when the path does not match' do
+      let(:page) { about_path }
+      it { is_expected.to be false }
+    end
+  end
+
   describe 'secret_share_path?' do
     let(:page) { '' }
     let(:current_controller) { '' }


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This merged [PR](https://github.com/ifmeorg/ifme/pull/1958) from @Revathyne adds the requirement to send a confirmation email when signing up for an account. This PR updates the layout for the "Resend confirmation instructions" page.

## More Details

<!--[More details on your changes, remove if not applicable]-->

It also fixes a grammar issue in the emails.

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

# Screenshots

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

![image](https://user-images.githubusercontent.com/3010728/108310872-f96ade00-7168-11eb-8120-8fb44787453a.png)


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
