### PR TITLE
Replace `react-render-html` library

### DIFF
--- a/client/app/components/Header/index.jsx
+++ b/client/app/components/Header/index.jsx
@@ -4,7 +4,7 @@ import React, {
 } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons';
-import renderHTML from 'react-render-html';
+import { Utils } from 'utils';
 import { I18n } from 'libs/i18n';
 import { Logo } from 'components/Logo';
 import { HeaderProfile } from 'components/Header/HeaderProfile';
@@ -106,7 +106,7 @@ export const Header = ({
     <div id="headerMobile" className={css.headerMobileNav}>
       <div>
         {profile ? <HeaderProfile profile={profile} /> : null}
-        {mobileOnly ? renderHTML(mobileOnly) : null}
+        {mobileOnly ? Utils.renderContent(mobileOnly) : null}
         {displayLinks()}
       </div>
     </div>

--- a/client/app/components/Input/InputCheckbox.jsx
+++ b/client/app/components/Input/InputCheckbox.jsx
@@ -1,11 +1,11 @@
 // @flow
-import React from 'react';
-import type { Node } from 'react';
-import renderHTML from 'react-render-html';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faQuestion } from '@fortawesome/free-solid-svg-icons';
-import globalCss from 'styles/_global.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Tooltip } from 'components/Tooltip';
+import type { Node } from 'react';
+import React from 'react';
+import globalCss from 'styles/_global.scss';
+import { Utils } from 'utils';
 import css from './Input.scss';
 import type { Checkbox as Props } from './utils';
 
@@ -65,7 +65,7 @@ export const InputCheckbox = (props: Props): Node => {
           && displayUnchecked(name, uncheckedValue)}
         {displayCheckbox(id, name, value, checked, onChange, label)}
         <label className={`${css.checkboxLabel}`} htmlFor={id}>
-          {renderHTML(label)}
+          {Utils.renderContent(label)}
         </label>
       </div>
       {displayInfo(info)}

--- a/client/app/components/Input/InputSelect.jsx
+++ b/client/app/components/Input/InputSelect.jsx
@@ -1,9 +1,9 @@
 // @flow
-import React, { useState } from 'react';
-import type { Node } from 'react';
-import renderHTML from 'react-render-html';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { Node } from 'react';
+import React, { useState } from 'react';
+import { Utils } from 'utils';
 import css from './Input.scss';
 import type { Option } from './utils';
 
@@ -49,7 +49,7 @@ export function InputSelect({
       >
         {options.map((option: Option) => (
           <option id={option.id} value={option.value} key={option.value}>
-            {renderHTML(option.label)}
+            {Utils.renderContent(option.label)}
           </option>
         ))}
       </select>

--- a/client/app/utils/__tests__/index.spec.jsx
+++ b/client/app/utils/__tests__/index.spec.jsx
@@ -93,7 +93,8 @@ describe('Utils', () => {
       const h1Object = Utils.renderContent(h1HeadingString);
       expect(h1Object.type).toEqual('h1');
       expect(h1Object.props.id).toEqual('main-heading');
-      expect(h1Object.props.children[0]).toEqual('THIS IS A HEADING');
+
+      expect(h1Object.props.children).toEqual('THIS IS A HEADING');
     });
 
     it('should verify that for html strings with vulnerable code, it gets sanitized in object representation', () => {

--- a/client/app/utils/index.js
+++ b/client/app/utils/index.js
@@ -2,7 +2,7 @@
 import axios from 'axios';
 import { sanitize } from 'dompurify';
 import React from 'react';
-import renderHTML from 'react-render-html';
+import parse from 'html-react-parser';
 
 const randomString = (): string => Math.random()
   .toString(36)
@@ -36,7 +36,7 @@ const getPusher = (): Object | null => {
 
 const renderContent = (content: string | any, attributes: Object = {}): any => {
   if (typeof content === 'string') {
-    return renderHTML(sanitize(content));
+    return parse(sanitize(content));
   }
   if (React.isValidElement(content)) {
     return React.cloneElement(content, attributes);

--- a/client/app/widgets/Comments/index.jsx
+++ b/client/app/widgets/Comments/index.jsx
@@ -2,7 +2,6 @@
 import React, { useState } from 'react';
 import type { Node } from 'react';
 import axios from 'axios';
-import renderHTML from 'react-render-html';
 import { I18n } from 'libs/i18n';
 import { StoryBy } from 'components/Story/StoryBy';
 import { StoryDate } from 'components/Story/StoryDate';
@@ -109,7 +108,7 @@ export const Comments = ({ comments, formProps }: Props): Node => {
     const author = <a href={`/profile?uid=${commentByUid}`}>{commentByName}</a>;
     return (
       <article key={id} className={`comment ${css.comment}`}>
-        <div className={css.commentContent}>{renderHTML(comment)}</div>
+        <div className={css.commentContent}>{Utils.renderContent(comment)}</div>
         <StoryDate date={createdAt} />
         <div className={css.commentInfo}>
           <StoryBy avatar={commentByAvatar} author={author} />

--- a/client/app/widgets/Notifications/index.jsx
+++ b/client/app/widgets/Notifications/index.jsx
@@ -2,7 +2,6 @@
 import React, { useState, useEffect } from 'react';
 import type { Node } from 'react';
 import axios from 'axios';
-import renderHTML from 'react-render-html';
 import { I18n } from 'libs/i18n';
 import Modal from 'components/Modal';
 import { Utils } from 'utils';
@@ -82,7 +81,7 @@ export const Notifications = ({ element, pusher }: Props): Node => {
 
   const displayNotifications = () => (
     <div aria-live="polite">
-      {renderHTML(notifications)}
+      {Utils.renderContent(notifications)}
       <button
         type="button"
         className="buttonDarkS smallMarginTop"

--- a/client/package.json
+++ b/client/package.json
@@ -51,8 +51,7 @@
     "react-chartkick": "^0.4.0",
     "react-dom": "^17.0.2",
     "react-lazyload": "^3.2.0",
-    "react-on-rails": "12.0.1",
-    "react-render-html": "^0.6.0"
+    "react-on-rails": "12.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
     "es5-shim": "^4.5.13",
     "font-awesome": "^4.7.0",
     "history": "^4.9.0",
+    "html-react-parser": "^5.1.18",
     "js-cookie": "^2.2.1",
     "jstimezonedetect": "^1.0.6",
     "location-autocomplete": "^1.2.4",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11264,13 +11264,6 @@ parse5@6.0.1, parse5@^6.0.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parse5@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
-  dependencies:
-    "@types/node" "*"
-
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -12170,11 +12163,6 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-react-attr-converter@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/react-attr-converter/-/react-attr-converter-0.3.1.tgz#4a2abf6d907b7ddae4d862dfec80e489ce41ad6e"
-  integrity sha512-dSxo2Mn6Zx4HajeCeQNLefwEO4kNtV/0E682R1+ZTyFRPqxDa5zYb5qM/ocqw9Bxr/kFQO0IUiqdV7wdHw+Cdg==
-
 react-autosuggest@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-10.1.0.tgz#4d25b8acc78bb518eb70189bb96bcd777dc71ffb"
@@ -12273,14 +12261,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-render-html@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/react-render-html/-/react-render-html-0.6.0.tgz#1af51d859ed75474435a1c65c293a48e12c36627"
-  integrity sha512-F9Xn8Iy2oJvepMdDrN+XUPOwqv3ni856ikuvu/dyJ2guozN01vF0C55Ja+CQfnziQNlLevSVXzuQKYa/mhyjAQ==
-  dependencies:
-    parse5 "^3.0.2"
-    react-attr-converter "^0.3.1"
 
 react-shallow-renderer@^16.13.1:
   version "16.15.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6215,6 +6215,15 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
@@ -6235,7 +6244,7 @@ domelementtype@1, domelementtype@^1.3.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
+domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -6246,6 +6255,13 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+domhandler@5.0.3, domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
 
 domhandler@^2.3.0:
   version "2.4.2"
@@ -6282,6 +6298,15 @@ domutils@^2.5.2, domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -6423,6 +6448,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.2.0, entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 envinfo@^7.7.3:
   version "7.10.0"
@@ -8206,6 +8236,14 @@ hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
+html-dom-parser@5.0.10:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-5.0.10.tgz#bf46b05c50f35c2fcadfc8e91566c54d3caf9bd7"
+  integrity sha512-GwArYL3V3V8yU/mLKoFF7HlLBv80BZ2Ey1BzfVNRpAci0cEKhFHI/Qh8o8oyt3qlAMLlK250wsxLdYX4viedvg==
+  dependencies:
+    domhandler "5.0.3"
+    htmlparser2 "9.1.0"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -8249,6 +8287,16 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
+html-react-parser@^5.1.18:
+  version "5.1.18"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-5.1.18.tgz#a07ff6d95fcaa6de45244386a12dddb981434915"
+  integrity sha512-65BwC0zzrdeW96jB2FRr5f1ovBhRMpLPJNvwkY5kA8Ay5xdL9t/RH2/uUTM7p+cl5iM88i6dDk4LXtfMnRmaJQ==
+  dependencies:
+    domhandler "5.0.3"
+    html-dom-parser "5.0.10"
+    react-property "2.0.2"
+    style-to-js "1.1.16"
+
 html-tags@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.2.0.tgz#dbb3518d20b726524e4dd43de397eb0a95726961"
@@ -8284,6 +8332,16 @@ html-webpack-plugin@^5.0.0:
     lodash "^4.17.21"
     pretty-error "^4.0.0"
     tapable "^2.0.0"
+
+htmlparser2@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.1.0.tgz#cdb498d8a75a51f739b61d3f718136c369bc8c23"
+  integrity sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
 
 htmlparser2@^3.10.0:
   version "3.10.1"
@@ -8493,6 +8551,11 @@ inline-style-parser@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
+
+inline-style-parser@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.2.4.tgz#f4af5fe72e612839fcd453d989a586566d695f22"
+  integrity sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==
 
 inquirer@^6.2.2:
   version "6.5.2"
@@ -12257,6 +12320,11 @@ react-on-rails@12.0.1:
     "@babel/runtime-corejs3" "^7.9.6"
     concurrently "^5.1.0"
 
+react-property@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.2.tgz#d5ac9e244cef564880a610bc8d868bd6f60fdda6"
+  integrity sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
@@ -13655,12 +13723,26 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
 
+style-to-js@1.1.16:
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.16.tgz#e6bd6cd29e250bcf8fa5e6591d07ced7575dbe7a"
+  integrity sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==
+  dependencies:
+    style-to-object "1.0.8"
+
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
+
+style-to-object@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.8.tgz#67a29bca47eaa587db18118d68f9d95955e81292"
+  integrity sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==
+  dependencies:
+    inline-style-parser "0.2.4"
 
 stylehacks@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Replaces `react-render-html`, which is currently [no longer maintained](https://github.com/hatashiro/react-render-html?tab=readme-ov-file#deprecation), for a new one: https://github.com/remarkablemark/html-react-parser 

## More Details

- Almost all of the show happens in `Utils.renderContent`
- There were a few components calling directly to the `react-render-html` library, which now I've updated to call the `Utils.renderContent` instead
- **There shouldn't be any noticeable UI change, please help me double-checking this, as I'm new to the app :)** 

## Corresponding Issue

- Resolves #2326 

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
