### PR TITLE
Issue#2155 ux

### DIFF
--- a/app/assets/stylesheets/static/static_content.scss
+++ b/app/assets/stylesheets/static/static_content.scss
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   padding: $size-40 34px;
   scroll-behavior: smooth;
-  margin: 0 auto;
+  margin-top: 50px;
 
   @media screen and (max-width: $medium) {
     padding: $size-20;

--- a/app/assets/stylesheets/static/static_content.scss
+++ b/app/assets/stylesheets/static/static_content.scss
@@ -5,7 +5,8 @@
   box-sizing: border-box;
   padding: $size-40 34px;
   scroll-behavior: smooth;
-  margin-top: 50px;
+  margin: 50px auto;
+  
 
   @media screen and (max-width: $medium) {
     padding: $size-20;

--- a/client/app/components/Header/Header.scss
+++ b/client/app/components/Header/Header.scss
@@ -97,6 +97,12 @@
   }
 
   &Desktop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+
     width: 100%;
     padding: 25px $size-34;
     box-sizing: border-box;
@@ -108,11 +114,11 @@
 
     @media screen and (max-width: $medium) {
       padding: 15px $size-10;
+      position: relative;
     }
 
     &Home {
       @include linkStyle();
-
       font-size: $size-30;
     }
 


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description
With the following changes in `client/app/components/Header/Header.scss`, the navbar will be sticky.

## More Details
The fixed navbar is not supported in mobile view. I intentionally left it out because the background is transparent in the navbar (i.e, background: transparent;) Giving the navbar a subtle color would prevent any clashes from occurring as a result of scrolling.


## Corresponding Issue

This enhancement addresses the issue https://github.com/ifmeorg/ifme/issues/2155. 

# Screenshots

#### Current behavior: navbar is in fixed position even with the scoll.
<img width="2413" alt="CleanShot 2022-10-13 at 05 05 29@2x" src="https://user-images.githubusercontent.com/71540402/195553868-f725939a-6835-42cb-a44d-bbf445e5b969.png">

#### The screenshot below is the background color I would propose using but haven't implemented yet.
This would prevent the clashes with logo and content on the scroll 
<img width="2425" alt="CleanShot 2022-10-13 at 05 02 41@2x" src="https://user-images.githubusercontent.com/71540402/195553215-d7f511e7-efe3-422b-98a8-6ea7f970890a.png">


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
