### PR TITLE
Fix: Remove HTML formatting when pasting in editor

### DIFF
--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -90,13 +90,13 @@ export function InputTextarea(props: Props) {
     }
   };
 
-  const onPaste = e => {
+  const onPaste = (e) => {
     e.preventDefault();
 
     const text = (e.originalEvent || e).clipboardData.getData('text/plain') ?? '';
 
-    document.execCommand("insertHTML", false, text);
-  }
+    document.execCommand('insertHTML', false, text);
+  };
 
   useEffect(() => {
     if (editorRef.current) {

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -90,6 +90,14 @@ export function InputTextarea(props: Props) {
     }
   };
 
+  const onPaste = e => {
+    e.preventDefault();
+
+    const text = (e.originalEvent || e).clipboardData.getData('text/plain') ?? '';
+
+    document.execCommand("insertHTML", false, text);
+  }
+
   useEffect(() => {
     if (editorRef.current) {
       editor.current = init({
@@ -108,6 +116,7 @@ export function InputTextarea(props: Props) {
       className={`${inputCss.default} ${dark ? css.dark : ''}`}
       onBlur={onBlur}
       onFocus={onFocus}
+      onPaste={onPaste}
       tabIndex={0}
       role="textbox"
       ref={editorRef}


### PR DESCRIPTION
# Description

Removed formatting when copying and pasting in editor.

## More Details

By default, a container with `contenteditable` set to true will allow HTML formatting to be pasted into its inner content. There are a few ways to prevent this from happening:

1. Instead of a generic `div`, we can use `textarea` or `input` elements for our text field. These elements will sanitize any HTML being pasted in and also serves for good accessibility and HTML semantics. 

2. Intercept the user's clipboard and sanitize it with JavaScript before pasting it.

Due to the nature of how the pell action bar is implemented, option 2 will be the simplest way to achieve this.

## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1987

# Screenshots

### Before
![new-moment-before](https://user-images.githubusercontent.com/20848851/120282045-8c3e0d00-c26e-11eb-947f-b6208ba7c568.gif)

### After
![new-moment-after](https://user-images.githubusercontent.com/20848851/120282091-97913880-c26e-11eb-824c-2bcae9c13f61.gif)

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
