### PR TITLE
Require shoulda/matchers and database_cleaner in spec_helper.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ end
 group :test do
   gem 'database_cleaner'
   gem 'rails-controller-testing'
-  gem 'shoulda-matchers', '~> 5.3.0'
+  gem 'shoulda-matchers', '~> 6.0'
   gem 'simplecov', '~> 0.17.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ GEM
     semantic_range (3.0.0)
     sentry-ruby (5.9.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    shoulda-matchers (5.3.0)
+    shoulda-matchers (6.4.0)
       activesupport (>= 5.2.0)
     sidekiq (6.5.10)
       connection_pool (>= 2.2.5, < 3)
@@ -686,7 +686,7 @@ DEPENDENCIES
   sdoc (= 1.0.0)
   selenium-webdriver (~> 4.22.0)
   sentry-ruby
-  shoulda-matchers (~> 5.3.0)
+  shoulda-matchers (~> 6.0)
   sidekiq (= 6.5.10)
   sidekiq-cron (~> 1.1)
   sidekiq-failures

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require 'rspec/rails'
 require 'rspec/collection_matchers'
 require 'capybara/rails'
 require 'capybara/rspec'
+require 'shoulda/matchers'
+require 'database_cleaner'
 
 include Warden::Test::Helpers
 Warden.test_mode!


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Require shoulda/matchers and database_cleaner in spec_helper.rb. This fixes issues with running `docker-compose run app bundle exec rspec` locally.

## More Details

<!--[More details on your changes, remove if not applicable]-->

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

# Screenshots

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
