### PR TITLE
Ignore CVE-2021-44528 temporarily until Rails upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,8 @@ jobs:
           root: tmp
           paths:
             - codeclimate.backend.json
-      - run: bundle exec bundle-audit check --ignore CVE-2015-9284 CVE-2021-22881 CVE-2021-22880 CVE-2021-22942 --update
+      # Remove ignore values when we upgrade to Rails 3
+      - run: bundle exec bundle-audit check --ignore CVE-2015-9284 CVE-2021-22881 CVE-2021-22880 CVE-2021-22942 CVE-2021-44528 --update
       - store_test_results:
           path: /tmp/circleci-test-results
       - store_artifacts:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

This PR temporarily disables the security vulnerability issue for updating `actionpack` to unblock deployments. The criticality is `unknown` currently. Updating `actionpack` requires updating Rails, which requires some refactoring with our tests. This is currently being worked on by me in https://github.com/ifmeorg/ifme/pull/2059. 

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
