### PR TITLE
2173 -  whitelist tags for html sanitizer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,8 @@ module Ifme
     config.i18n.available_locales = Locale.available_locales.sort_by(&:swapcase).map &:to_sym
     config.i18n.default_locale = :en
 
+    config.action_view.sanitized_allowed_tags = Rails::Html::Sanitizer.white_list_sanitizer.allowed_tags + ['strike', 'u']
+
     config.to_prepare do
       Devise::Mailer.layout 'mailer'
     end


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Underline and Strike-through are not applied on in Moment and Strategy posts, as tags are stripped by sanitizer method, globally enabled them. 


## Corresponding Issue

https://github.com/ifmeorg/ifme/issues/2173

# Screenshots

<img width="1502" alt="Screenshot 2022-10-16 at 12 28 01 PM" src="https://user-images.githubusercontent.com/7279519/196022740-d77cb826-7fa3-451d-b9db-b5711cb6d970.png">

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
