### PR TITLE
Fixed #1898 Added white background to Pell editor options.

### DIFF
--- a/client/app/components/Input/InputTextarea.scss
+++ b/client/app/components/Input/InputTextarea.scss
@@ -57,11 +57,12 @@
     }
 
     &Selected {
-      color: $key-lime;
+      background: white;
+      color: $mulberry;
 
       b,
       strong {
-        color: $key-lime !important;
+        color: $mulberry !important;
       }
     }
   }

--- a/client/app/components/Input/InputTextarea.scss
+++ b/client/app/components/Input/InputTextarea.scss
@@ -57,7 +57,7 @@
     }
 
     &Selected {
-      background: white;
+      background:$white;
       color: $mulberry;
 
       b,


### PR DESCRIPTION
# Description

<!--[]-->
I added a white background to the Pell Editor options to increase visibility.

## More Details

<!--[]-->
I was having trouble finding a color that passed the accessibility tests for mulberry and white, so I made the options mulberry colored with a white background instead. I wanted to find a variant of key-lime, but none passed the accessibility tests for white. I think an accessible color for mulberry and white is difficult to find because mulberry is a darker color and white is a lighter color, so their contrasting colors blend in with one another. For example, a bright color like yellow contrasts well with mulberry but blends in with white, making it unusable.

## Corresponding Issue

<!--[]-->
https://github.com/ifmeorg/ifme/issues/1898

# Screenshots

<!--[]-->

  Screenshots (required for user interface work), remove if not applicable
Before:
![image](https://user-images.githubusercontent.com/70127717/124234157-88e5ad80-dac8-11eb-9fe5-3305bccc78a5.png)
Contrast Ratio 1.34:1

After:
![image](https://user-images.githubusercontent.com/70127717/124233149-6737f680-dac7-11eb-928d-9ce0d57a4950.png)
Contrast Ratio 12.04:1

