### PR TITLE
Fix Flow and Rails upgrade regressions

### DIFF
--- a/app/helpers/viewers_helper.rb
+++ b/app/helpers/viewers_helper.rb
@@ -59,7 +59,9 @@ module ViewersHelper
   def get_viewer_list(data, link)
     return only_you_as_viewer(link) if data.blank?
 
-    names = data.to_a.map { |id| User.find_by(id:).name }.to_sentence
+    names = User.where(id: Array(data)).pluck(:name).to_sentence
+    return only_you_as_viewer(link) if names.blank?
+
     link ? t('shared.viewers.many', viewers: names) : names
   end
 
@@ -67,7 +69,7 @@ module ViewersHelper
     objs = obj.where(user_id: data.user_id).all.order('created_at DESC')
     objs.each do |ob|
       item = ob.send(data_type).pluck(:id)
-      return ob.viewers if item.include?(data.id)
+      return Array(ob.viewers) if item.include?(data.id)
     end
     []
   end
@@ -92,7 +94,7 @@ module ViewersHelper
       checkboxes.push(
         id: "#{name}_viewers_#{item.id}",
         value: item.id,
-        checked: obj.viewers.include?(item.id),
+        checked: Array(obj.viewers).include?(item.id),
         label: sanitize(user.name).presence || user.email
       )
     end

--- a/client/app/components/Form/utils.js
+++ b/client/app/components/Form/utils.js
@@ -3,10 +3,8 @@ import { Utils } from 'utils';
 import { REQUIRES_DEFAULT } from 'components/Input/InputDefault';
 import type { Props as InputProps } from 'components/Input/utils';
 
-export type MyInputProps = {
-  ...$Exact<InputProps>,
-  myKey?: string,
-};
+type KeyProps = { myKey?: string };
+export type MyInputProps = InputProps & KeyProps;
 
 export type FormProps = {
   action?: string,


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Changes to the `KeyProps` type in client/app/components/Form/utils.js that were made when Flow was upgraded introduced a regression in the client app. 

Additionally, the Rails upgrade also introduced a regression in `get_viewer_list` in app/helpers/viewers_helper.rb. 

## More Details

<!--[More details on your changes, remove if not applicable]-->

I verified that these are the only places these regressions exist.

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

https://github.com/ifmeorg/ifme/issues/2429

# Screenshots

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

1. Start the local app
2. Log in or sign up for an account
3. Be redirected to the signed in app and everything loads correctly with no server errors.

<img width="1430" height="820" alt="image" src="https://github.com/user-attachments/assets/a5107574-4cca-4705-a1c0-50431f703968" />


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
