### PR TITLE
Fix node warnings in tests

### DIFF
--- a/client/app/components/Header/__tests__/HeaderProfile.spec.jsx
+++ b/client/app/components/Header/__tests__/HeaderProfile.spec.jsx
@@ -4,6 +4,10 @@ import { queryByText, render } from '@testing-library/react';
 import React from 'react';
 import { HeaderProfile } from '../HeaderProfile';
 
+jest.mock('widgets/Notifications', () => ({
+  Notifications: () => <></>,
+}));
+
 const profileWithAvatar = {
   avatar: '//congue.volutpat/sollicitudin.jpg',
   name: 'Sollicitudin',


### PR DESCRIPTION
# Description
In this PR I fixed node warnings in [HeaderProfile.spec.jsx](https://github.com/ifmeorg/ifme/blob/main/client/app/components/Header/__tests__/HeaderProfile.spec.jsx)

## More Details
Took a look on tests and decided to mock the entire `Notifications` component, warnings were generated since `axios` is used in it. Since there are no tests for Notifications in HeaderProfile.spec.jsx I decided to mock the entire component instead of mocking `axios`.

## Corresponding Issue
Closes #2033.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
