### PR TITLE
fix(app): #2250 Fixes broken profile section

### DIFF
--- a/client/app/components/Header/HeaderProfile.scss
+++ b/client/app/components/Header/HeaderProfile.scss
@@ -31,7 +31,6 @@
         line-height: 3.5;
         display: flex;
         flex-direction: row;
-        flex-wrap: wrap;
         align-items: center;
         justify-content: space-evenly;
 


### PR DESCRIPTION
# Description
Make the links in the profile header stay in a single line rather making it come down to next lines. This makes navbar stay consistent while the content screen reduces in size. 


## Corresponding Issue
Closes #2250 

# Screenshots

![image](https://github.com/user-attachments/assets/282b157c-6c9a-4d9c-8101-f231cead7e8d)
