### PR TITLE
#1857 Fix Act warnings in Jest tests

### DIFF
--- a/client/app/components/BaseContainer/__tests__/index.spec.jsx
+++ b/client/app/components/BaseContainer/__tests__/index.spec.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import axios from 'axios';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import BaseContainer from 'components/BaseContainer';
 
 const response = {
@@ -54,7 +54,7 @@ describe('BaseContainer', () => {
           const { container, getByRole } = render(getComponent({ fetchUrl }));
           const loadMoreButton = getByRole('button');
           fireEvent.click(loadMoreButton);
-          await axiosGetSpy();
+          await act(() => axiosGetSpy());
           expect(axiosGetSpy).toBeCalledWith(
             'https://if-me.org/some-fetch-url.json?page=2',
           );
@@ -96,7 +96,7 @@ describe('BaseContainer', () => {
           const { container, queryByRole } = render(getComponent({ fetchUrl }));
           const loadMoreButton = queryByRole('button');
           fireEvent.click(loadMoreButton);
-          await axiosGetSpy();
+          await act(() => axiosGetSpy());
           const stories = container.querySelectorAll('.story');
           expect(axiosGetSpy).toBeCalledWith(
             'https://if-me.org/some-fetch-url.json?page=2&uid=some-uid',


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Small change to fix warnings thrown when Jest tests cause React state updates but are not wrapped into an act(...) helper. The referenced issue mentions seeing the warnings in 
`client/app/widgets/Comments/__tests__/Comments.spec.jsx` and `client/app/components/BaseContainer/__tests__/index.spec.jsx`. I did not see the warnings in Comments.spec.jsx, and I do not see where the code may be causing those warnings at this time.

## Corresponding Issue

#1857 

# Screenshots

Not a UI change, but here's a before and after screenshot to prove the act warnings are resolved:
![image](https://user-images.githubusercontent.com/8864734/119926003-23882500-bf3c-11eb-99aa-e814d98ea756.png)
![image](https://user-images.githubusercontent.com/8864734/119926072-461a3e00-bf3c-11eb-9e4e-afa0e35d0895.png)
---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
