### PR TITLE
Remove manually installing libssl in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,11 +84,6 @@ jobs:
           - ./vendor/bundle
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
-          name: Download libssl1.1
-          command: |
-            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb
-            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb
-      - run:
           command: bundle exec rake db:create db:schema:load --trace
           environment:
             RAILS_ENV: test


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->
This PR removes the need manually install libssl in CI. It's burdensome to have to manage new URLs for new versions of this package everytime our CI builds break.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
