### PR TITLE
Fix form submission with empty description

### DIFF
--- a/client/app/components/Form/utils.js
+++ b/client/app/components/Form/utils.js
@@ -31,7 +31,7 @@ export const getNewInputs = ({
   errors,
 }: GetNewInputsArgs): GetNewInputsReturn => {
   const isInputError = (input: MyInputProps) => {
-    const validType = REQUIRES_DEFAULT.includes(input.type) || input.type === 'textarea';
+    const validType = REQUIRES_DEFAULT.includes(input.type) || input.type === 'textarea' || input.type === "textareaTemplate";
     return (
       validType && input.required && refs[input.id] && !refs[input.id].value
     );

--- a/client/app/components/Form/utils.js
+++ b/client/app/components/Form/utils.js
@@ -31,7 +31,9 @@ export const getNewInputs = ({
   errors,
 }: GetNewInputsArgs): GetNewInputsReturn => {
   const isInputError = (input: MyInputProps) => {
-    const validType = REQUIRES_DEFAULT.includes(input.type) || input.type === 'textarea' || input.type === "textareaTemplate";
+    const validType = REQUIRES_DEFAULT.includes(input.type)
+      || input.type === 'textarea'
+      || input.type === 'textareaTemplate';
     return (
       validType && input.required && refs[input.id] && !refs[input.id].value
     );

--- a/client/app/components/Input/InputTextarea.scss
+++ b/client/app/components/Input/InputTextarea.scss
@@ -57,7 +57,7 @@
     }
 
     &Selected {
-      background:$white;
+      background: $white;
       color: $mulberry;
 
       b,

--- a/client/app/components/Input/InputTextareaTemplate.jsx
+++ b/client/app/components/Input/InputTextareaTemplate.jsx
@@ -6,6 +6,7 @@ import { InputTextarea } from 'components/Input/InputTextarea';
 import { Utils } from 'utils';
 import globalCss from 'styles/_global.scss';
 import type { Option } from './utils';
+import { mergeRefs } from "./utils";
 
 // TODO (julianguyen): Tests after writing stubs for pell editor
 
@@ -17,6 +18,7 @@ export type Props = {
   hasError?: Function,
   dark?: boolean,
   options?: Option[],
+  myRef?: any,
 };
 
 export const InputTextareaTemplate = ({
@@ -27,6 +29,7 @@ export const InputTextareaTemplate = ({
   hasError,
   dark,
   options: optionsProp,
+  myRef
 }: Props) => {
   const [value, setValue] = useState(valueProp);
   const [textareaKey, setTextareaKey] = useState();
@@ -80,7 +83,7 @@ export const InputTextareaTemplate = ({
         value={options ? options[0].value || value : value}
         required={required}
         hasError={hasError}
-        myRef={textareaRef}
+        myRef={mergeRefs(textareaRef, myRef)}
         dark={dark}
       />
     </>

--- a/client/app/components/Input/InputTextareaTemplate.jsx
+++ b/client/app/components/Input/InputTextareaTemplate.jsx
@@ -6,7 +6,7 @@ import { InputTextarea } from 'components/Input/InputTextarea';
 import { Utils } from 'utils';
 import globalCss from 'styles/_global.scss';
 import type { Option } from './utils';
-import { mergeRefs } from "./utils";
+import { mergeRefs } from './utils';
 
 // TODO (julianguyen): Tests after writing stubs for pell editor
 
@@ -29,7 +29,7 @@ export const InputTextareaTemplate = ({
   hasError,
   dark,
   options: optionsProp,
-  myRef
+  myRef,
 }: Props) => {
   const [value, setValue] = useState(valueProp);
   const [textareaKey, setTextareaKey] = useState();

--- a/client/app/components/Input/index.jsx
+++ b/client/app/components/Input/index.jsx
@@ -133,6 +133,7 @@ export const Input = ({
         hasError={(errorPresent: boolean) => hasError(errorPresent)}
         dark={dark}
         options={options}
+        myRef={myRef}
       />
     );
   };

--- a/client/app/components/Input/utils.js
+++ b/client/app/components/Input/utils.js
@@ -111,12 +111,13 @@ export type Props = {
   copyOnClick?: string,
 };
 
+/* eslint no-param-reassign: ["error", { "props": false }] */
 export const mergeRefs = (...refs: any) => (element: HTMLInputElement) => {
-  refs.forEach(ref => {
+  refs.forEach((ref) => {
     if (typeof ref === 'function') {
       ref(element);
     } else if (ref) {
       ref.current = element;
     }
-  })
+  });
 };

--- a/client/app/components/Input/utils.js
+++ b/client/app/components/Input/utils.js
@@ -110,3 +110,15 @@ export type Props = {
   googleAPIKey?: string,
   copyOnClick?: string,
 };
+
+export const mergeRefs = (...refs) => {
+  return element => {
+    for (const ref of refs) {
+      if (typeof ref === 'function'){
+        ref(element);
+      } else if (ref) {
+        ref.current = element;
+      }
+    }
+  }
+}

--- a/client/app/components/Input/utils.js
+++ b/client/app/components/Input/utils.js
@@ -111,14 +111,12 @@ export type Props = {
   copyOnClick?: string,
 };
 
-export const mergeRefs = (...refs) => {
-  return element => {
-    for (const ref of refs) {
-      if (typeof ref === 'function'){
-        ref(element);
-      } else if (ref) {
-        ref.current = element;
-      }
+export const mergeRefs = (...refs: any) => (element: HTMLInputElement) => {
+  for (const ref of refs) {
+    if (typeof ref === 'function') {
+      ref(element);
+    } else if (ref) {
+      ref.current = element;
     }
   }
-}
+};

--- a/client/app/components/Input/utils.js
+++ b/client/app/components/Input/utils.js
@@ -112,11 +112,11 @@ export type Props = {
 };
 
 export const mergeRefs = (...refs: any) => (element: HTMLInputElement) => {
-  for (const ref of refs) {
+  refs.forEach(ref => {
     if (typeof ref === 'function') {
       ref(element);
     } else if (ref) {
       ref.current = element;
     }
-  }
+  })
 };


### PR DESCRIPTION
# Description

Form submission would throw an error with empty description unless the user focused/selected the text-area atleast. This was caused since there was no check in place for input elements of **textareatemplate** type.

Created a small function to merge refs. Using that, sent the parent ref to the input element. With this, the check is in place and form submission won't happen for an empty description regardless of focus/blur.

## Corresponding Issue

#2007 

# Screenshots
[Gif](https://gifyu.com/image/GkQP)

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
