### PR TITLE
Improve/wording to fix a typo in Installation section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please check out our [Wiki](https://github.com/ifmeorg/ifme/wiki) for full docum
 
 ### Installation
 
-Information about installing and configuring the app [here](https://github.com/ifmeorg/ifme/wiki/Installation). Test, development, and production instances are covered.
+[Here](https://github.com/ifmeorg/ifme/wiki/Installation) are instructions for setting up and installing the app. Test, development, and production instances are covered.
 
 ### Contributor Blurb
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please check out our [Wiki](https://github.com/ifmeorg/ifme/wiki) for full docum
 
 ### Installation
 
-[Here](https://github.com/ifmeorg/ifme/wiki/Installation) are instructions for setting up and installing the app. Test, development, and production instances are covered.
+[Here](https://github.com/ifmeorg/ifme/wiki/Installation) are the instructions for setting up and installing the app. Test, development, and production instances are covered.
 
 ### Contributor Blurb
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please check out our [Wiki](https://github.com/ifmeorg/ifme/wiki) for full docum
 
 ### Installation
 
-[Here](https://github.com/ifmeorg/ifme/wiki/Installation) are the instructions for setting up and installing the app. Test, development, and production instances are covered.
+[These are the instructions](https://github.com/ifmeorg/ifme/wiki/Installation) for setting up and installing the app. Test, development, and production instances are covered.
 
 ### Contributor Blurb
 


### PR DESCRIPTION
# Description

There is a typo in the [Installation](https://github.com/ifmeorg/ifme#installation) section of the README. 
Currently, it says

> Information about installing and configuring the app [here](https://github.com/ifmeorg/ifme/wiki/Installation)

which can be improved to say

> [Here](https://github.com/ifmeorg/ifme/wiki/Installation) are the instructions for setting up and installing the app

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
