### PR TITLE
Call invalidate_all_sessions in prepend_before_action

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,7 @@
 class SessionsController < Devise::SessionsController
   prepend_before_action :check_recaptcha, only: [:create]
   before_action :set_recaptcha, only: [:new]
+  prepend_before_action :invalidate_all_sessions, only: [:destroy]
 
   def new
     super
@@ -14,7 +15,6 @@ class SessionsController < Devise::SessionsController
   end
 
   def destroy
-    current_user.invalidate_all_sessions!
     super
   end
 
@@ -56,5 +56,9 @@ class SessionsController < Devise::SessionsController
     return false if user.nil?
 
     RecaptchaService.new(user).recaptcha_required_for_login?
+  end
+
+  def invalidate_all_sessions
+    current_user.invalidate_all_sessions!
   end
 end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Noticing some inconsistencies between dev and production when it comes to calling `current_user.invalidate_all_sessions!`.  It's being called consistently in dev before the default functionality of Devise's `destroy`, whereas in prod it's not. So I'm going to try to stick this functionality in a `prepend_before_action`, to make sure it's always called before. Let's see if this works 🤞 

Things continue to work in dev as expected ✅ 

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

#2058

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!

![GIF of illustrated tigers crawling infinitely](https://media.giphy.com/media/28HLxPR2vopAQ/giphy.gif)
