### PR TITLE
Replace uglifier with terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'jbuilder', '~> 2.9.1'
 gem 'jquery-rails', '4.4.0'
 gem 'sass-rails', '~> 5.0', '>= 5.0.6'
 gem 'turbolinks', '~> 5.2.0'
-gem 'uglifier', '~> 4.1.20'
 
 gem 'carrierwave', '~> 1.3.1'
 gem 'certified', '1.0.0'
@@ -112,3 +111,5 @@ group :production do
   gem 'rails_12factor', '0.0.3'
   gem 'sentry-ruby'
 end
+
+gem "terser", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,6 +547,8 @@ GEM
       sprockets (>= 3.0.0)
     ssrf_filter (1.1.1)
     stringio (3.0.2)
+    terser (1.1.14)
+      execjs (>= 0.3.0, < 3)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.0)
@@ -557,8 +559,6 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uglifier (4.1.20)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -669,8 +669,8 @@ DEPENDENCIES
   simplecov (~> 0.17.0)
   spring
   sprockets-rails
+  terser (~> 1.1)
   turbolinks (~> 5.2.0)
-  uglifier (~> 4.1.20)
   webdrivers (>= 5.0.0)
   webpacker
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScript and CSS using a preprocessor.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
 


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

As recommended in [this react/react-rails issue](https://github.com/reactjs/react-rails/issues/1176), switching from `uglifier` to `terser` to address the following bug:

```
mote:        I, [2023-05-09T16:35:58.877827 #2725]  INFO -- sentry: ** [Sentry] [Transport] Sending envelope with items [event] d786d36a0e114eecbf7e33f5862d8f0e to Sentry        
remote:        Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true). 
```


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
