### PR TITLE
Update `renderContent` to accept attributes

### DIFF
--- a/client/app/components/Tooltip/index.jsx
+++ b/client/app/components/Tooltip/index.jsx
@@ -26,8 +26,8 @@ export const Tooltip = (props: Props): Node => {
   const tooltipId = id || `tooltip${Utils.randomString()}`;
   return (
     <div className={css.tooltipWrapper}>
-      <div className={css.tooltipElement} aria-labelledby={tooltipId}>
-        {Utils.renderContent(element)}
+      <div className={css.tooltipElement}>
+        {Utils.renderContent(element, { 'aria-labelledby': tooltipId })}
       </div>
       <div
         id={tooltipId}

--- a/client/app/utils/__tests__/index.spec.jsx
+++ b/client/app/utils/__tests__/index.spec.jsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import React from 'react';
 import { Utils } from '../index';
 
 describe('Utils', () => {
@@ -101,6 +102,21 @@ describe('Utils', () => {
       expect(imageObject.type).toEqual('img');
       expect(imageObject.props.src).toEqual('img.jpg');
       expect(imageObject.props.onError).toBe(undefined);
+    });
+
+    it('should apply attributes to React elements', () => {
+      const reactElement = React.createElement('div', { className: 'test' }, 'Test content');
+      const attributes = { 'aria-labelledby': 'test-id' };
+      const renderedContent = Utils.renderContent(reactElement, attributes);
+      expect(renderedContent.props['aria-labelledby']).toEqual('test-id');
+      expect(renderedContent.props.className).toEqual('test');
+    });
+
+    it('should not modify non-string, non-React element content when attributes are provided', () => {
+      const content = { key: 'value' };
+      const attributes = { 'aria-labelledby': 'test-id' };
+      const renderedContent = Utils.renderContent(content, attributes);
+      expect(renderedContent).toEqual(content);
     });
   });
 });

--- a/client/app/utils/index.js
+++ b/client/app/utils/index.js
@@ -1,7 +1,8 @@
 // @flow
 import axios from 'axios';
-import renderHTML from 'react-render-html';
 import { sanitize } from 'dompurify';
+import React from 'react';
+import renderHTML from 'react-render-html';
 
 const randomString = (): string => Math.random()
   .toString(36)
@@ -33,9 +34,12 @@ const getPusher = (): Object | null => {
   return null;
 };
 
-const renderContent = (content: string | any): any => {
+const renderContent = (content: string | any, attributes: Object = {}): any => {
   if (typeof content === 'string') {
     return renderHTML(sanitize(content));
+  }
+  if (React.isValidElement(content)) {
+    return React.cloneElement(content, attributes);
   }
   return content;
 };

--- a/client/app/widgets/Comments/__tests__/Comments.spec.jsx
+++ b/client/app/widgets/Comments/__tests__/Comments.spec.jsx
@@ -87,9 +87,7 @@ describe('Comments', () => {
         screen.getByRole('button', { name: 'Submit' }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('link', {
-          name: `Report comment by ${getComment().commentByName}`,
-        }),
+        screen.getByLabelText(`Report comment by ${getComment().commentByName}`)
       ).toBeInTheDocument();
     });
 
@@ -111,9 +109,7 @@ describe('Comments', () => {
       expect(screen.getByRole('article')).toHaveTextContent('Hey');
 
       await userEvent.click(
-        screen.getByRole('link', {
-          name: `Delete comment by ${getComment().commentByName}`,
-        }),
+        screen.getByLabelText(`Delete comment by ${getComment().commentByName}`)
       );
 
       await waitFor(() => expect(screen.queryByRole('article')).not.toBeInTheDocument());
@@ -156,9 +152,7 @@ describe('Comments', () => {
       expect(screen.getByRole('article')).toHaveTextContent('Hey');
 
       await userEvent.click(
-        screen.getByRole('link', {
-          name: `Delete comment by ${getComment().commentByName}`,
-        }),
+        screen.getByLabelText(`Delete comment by ${getComment().commentByName}`)
       );
 
       await waitFor(() => expect(screen.queryByRole('article')).not.toBeInTheDocument());

--- a/client/app/widgets/Comments/__tests__/Comments.spec.jsx
+++ b/client/app/widgets/Comments/__tests__/Comments.spec.jsx
@@ -87,7 +87,7 @@ describe('Comments', () => {
         screen.getByRole('button', { name: 'Submit' }),
       ).toBeInTheDocument();
       expect(
-        screen.getByLabelText(`Report comment by ${getComment().commentByName}`)
+        screen.getByLabelText(`Report comment by ${getComment().commentByName}`),
       ).toBeInTheDocument();
     });
 
@@ -109,7 +109,7 @@ describe('Comments', () => {
       expect(screen.getByRole('article')).toHaveTextContent('Hey');
 
       await userEvent.click(
-        screen.getByLabelText(`Delete comment by ${getComment().commentByName}`)
+        screen.getByLabelText(`Delete comment by ${getComment().commentByName}`),
       );
 
       await waitFor(() => expect(screen.queryByRole('article')).not.toBeInTheDocument());
@@ -152,7 +152,7 @@ describe('Comments', () => {
       expect(screen.getByRole('article')).toHaveTextContent('Hey');
 
       await userEvent.click(
-        screen.getByLabelText(`Delete comment by ${getComment().commentByName}`)
+        screen.getByLabelText(`Delete comment by ${getComment().commentByName}`),
       );
 
       await waitFor(() => expect(screen.queryByRole('article')).not.toBeInTheDocument());


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Updates `renderContent` utils method, so it can now accept (optional) attributes, that will be attached to the provided React element

## More Details

This doesn't include `string` content, because the result of `renderHTML(sanitize(content));` could be an array of elements, so in that case we have a few options:
A. apply the attributes to all the elements
B. wrap the elements in a `div` and apply the attributes to that div (but again, we would be in the scenario of applying invalid attributes)
C. apply the attributes to the first element

## Corresponding Issue

Resolves #2120

# Screenshots

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/78d81609-7f1e-4abb-938b-19d02f56ca8c">
<img width="1608" alt="image" src="https://github.com/user-attachments/assets/efcd2e8b-4033-4bfd-8177-e1a5f14dd2ea">


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
