### PR TITLE
Update libssl dependency in Circle CI config, Gemfile.lock, and Rubocop config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ jobs:
       - run:
           name: Download libssl1.1
           command: |
-            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
+            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
       - run:
           command: bundle exec rake db:create db:schema:load --trace
           environment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,8 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
+    nokogiri (1.14.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
@@ -582,6 +584,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

The current Circle CI build is breaking because the package for libssl does not exist, i.e. http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb

I updated to the latest version. I do wonder whether this is sustainable in the long-term. What happens when a Debian image of Ubuntu 2.18 goes out of date?

This PR also updates the Gemfile.lock and Rubocop config files.

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

#2116

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
