### PR TITLE
Add element roles to alert and notice elements

### DIFF
--- a/app/assets/stylesheets/core/alerts.scss
+++ b/app/assets/stylesheets/core/alerts.scss
@@ -1,11 +1,13 @@
 .alert {
-  @include setMargin($size-0, $size-0, $size-26, $size-0);
-
   background: $carmine;
   color: $white;
   padding: $size-10;
   text-align: center;
   border-radius: $size-4;
+
+  &Dashboard {
+    @include setMargin($size-0, $size-0, $size-26, $size-0);
+  }
 
   &Text {
     color: $carmine;

--- a/app/assets/stylesheets/core/notices.scss
+++ b/app/assets/stylesheets/core/notices.scss
@@ -1,9 +1,11 @@
 .notice {
-  @include setMargin($size-0, $size-0, $size-26, $size-0);
-
   background: $limeade;
   color: $white;
   padding: $size-10;
   text-align: center;
   border-radius: $size-4;
+
+  &Dashboard {
+    @include setMargin($size-0, $size-0, $size-26, $size-0);
+  }
 }

--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -1,8 +1,8 @@
 <div class="gridMany">
   <% if notice.present? %>
-    <div role="region" aria-live="polite" class="notice"><%= notice %></div>
+    <div role="region" aria-live="polite" class="notice <%= (user_signed_in? && !static_page?) || secret_share_path? ? 'noticeDashboard' : '' %>"><%= notice %></div>
   <% end %>
   <% if alert.present? %>
-    <div role="alert" class="alert"><%= alert %></div>
+    <div role="alert" class="alert <%= (user_signed_in? && !static_page?) || secret_share_path? ? 'alertDashboard' : '' %>"><%= alert %></div>
   <% end %>
 </div>


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Improve a11y in alert and notice elements by adding `role="region"` and `aria-live="polite"` for notices and `role="alert"` for alerts.

![GIF of an animated skeleton dancing](https://media.giphy.com/media/t2uEYBdHWXEkqx9M9n/giphy.gif)

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
