### PR TITLE
Fix var name typo in profile_picture.rb

### DIFF
--- a/app/services/profile_picture.rb
+++ b/app/services/profile_picture.rb
@@ -45,10 +45,10 @@ class ProfilePicture
     def get_cloudinary_url(path, type)
       id_or_url = get_cloudinary_image_id(path)
       type == 'fetch' && id_or_url = get_local_url(path)
-      cl_image_path(id_or_url, claudinary_params(type))
+      cl_image_path(id_or_url, cloudinary_params(type))
     end
 
-    def claudinary_params(type)
+    def cloudinary_params(type)
       { type:,
         format: 'jpg',
         quality: 'auto:good',


### PR DESCRIPTION
# Description

Fixes a typo: renamed `claudinary` to `cloudinary`.

## More Details

Simple rename of a misnamed variable or reference to Cloudinary service for clarity and correctness.

## Corresponding Issue

N/A

# Screenshots

N/A
