### PR TITLE
Use buildpack-deps:trusty Docker image for deploy for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,8 @@ jobs:
             ./tmp/cc-test-reporter upload-coverage -i tmp/codeclimate.total.json
   deploy:
     docker:
-      - image: cimg/base
+      # TODO: Update this to correct cimg/base
+      - image: buildpack-deps:trusty
     steps:
       - checkout
       - run:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Use `buildpack-deps:trusty` Docker image for deploy for now. This official CIrcle CI discussion [post](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) mentions using `cimg/base`. Tried using it but no luck 🙃  Will revisit this during the week!

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
