### PR TITLE
Make the header bar component stick to top

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,16 @@ html {
   }
 }
 
+#headerContainer {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.stickyHeader {
+  background-color: $black-90;
+}
+
 .content {
   margin: 0 auto;
   padding: 0;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,8 @@
 
   <body class="content <%= (user_signed_in? && !static_page?) || secret_share_path? ? 'dashboard' : 'static' %>">
     <%= react_component('SkipToContent', props: { id: 'mainContent' })%>
-    <%= react_component('Header', props: header_props) %>
+    <div id="headerContainerTop"></div>
+    <div id="headerContainer"><%= react_component('Header', props: header_props) %></div>
     <main>
       <%= react_component('Toast', props: { 
         notice: notice.present? ? notice : '', 

--- a/client/app/components/Header/index.jsx
+++ b/client/app/components/Header/index.jsx
@@ -9,6 +9,7 @@ import { HeaderProfile } from 'components/Header/HeaderProfile';
 import type { Profile, Link } from './types';
 import css from './Header.scss';
 import { useFocusTrap } from '../../hooks';
+import { stickyHeader } from '../../hooks';
 
 export type Props = {
   home: Link,
@@ -121,6 +122,7 @@ export const Header = ({
         tabIndex="-1"
       >
         {displayDesktop()}
+        {stickyHeader()}
         {mobileNavOpen ? displayMobile() : null}
       </div>
     </header>

--- a/client/app/hooks/index.js
+++ b/client/app/hooks/index.js
@@ -1,1 +1,2 @@
 export { useFocusTrap } from './useFocusTrap';
+export { stickyHeader } from './stickyHeader';

--- a/client/app/hooks/stickyHeader.js
+++ b/client/app/hooks/stickyHeader.js
@@ -1,0 +1,28 @@
+// @flow
+export const stickyHeader = () => {
+  // Check when element gets position sticky
+  var observer = new IntersectionObserver(
+    function (entries) {
+      // no intersection
+      if (
+        entries[0].intersectionRatio === 0 &&
+        // Filter false positives due to page not rendered
+        entries[0].rootBounds !== null
+      ) {
+        console.log(entries[0]);
+        document
+          .querySelector('#headerContainer')
+          .classList.add('stickyHeader');
+      }
+      // fully intersects
+      else if (entries[0].intersectionRatio === 1) {
+        console.log(entries[0]);
+        document
+          .querySelector('#headerContainer')
+          .classList.remove('stickyHeader');
+      }
+    },
+    { threshold: [0, 1] }
+  );
+  observer.observe(document.querySelector('#headerContainerTop'));
+};


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

1. Created two additional div nodes in order to apply CSS position: sticky property to the header component. 
2. Added some extra css properties to the header component div container.
3. Created an additional hook named stickyHeader which is invoked from the header component and contains the logic to detect scrolling to change the background color of the header to black when user scrolls down and restores its original color if user scrolls up to the top.

## Corresponding Issue

[Issue 2155](https://github.com/ifmeorg/ifme/issues/2155)

# Screenshots
![chrome-capture-2023-6-24](https://github.com/ifmeorg/ifme/assets/17122804/5f729cdb-39c5-46b9-9f1f-dc9f02496077)

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
