### PR TITLE
Embed external images in Moments and Strategies editor

### DIFF
--- a/app/assets/stylesheets/core/containers.scss
+++ b/app/assets/stylesheets/core/containers.scss
@@ -11,3 +11,9 @@
   width: 100%;
   margin: 0;
 }
+
+.imageContainer {
+  img {
+    max-width: 100%;
+  }
+}

--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -20,7 +20,7 @@
 </div>
 
 <% if @moment.why.present? %>
-  <div class="smallMarginTop">
+  <div class="smallMarginTop imageContainer">
     <% if @moment.fix.present? %>
       <div class="label">
         <%= label_tag t('moments.form.why_legacy') %>

--- a/app/views/strategies/show.html.erb
+++ b/app/views/strategies/show.html.erb
@@ -16,7 +16,7 @@
 </div>
 
 <% if @strategy.description.present? %>
-  <div class="smallMarginTop">
+  <div class="smallMarginTop imageContainer">
     <%= sanitize(@strategy.description) %>
   </div>
 <% end %>

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -5,7 +5,7 @@ import { sanitize } from 'dompurify';
 import ReactDOMServer from 'react-dom/server';
 import { init, exec } from 'pell';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faLink } from '@fortawesome/free-solid-svg-icons';
+import { faImage, faLink } from '@fortawesome/free-solid-svg-icons';
 import css from './InputTextarea.scss';
 import inputCss from './Input.scss';
 
@@ -15,6 +15,11 @@ const handleResult = (type: string) => {
       const url = window.prompt('URL');
       if (url) exec('createLink', url);
       break;
+    }
+    case 'image': {
+      const src = window.prompt('Please provide a link to your image.');
+      if(src) exec('insertImage',src);
+      break
     }
     case 'olist':
       exec('insertOrderedList');
@@ -44,6 +49,10 @@ const actions = [
   {
     ...action('link'),
     icon: ReactDOMServer.renderToString(<FontAwesomeIcon icon={faLink} />),
+  },
+  {
+    ...action('image'),
+    icon: ReactDOMServer.renderToString(<FontAwesomeIcon icon={faImage} />),
   },
 ];
 

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -18,8 +18,8 @@ const handleResult = (type: string) => {
     }
     case 'image': {
       const src = window.prompt('Please provide a link to your image.');
-      if(src) exec('insertImage',src);
-      break
+      if (src) exec('insertImage', src);
+      break;
     }
     case 'olist':
       exec('insertOrderedList');

--- a/client/app/components/Input/InputTextarea.scss
+++ b/client/app/components/Input/InputTextarea.scss
@@ -45,6 +45,10 @@
   p {
     margin: $size-0;
   }
+
+  img {
+    max-width: 100%;
+  }
 }
 
 .dark {

--- a/client/app/components/Input/__tests__/InputTextarea.spec.jsx
+++ b/client/app/components/Input/__tests__/InputTextarea.spec.jsx
@@ -150,6 +150,7 @@ describe('InputTextarea', () => {
         { title: 'Bold', expectedArgs: ['bold'] },
         // overridden actions
         { title: 'Link', expectedArgs: ['createLink', sampleUrl] },
+        { title: 'Image', expectedArgs: ['insertImage', sampleUrl] },
         { title: 'Ordered List', expectedArgs: ['insertOrderedList'] },
         { title: 'Unordered List', expectedArgs: ['insertUnorderedList'] },
       ];


### PR DESCRIPTION
# Description

Implemented changes to allow editor to embed an image after the user provides an appropriate link via prompt.

## More Details

This was implemented to conform with the rest of the workflow which uses [pell](https://github.com/jaredreich/pell). 

One concern I have is that behind the scenes  pell relies heavily on the [document.execCommand ](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) property which is deprecated.

This is also highlighted as an [issue](https://github.com/jaredreich/pell/issues/199) in the repository itself.

## Corresponding Issue

[Issue 2141](https://github.com/ifmeorg/ifme/issues/2141)

# Screenshots

![Peek Issue 2141](https://user-images.githubusercontent.com/75752916/202862288-435a339b-da67-49f5-8c73-3ee9c8f7fa09.gif)

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
