### PR TITLE
Fix Chrome dependency issue in Circle CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,11 @@ jobs:
       - run:
           name: Setup Chrome
           command: |
+            sudo apt-get update
+            sudo apt-get install libu2f-udev
             wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            sudo apt install ./google-chrome-stable_current_amd64.deb
+            sudo dpkg -i ./google-chrome*.deb
+            sudo apt-get install
       - save_cache:
           key: v1-dep-{{ .Branch }}-{{ epoch }}
           paths:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

The CI builds have been broken for the last month becaue Chrome cannot be installed in the Docker container for the Circle CI build.

## More Details

<!--[More details on your changes, remove if not applicable]-->

```
#!/bin/bash --login
wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
sudo apt install ./google-chrome-stable_current_amd64.deb

--2023-02-09 21:10:01--  https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
Resolving dl.google.com (dl.google.com)... 142.251.163.91, 142.251.163.136, 142.251.163.93, ...
Connecting to dl.google.com (dl.google.com)|142.251.163.91|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 93811132 (89M) [application/x-debian-package]
Saving to: ‘google-chrome-stable_current_amd64.deb’

google-chrome-stabl 100%[===================>]  89.46M   320MB/s    in 0.3s    

2023-02-09 21:10:01 (320 MB/s) - ‘google-chrome-stable_current_amd64.deb’ saved [93811132/93811132]

Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'google-chrome-stable' instead of './google-chrome-stable_current_amd64.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 google-chrome-stable : Depends: libu2f-udev but it is not installable
E: Unable to correct problems, you have held broken packages.

Exited with code exit status 100
CircleCI received exit code 100
```

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
