### PR TITLE
Update Circle CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,8 +131,7 @@ jobs:
             ./tmp/cc-test-reporter upload-coverage -i tmp/codeclimate.total.json
   deploy:
     docker:
-      # TODO: Update this to correct cimg/base
-      - image: buildpack-deps:trusty
+      - image: cimg/base:stable
     steps:
       - checkout
       - run:


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Deploys to Heroku are not working in Circle CI. The issue is that we're using an old Circle CI image i.e. `buildpack-deps:trusty` which is too old and likely cause the TLS error that's preventing auto-deploys from happening.

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
