### PR TITLE
Show Moments bookmark toggle in production

### DIFF
--- a/app/helpers/moments_form_helper.rb
+++ b/app/helpers/moments_form_helper.rb
@@ -87,7 +87,7 @@ module MomentsFormHelper
       'bookmarked', 'switch', 'moments.form.bookmarked_question'
     ).merge(
       value: true, uncheckedValue: false,
-      checked: params[:bookmarked] ? true : @moment.bookmarked, 
+      checked: params[:bookmarked] ? true : @moment.bookmarked,
       dark: true,
       info: t('moments.form.bookmarked_info')
     )
@@ -105,8 +105,8 @@ module MomentsFormHelper
       moment_name, moment_why, moment_fix, moment_category, moment_mood,
       moment_strategy, get_viewers_input(
         @viewers, 'moment', 'moments', @moment
-      ), moment_comment, moment_publishing(edit),
-      Rails.env.development? ? moment_bookmarked : {}, moment_display_resources
+      ), moment_comment, moment_publishing(edit), moment_bookmarked,
+      moment_display_resources
     ]
   end
 

--- a/spec/helpers/moments_form_helper_spec.rb
+++ b/spec/helpers/moments_form_helper_spec.rb
@@ -238,6 +238,17 @@ describe MomentsFormHelper do
               value: '0'
             },
             {
+              id: 'moment_bookmarked',
+              checked: false,
+              dark: true,
+              info: 'Bookmarked moments appear in your Care Plan',
+              label: 'Bookmark this moment?',
+              name: 'moment[bookmarked]',
+              type: 'switch',
+              uncheckedValue: false,
+              value: true
+            },
+            {
               id: 'moment_resource_recommendations',
               type: 'switch',
               name: 'moment[resource_recommendations]',
@@ -470,6 +481,17 @@ describe MomentsFormHelper do
               type: 'switch',
               uncheckedValue: '1',
               value: '0'
+            },
+            {
+              id: 'moment_bookmarked',
+              checked: false,
+              dark: true,
+              info: 'Bookmarked moments appear in your Care Plan',
+              label: 'Bookmark this moment?',
+              name: 'moment[bookmarked]',
+              type: 'switch',
+              uncheckedValue: false,
+              value: true
             },
             {
               id: 'moment_resource_recommendations',
@@ -746,6 +768,17 @@ describe MomentsFormHelper do
               checked: true
             },
             {
+              id: 'moment_bookmarked',
+              checked: false,
+              dark: true,
+              info: 'Bookmarked moments appear in your Care Plan',
+              label: 'Bookmark this moment?',
+              name: 'moment[bookmarked]',
+              type: 'switch',
+              uncheckedValue: false,
+              value: true
+            },
+            {
               id: 'moment_resource_recommendations',
               type: 'switch',
               name: 'moment[resource_recommendations]',
@@ -1012,6 +1045,17 @@ describe MomentsFormHelper do
               value: '0',
               uncheckedValue: '1',
               checked: true
+            },
+            {
+              id: 'moment_bookmarked',
+              checked: false,
+              dark: true,
+              info: 'Bookmarked moments appear in your Care Plan',
+              label: 'Bookmark this moment?',
+              name: 'moment[bookmarked]',
+              type: 'switch',
+              uncheckedValue: false,
+              value: true
             },
             {
               id: 'moment_resource_recommendations',


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

We recently added the ability to bookmark Moments so that they display on the Care Plan page 🎉 

I noticed a bug in production where the toggle is not showing up in the editor. It's because we hid it behind a dev environment flag.

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->
https://github.com/ifmeorg/ifme/issues/2143

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
