### PR TITLE
Fix user seeds not populating from `pwned_password` validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .idea/
 .tags
 *.swp
+.tool-versions
 
 # Ignore coverage results
 /coverage

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,10 +7,13 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 # Users
-user1 = User.create(name: 'Test1 Lastname', email: 'test1@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'Toronto, ON, Canada', about: 'Hi my name is Test1! I want to use the site so that I can improve the way I handle my anxiety.')
-user2 = User.create(name: 'Test2 Lastname', email: 'test2@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'Toronto, ON, Canada')
-user3 = User.create(name: 'Test3 Two-Lastnames', email: 'test3@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'San Francisco, CA, United States')
-user4 = User.create(name: 'Admin User', email: 'admin@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'San Francisco, CA, United States', admin: true)
+user1 = User.new(name: 'Test1 Lastname', email: 'test1@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'Toronto, ON, Canada', about: 'Hi my name is Test1! I want to use the site so that I can improve the way I handle my anxiety.')
+user2 = User.new(name: 'Test2 Lastname', email: 'test2@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'Toronto, ON, Canada')
+user3 = User.new(name: 'Test3 Two-Lastnames', email: 'test3@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'San Francisco, CA, United States')
+user4 = User.new(name: 'Admin User', email: 'admin@example.com', password: 'passworD@99', confirmed_at: Time.zone.now, location: 'San Francisco, CA, United States', admin: true)
+
+## Save with validate: false to bypass pwned_password data breach check for seeding users
+[user1, user2, user3, user4].each { |user| user.save!(validate: false) }
 
 # Allies
 Allyship.create(user_id: user1.id, ally_id: user2.id, status: :accepted)


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Ignore validations when creating `User` in the seed file to match the sample users on https://github.com/ifmeorg/ifme/wiki/Installation#testing-accounts 

## More Details

Since my implementation of https://github.com/ifmeorg/ifme/pull/1935 , when the pwned password list database updates, more passwords will be checked to the data breach dump which prevents users from creating a password that's already been found in a breach.

Since these are just test users which you can find on a public Wiki page in plaintext, it doesn't matter that the password is `password` so I decide to ignore the validations so we can seed those users for testing purposes.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
