### PR TITLE
Improve/add appropriate message during workspace setup step

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,8 @@ task setup_workspace: :environment do
     end
     File.write(target, content)
   end
+
+  puts "Workspace setup completed."
 end
 
 # Run the secret task, grab the output, strip the new lines

--- a/Rakefile
+++ b/Rakefile
@@ -25,25 +25,30 @@ end
 
 desc 'Automate the Config Setup for New Environments'
 task setup_workspace: :environment do
-  SECRETS = {
-    SECRET_KEY_BASE: generate_secret,
-    DEVISE_SECRET_KEY: generate_secret
-  }.freeze
+  begin
+    SECRETS = {
+      SECRET_KEY_BASE: generate_secret,
+      DEVISE_SECRET_KEY: generate_secret
+    }.freeze
 
-  %w[development test].each do |environment|
-    example = Rails.root.join('config', 'env', "#{environment}.example.env")
-    target = Rails.root.join('config', 'env', "#{environment}.env")
-    FileUtils.cp(example, target)
+    %w[development test].each do |environment|
+      example = Rails.root.join('config', 'env', "#{environment}.example.env")
+      target = Rails.root.join('config', 'env', "#{environment}.env")
+      FileUtils.cp(example, target)
 
-    # insert the secrets into the file
-    content = File.read(target)
-    %w[SECRET_KEY_BASE DEVISE_SECRET_KEY].each do |key|
-      content.sub!(%(#{key}=""), %(#{key}="#{SECRETS[key.to_sym]}"))
+      # insert the secrets into the file
+      content = File.read(target)
+      %w[SECRET_KEY_BASE DEVISE_SECRET_KEY].each do |key|
+        content.sub!(%(#{key}=""), %(#{key}="#{SECRETS[key.to_sym]}"))
+      end
+      File.write(target, content)
     end
-    File.write(target, content)
-  end
 
-  puts "Workspace setup completed."
+    puts "Workspace setup completed successfully 🎉"
+  rescue StandardError => e
+    puts "Exception Occurred #{e.class}. Message: #{e.message}. Backtrace:  \n #{e.backtrace.join("\n")}"
+    Rails.logger.error "Exception Occurred #{e.class}. Message: #{e.message}. Backtrace:  \n #{e.backtrace.join("\n")}"
+  end
 end
 
 # Run the secret task, grab the output, strip the new lines


### PR DESCRIPTION
# Description

Currently, when we run `bin/rake setup_workspace` [step](https://github.com/ifmeorg/ifme/wiki/Installation#configuration-files), it's not clear (i.e. does not indicate) whether the setup process is completed properly or not. This change adds an appropriate message with a check whether the setup process was successful or not.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
