### PR TITLE
[#2039] Improve a11y of Modal component 

### DIFF
--- a/client/app/components/Avatar/index.jsx
+++ b/client/app/components/Avatar/index.jsx
@@ -36,7 +36,7 @@ export const Avatar = (props: Props) => {
         small ? css.small : ''
       }`}
     >
-      <LazyLoad height={height} offset={height} once>
+      <LazyLoad height={height} offset={height} once tabIndex={0}>
         {src ? (
           displayImage(alt, src)
         ) : (


### PR DESCRIPTION
closes #2039

I decided to keep role="button" and tabIndex={0}, and made the children focusable 