### PR TITLE
[#2107] Fix Safari bug cause by unsupported lookbehind assertion

### DIFF
--- a/client/app/libs/i18n/index.js
+++ b/client/app/libs/i18n/index.js
@@ -21,10 +21,11 @@ export const I18n = {
   t: (scope: string, options?: Options): string => {
     const locale = Cookies.get('locale') || 'en';
     let result = translations[locale][scope] || missingResult(locale, scope);
-    const resultOptions = result.match(/(?<={).*?(?=})/g);
+    const resultOptions = result.match(/\{(.*?)\}/g);
     if (resultOptions) {
       resultOptions.forEach((option: string) => {
-        result = result.replaceAll(`{${option}}`, getValue(options, option));
+        const optionKey = option.replace('{', '').replace('}', '');
+        result = result.replaceAll(option, getValue(options, optionKey));
       });
     }
     return result;


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Internationalization (i18n) rendered in the React front-end is not loading in Safari because the browser does not support the lookbehind assertion that is used in the Regex pattern.

This PR fixes this issue by updating the Regex.

Thanks to @decisivewaffles for creating a bug ticket! 

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

https://github.com/ifmeorg/ifme/issues/2107

# Screenshots

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

## Before

![image](https://user-images.githubusercontent.com/3010728/170154295-1ff5f35c-1141-407d-96ff-74e724a8b4b0.png)

## After

![image](https://user-images.githubusercontent.com/3010728/170154309-4c755e02-10b5-4a69-b61f-7522afd074be.png)

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
