### PR TITLE
chore: update Node.js from 14 to 20 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -qq && \
     apt-get install -y build-essential cmake git tzdata libpq-dev ruby-dev curl libvips42
 
 # Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get install -y nodejs
 
 # yarn


### PR DESCRIPTION
## Description
This PR updates Node.js from version 14 (EOL April 2023) to version 20 in the Dockerfile.

## Motivation
- Node.js 14 reached end-of-life in April 2023
- DOMPurify 3.3.2 requires Node.js >= 20
- The current setup fails during build due to GPG key errors for the deprecated Node 14 repository

## Changes
- Updated Node.js setup script from 14.x to 20.x in Dockerfile (line 7)

## Testing
- [x] Build completed successfully with Node.js 20
- [x] Docker compose up works correctly
- [x] Application runs on localhost:3000

## Related Issues
Fixes build errors related to Node.js 14 EOL