### PR TITLE
Bug Fix/Confirmation email

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,10 +58,10 @@ module ApplicationHelper
   end
 
   def new_user_confirmation_path?
-    # path = new_user_confirmation_path
-    # devise_page?(path, 'devise/confirmations', 'new') ||
-    #   devise_page?(path, 'devise/confirmations', 'create')
-    false
+    path = new_user_confirmation_path
+
+    devise_page?(path, 'devise/confirmations', 'new') ||
+      devise_page?(path, 'devise/confirmations', 'create')
   end
 
   def secret_share_path?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,5 +238,11 @@ class User < ApplicationRecord
   def access_token_expired?
     !access_expires_at || Time.zone.now > access_expires_at
   end
+
+  def confirmation_required?
+    return false if oauth_provided?
+
+    super
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,7 +82,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :invitable, :database_authenticatable, :registerable, :uid, :lockable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable,
-         omniauth_providers: %i[google_oauth2 facebook]
+         :confirmable, omniauth_providers: %i[google_oauth2 facebook]
   # https://github.com/michaelbanfield/devise-pwned_password#disabling-in-test-environments
   # TODO: reenable if we disable real network requests & stub them with Webmock
   # https://github.com/bblimke/webmock

--- a/db/migrate/20211005010735_add_confirmable_to_devise.rb
+++ b/db/migrate/20211005010735_add_confirmable_to_devise.rb
@@ -1,0 +1,19 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column :users, :confirmation_token,   :string
+    add_column :users, :confirmed_at,         :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email,    :string
+
+    add_index  :users, :confirmation_token, unique: true
+  end
+
+  def self.down
+    remove_index  :users, :confirmation_token
+
+    remove_column :users, :unconfirmed_email
+    remove_column :users, :confirmation_sent_at
+    remove_column :users, :confirmed_at
+    remove_column :users, :confirmation_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_28_174852) do
+ActiveRecord::Schema.define(version: 2021_10_05_010735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -307,6 +307,11 @@ ActiveRecord::Schema.define(version: 2021_03_28_174852) do
     t.text "third_party_avatar"
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -48,12 +48,14 @@ FactoryBot.define do
     sequence(:email) { |n| "some-email#{n}@ifme.org" }
     sequence(:name) { |n| "Some Person#{n}" }
     password { 'passworD%1' }
+    confirmed_at { Time.zone.now }
   end
 
   factory :user1, class: User do
     name { 'Oprah Chang' }
     sequence(:email) { |n| "oprah.chang#{n}@example.com" }
     password { 'passworD%1' }
+    confirmed_at { Time.zone.now }
     location { 'Toronto, ON, Canada' }
   end
 
@@ -61,6 +63,7 @@ FactoryBot.define do
     name { 'Plum Blossom' }
     email { 'plum.blossom@example.com' }
     password { 'passworD%1' }
+    confirmed_at { Time.zone.now }
     location { 'Toronto, ON, Canada' }
 
     trait :with_allies do
@@ -81,6 +84,7 @@ FactoryBot.define do
     name { 'Gentle Breezy' }
     email { 'gentle.breezy@example.com' }
     password { 'passworD%1' }
+    confirmed_at { Time.zone.now }
     location { 'Toronto, ON, Canada' }
   end
 
@@ -88,8 +92,13 @@ FactoryBot.define do
     name { 'Orange Southland' }
     email { 'orange.southland@example.com' }
     password { 'passworD%1' }
+    confirmed_at { Time.zone.now }
     location { 'Toronto, ON, Canada' }
     token { 'has_a_token' }
     access_expires_at { Time.zone.now + 600 }
+
+    trait :unconfirmable do
+      confirmed_at { nil }
+    end
   end
 end

--- a/spec/features/user_auth_spec.rb
+++ b/spec/features/user_auth_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.feature 'UserAuthLogin', type: :feature, js: true do
+  context 'when user has not confirmable yet and tries to login' do
+    scenario 'successful logs in' do
+      user = create :user_oauth, :unconfirmable
+      login_as user
+
+      visit moments_path
+
+      expect(page.body).to_not have_content("confirm your email")
+      expect(page).to have_current_path moments_path
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -316,35 +316,35 @@ describe ApplicationHelper do
     end
   end
 
-  # describe 'new_user_confirmation_path?' do
-  #   let(:page) { '' }
-  #   let(:current_controller) { '' }
-  #   let(:action_name) { '' }
-  #   subject { new_user_confirmation_path? }
+  describe 'new_user_confirmation_path?' do
+    let(:page) { '' }
+    let(:current_controller) { '' }
+    let(:action_name) { '' }
+    subject { new_user_confirmation_path? }
 
-  #   before(:each) do
-  #     params[:controller] = current_controller
-  #     allow(self).to receive('action_name').and_return(action_name)
-  #     allow(self).to receive('current_page?').and_return(false)
-  #     allow(self).to receive('current_page?').with(page).and_return(true)
-  #   end
+    before(:each) do
+      params[:controller] = current_controller
+      allow(self).to receive('action_name').and_return(action_name)
+      allow(self).to receive('current_page?').and_return(false)
+      allow(self).to receive('current_page?').with(page).and_return(true)
+    end
 
-  #   context 'when the path matches' do
-  #     let(:page) { new_user_confirmation_path }
-  #     it { is_expected.to be true }
-  #   end
+    context 'when the path matches' do
+      let(:page) { new_user_confirmation_path }
+      it { is_expected.to be true }
+    end
 
-  #   context 'when the controller and action match the path' do
-  #     let(:current_controller) { 'devise/confirmations' }
-  #     let(:action_name) { 'new' }
-  #     it { is_expected.to be true }
-  #   end
+    context 'when the controller and action match the path' do
+      let(:current_controller) { 'devise/confirmations' }
+      let(:action_name) { 'new' }
+      it { is_expected.to be true }
+    end
 
-  #   context 'when the path does not match' do
-  #     let(:page) { about_path }
-  #     it { is_expected.to be false }
-  #   end
-  # end
+    context 'when the path does not match' do
+      let(:page) { about_path }
+      it { is_expected.to be false }
+    end
+  end
 
   describe 'secret_share_path?' do
     let(:page) { '' }


### PR DESCRIPTION
# Description

- This PR rollback the confirmation email.
- Adds a handling case when confirmation was used by a user with a oauth sign-in.

## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/1964
