### PR TITLE
Upgrade sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,5 +110,5 @@ end
 group :production do
   gem 'rack-timeout'
   gem 'rails_12factor', '0.0.3'
-  gem 'sentry-raven'
+  gem 'sentry-ruby'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-linux)
+      racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -505,8 +507,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-ruby (5.9.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (6.5.7)
@@ -658,7 +660,7 @@ DEPENDENCIES
   sass-rails (~> 5.0, >= 5.0.6)
   sdoc (= 1.0.0)
   selenium-webdriver (~> 4.1.0)
-  sentry-raven
+  sentry-ruby
   shoulda-matchers (~> 5.3.0)
   sidekiq
   sidekiq-cron (~> 1.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :if_not_signed_in, unless: :devise_controller?
-  before_action :set_raven_context, if: proc { Rails.env.production? }
+  before_action :set_sentry_context, if: proc { Rails.env.production? }
   before_action :set_locale
   around_action :with_timezone
 
@@ -35,9 +35,9 @@ class ApplicationController < ActionController::Base
     configure_for_accept_invitation
   end
 
-  def set_raven_context
-    Raven.user_context(id: current_user.id) if user_signed_in?
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  def set_sentry_context
+    Sentry.set_user(id: current_user.id) if user_signed_in?
+    Sentry.set_extras(params: params.to_unsafe_h, url: request.url)
   end
 
   def locale

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,9 +127,8 @@ Rails.application.configure do
   config.action_controller.default_url_options = { host: primary_domain }
   config.action_controller.asset_host = primary_domain
     
-  Raven.configure do |config|
+  Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
-    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   end
 
   # Inserts middleware to perform automatic connection switching.


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

With the recent upgrade to Ruby 3 and Rails 7, we need to replace `sentry-raven` with `sentry-ruby` in our Heroku deployment build. This [guide](https://docs.sentry.io/platforms/ruby/migration/) outlines it all!

We use Sentry for our observability in production 💃 

This is the error message:
```
remote:        Post-install message from sentry-raven:        
remote:        `sentry-raven` is deprecated! Please migrate to `sentry-ruby`        
remote:                
remote:        See https://docs.sentry.io/platforms/ruby/migration for the migration guide.        
remote:                
remote:        Bundle completed (86.17s)        
remote:        Cleaning up the bundler cache.        
remote:        Resolving dependencies....        
remote:        Removing bundler (2.3.25)        
remote: -----> Detecting rake tasks        
remote: -----> Preparing app for Rails asset pipeline        
remote:        Running: rake assets:precompile        
remote:        I, [2023-05-09T04:46:03.247291 #2731]  INFO -- sentry: ** [Raven] Raven 3.1.2 ready to catch errors        
remote:        Sending event cdf8aa242f8d46609764e40a49a38f83 to Sentry        
remote:        rake aborted!  
```

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
