### PR TITLE
2300 tagging strategy or moment from category page

### DIFF
--- a/app/assets/stylesheets/dashboard/dashboard_section.scss
+++ b/app/assets/stylesheets/dashboard/dashboard_section.scss
@@ -46,6 +46,11 @@
           margin: $size-10 $size-0 $size-0 $size-0;
           padding-left: $size-0;
           width: 100%;
+
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: $size-10;
         }
       }
     }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -28,6 +28,10 @@ class CategoriesController < ApplicationController
   def show
     setup_stories
     redirect_to_path(categories_path) if @category.user_id != current_user.id
+    @page_new_buttons = [
+      { text: t('moments.new'), path: new_moment_path(category: @category.slug) },
+      { text: t('strategies.new'), path: new_strategy_path(category: @category.slug) }
+    ]
   end
 
   # GET /categories/new

--- a/app/helpers/moments_form_helper.rb
+++ b/app/helpers/moments_form_helper.rb
@@ -122,7 +122,12 @@ module MomentsFormHelper
   def data_for(item)
     case item.class.name
     when 'Category'
-      @moment.categories.pluck(:id)
+      ids = @moment.categories.pluck(:id)
+      if params[:category].present? && ids.empty?
+        category = Category.friendly.find_by(slug: params[:category])
+        ids << category.id if category
+      end
+      ids
     when 'Mood'
       @moment.moods.pluck(:id)
     when 'Strategy'

--- a/app/helpers/strategies_form_helper.rb
+++ b/app/helpers/strategies_form_helper.rb
@@ -106,11 +106,17 @@ module StrategiesFormHelper
   def category_checkboxes
     checkboxes = []
     @categories.each do |item|
+      checked = @strategy.categories.include?(item)
+
+      if params[:category].present? && @strategy.new_record? && !checked
+        checked = item.slug == params[:category]
+      end
+
       checkboxes.push(
         id: item.slug,
         label: item.name,
         value: item.id,
-        checked: @strategy.categories.include?(item)
+        checked: checked
       )
     end
     checkboxes

--- a/app/views/shared/_page_title.html.erb
+++ b/app/views/shared/_page_title.html.erb
@@ -23,6 +23,15 @@
     <div class="pageTitleRight">
       <%= link_to @page_new, yield(:page_new), class: 'buttonM' %>
     </div>
+  <% elsif @page_new_buttons.present? %>
+    <div>
+      <%= yield(:title) %>
+    </div>
+    <div class="pageTitleRight">
+      <% @page_new_buttons.each_with_index do |button, index| %>
+        <%= link_to button[:text], button[:path], class: "buttonM #{index > 0 ? 'marginLeft' : ''}" %>
+      <% end %>
+    </div>
   <% elsif @page_author.present? %>
     <div>
       <%= yield(:title) %>

--- a/app/views/shared/_page_title.html.erb
+++ b/app/views/shared/_page_title.html.erb
@@ -29,7 +29,7 @@
     </div>
     <div class="pageTitleRight">
       <% @page_new_buttons.each_with_index do |button, index| %>
-        <%= link_to button[:text], button[:path], class: "buttonM #{index > 0 ? 'marginLeft' : ''}" %>
+        <%= link_to button[:text], button[:path], class: "buttonM" %>
       <% end %>
     </div>
   <% elsif @page_author.present? %>


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

Added the ability to create a new strategy or moment from a concrete category page with tagging of the related category in the form for creating that new strategy or moment.

## More Details

Added buttons aligned right to the title. They take the user to the form for creating a new strategy or moment. The tagged category from which the user clicked the buttons is stored in the URL query string and is read by the corresponding form. Also added some styling for mobile responsiveness.

The new @page_new_buttons handles multiple buttons for any title on any page for further use in the future although if one adds too many buttons, new CSS media query will be required to add as well.

# Screenshots

![image](https://github.com/user-attachments/assets/b80c976f-9c75-48be-9cf1-03d354b2c056)
![image](https://github.com/user-attachments/assets/93f1a979-d3c3-448d-bae2-1edc6edc425b)
![image](https://github.com/user-attachments/assets/36c9baf9-8f00-444e-88d4-df3b3d99c734)

# Corresponding Issue
#2300 