### PR TITLE
Exclude activesupport upgrade from bundle-audit check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           paths:
             - codeclimate.backend.json
       # Remove ignore values when we upgrade to Ruby 3 + Rails 7
-      - run: bundle exec bundle-audit check --ignore CVE-2021-22942 CVE-2022-22577 CVE-2022-23633 CVE-2021-44528  CVE-2022-27777 CVE-2022-21831 CVE-2022-32224 CVE-2023-22792 CVE-2023-22795 CVE-2022-44566 CVE-2023-22794 CVE-2023-22796 --update
+      - run: bundle exec bundle-audit check --ignore CVE-2021-22942 CVE-2022-22577 CVE-2022-23633 CVE-2021-44528  CVE-2022-27777 CVE-2022-21831 CVE-2022-32224 CVE-2023-22792 CVE-2023-22795 CVE-2022-44566 CVE-2023-22794 CVE-2023-22796 CVE-2023-28120 --update
       - store_test_results:
           path: /tmp/circleci-test-results
       - store_artifacts:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Until we upgrade to Ruby v3 and Rails v7, we need to exclude updates to `active*` packages e.g. activerecord and activesupport in the bundle-audit check.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
