### PR TITLE
[#2322] Add language selector to navbar

### DIFF
--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -6,7 +6,9 @@ module HeaderHelper
       home: { name: t('app_name'), url: root_path },
       profile: user_signed_in? ? profile : nil,
       links:,
-      mobileOnly: user_signed_in? ? mobile_only : nil
+      mobileOnly: user_signed_in? ? mobile_only : nil,
+      locale: @locale,
+      locales: @locales
     }
   end
 

--- a/client/app/components/Header/Header.scss
+++ b/client/app/components/Header/Header.scss
@@ -57,6 +57,24 @@
     }
   }
 
+  &Locale {
+    @include setMargin($size-0, $size-0, $size-0, $size-26);
+
+    display: flex;
+    align-items: center;
+
+    @media screen and (max-width: $medium) {
+      display: none;
+    }
+  }
+
+  &MobileLocale {
+    @include setMargin($size-20, $size-0, $size-0, $size-0);
+
+    display: flex;
+    justify-content: center;
+  }
+
   &Scroll {
     background-color: $black-80;
 
@@ -125,6 +143,10 @@
     }
 
     &Nav {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
       &Links {
         @include setFontSize($size-18);
 

--- a/client/app/components/Header/Header.scss
+++ b/client/app/components/Header/Header.scss
@@ -66,6 +66,10 @@
     @media screen and (max-width: $medium) {
       display: none;
     }
+
+    select {
+      @include setPadding($size-12, $size-0, $size-12, $size-24);
+    }
   }
 
   &MobileLocale {
@@ -73,6 +77,10 @@
 
     display: flex;
     justify-content: center;
+
+    select {
+      text-align: center;
+    }
   }
 
   &Scroll {

--- a/client/app/components/Header/__tests__/Header.spec.jsx
+++ b/client/app/components/Header/__tests__/Header.spec.jsx
@@ -117,7 +117,7 @@ describe('Header', () => {
     await user.click(container.querySelector('#headerHamburger'));
 
     expect(
-      container.querySelector('#headerMobile #locale'),
+      container.querySelector('#headerMobile #mobileLocale'),
     ).toBeInTheDocument();
   });
 });

--- a/client/app/components/Header/__tests__/Header.spec.jsx
+++ b/client/app/components/Header/__tests__/Header.spec.jsx
@@ -90,4 +90,34 @@ describe('Header', () => {
     await user.keyboard('{Shift>}{Tab}{/Shift}{Enter}');
     expect(container.querySelector('#headerMobile')).not.toBeInTheDocument();
   });
+
+  const componentWithLocales = (
+    <Header
+      home={{ name: 'Home', url: '/some-path' }}
+      links={[{ name: 'Link 1', url: '/some-path-one' }]}
+      locale="en"
+      locales={['en', 'es']}
+    />
+  );
+
+  it('renders the language selector when locales are provided', () => {
+    const { container } = setup(componentWithLocales);
+
+    expect(container.querySelector('#locale')).toBeInTheDocument();
+  });
+
+  it('does not render the language selector without locales', () => {
+    const { container } = setup(component);
+
+    expect(container.querySelector('#locale')).not.toBeInTheDocument();
+  });
+
+  it('renders the language selector inside the open mobile menu', async () => {
+    const { container, user } = setup(componentWithLocales);
+    await user.click(container.querySelector('#headerHamburger'));
+
+    expect(
+      container.querySelector('#headerMobile #locale'),
+    ).toBeInTheDocument();
+  });
 });

--- a/client/app/components/Header/__tests__/Header.spec.jsx
+++ b/client/app/components/Header/__tests__/Header.spec.jsx
@@ -103,13 +103,13 @@ describe('Header', () => {
   it('renders the language selector when locales are provided', () => {
     const { container } = setup(componentWithLocales);
 
-    expect(container.querySelector('#locale')).toBeInTheDocument();
+    expect(container.querySelector('#navbarLocale')).toBeInTheDocument();
   });
 
   it('does not render the language selector without locales', () => {
     const { container } = setup(component);
 
-    expect(container.querySelector('#locale')).not.toBeInTheDocument();
+    expect(container.querySelector('#navbarLocale')).not.toBeInTheDocument();
   });
 
   it('renders the language selector inside the open mobile menu', async () => {

--- a/client/app/components/Header/index.jsx
+++ b/client/app/components/Header/index.jsx
@@ -109,7 +109,7 @@ export const Header = ({
         {!mobileNavOpen && (
           <div className={css.headerDesktopNavLinks}>{displayLinks()}</div>
         )}
-        {!mobileNavOpen && displayLocale(css.headerLocale, 'locale')}
+        {!mobileNavOpen && displayLocale(css.headerLocale, 'navbarLocale')}
       </div>
     </div>
   );

--- a/client/app/components/Header/index.jsx
+++ b/client/app/components/Header/index.jsx
@@ -8,6 +8,7 @@ import { Utils } from 'utils';
 import { I18n } from 'libs/i18n';
 import { Logo } from 'components/Logo';
 import { HeaderProfile } from 'components/Header/HeaderProfile';
+import { ToggleLocale } from 'widgets/ToggleLocale';
 import type { Profile, Link } from './types';
 import css from './Header.scss';
 import { useFocusTrap } from '../../hooks';
@@ -17,6 +18,8 @@ export type Props = {
   links: Link[],
   mobileOnly?: any,
   profile?: Profile,
+  locale?: string,
+  locales?: string[],
 };
 
 export type State = {
@@ -24,7 +27,7 @@ export type State = {
 };
 
 export const Header = ({
-  home, links, mobileOnly, profile,
+  home, links, mobileOnly, profile, locale, locales,
 }: Props): Node => {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
@@ -74,6 +77,14 @@ export const Header = ({
     </div>
   ));
 
+  const displayLocale = (className: string): Node => (
+    locale != null && locales != null && locales.length > 0 ? (
+      <div className={className}>
+        <ToggleLocale locale={locale} locales={locales} />
+      </div>
+    ) : null
+  );
+
   const displayDesktop = (): Node => (
     <div
       className={`${css.headerDesktop} ${scrolled ? css.headerScroll : ''}`}
@@ -98,6 +109,7 @@ export const Header = ({
         {!mobileNavOpen && (
           <div className={css.headerDesktopNavLinks}>{displayLinks()}</div>
         )}
+        {!mobileNavOpen && displayLocale(css.headerLocale)}
       </div>
     </div>
   );
@@ -108,6 +120,7 @@ export const Header = ({
         {profile ? <HeaderProfile profile={profile} /> : null}
         {mobileOnly ? Utils.renderContent(mobileOnly) : null}
         {displayLinks()}
+        {displayLocale(css.headerMobileLocale)}
       </div>
     </div>
   );
@@ -149,7 +162,14 @@ export const Header = ({
 };
 
 export default ({
-  home, links, mobileOnly, profile,
+  home, links, mobileOnly, profile, locale, locales,
 }: Props): Node => (
-  <Header home={home} links={links} mobileOnly={mobileOnly} profile={profile} />
+  <Header
+    home={home}
+    links={links}
+    mobileOnly={mobileOnly}
+    profile={profile}
+    locale={locale}
+    locales={locales}
+  />
 );

--- a/client/app/components/Header/index.jsx
+++ b/client/app/components/Header/index.jsx
@@ -77,10 +77,10 @@ export const Header = ({
     </div>
   ));
 
-  const displayLocale = (className: string): Node => (
+  const displayLocale = (className: string, id: string): Node => (
     locale != null && locales != null && locales.length > 0 ? (
       <div className={className}>
-        <ToggleLocale locale={locale} locales={locales} />
+        <ToggleLocale locale={locale} locales={locales} id={id} />
       </div>
     ) : null
   );
@@ -109,7 +109,7 @@ export const Header = ({
         {!mobileNavOpen && (
           <div className={css.headerDesktopNavLinks}>{displayLinks()}</div>
         )}
-        {!mobileNavOpen && displayLocale(css.headerLocale)}
+        {!mobileNavOpen && displayLocale(css.headerLocale, 'locale')}
       </div>
     </div>
   );
@@ -120,7 +120,7 @@ export const Header = ({
         {profile ? <HeaderProfile profile={profile} /> : null}
         {mobileOnly ? Utils.renderContent(mobileOnly) : null}
         {displayLinks()}
-        {displayLocale(css.headerMobileLocale)}
+        {displayLocale(css.headerMobileLocale, 'mobileLocale')}
       </div>
     </div>
   );

--- a/client/app/stories/Header.stories.jsx
+++ b/client/app/stories/Header.stories.jsx
@@ -38,3 +38,20 @@ HasActiveLink.storyName = 'With an active link';
 HasActiveLink.parameters = {
   backgrounds: { default: 'mulberry' },
 };
+
+export const WithLanguageSelector = Template.bind({});
+
+WithLanguageSelector.args = {
+  home: { name: 'if me', link: 'http://if-me.org' },
+  links: [
+    { name: 'Link 1', link: '#', active: true },
+    { name: 'Link 2', link: '#' },
+    { name: 'Link 3', link: '#' },
+  ],
+  locale: 'en',
+  locales: ['en', 'es', 'fr'],
+};
+WithLanguageSelector.storyName = 'With language selector';
+WithLanguageSelector.parameters = {
+  backgrounds: { default: 'mulberry' },
+};

--- a/client/app/widgets/ToggleLocale/index.jsx
+++ b/client/app/widgets/ToggleLocale/index.jsx
@@ -11,6 +11,7 @@ import type { Option } from 'components/Input/utils';
 export type Props = {
   locale: string,
   locales: string[],
+  id?: string,
 };
 
 const options = (locales: string[]): Option[] => {
@@ -38,10 +39,10 @@ const onChange = (e: SyntheticEvent<HTMLInputElement>) => {
 };
 
 export const ToggleLocale = (props: Props): Node => {
-  const { locale, locales } = props;
+  const { locale, locales, id = 'locale' } = props;
   return (
     <Input
-      id="locale"
+      id={id}
       type="select"
       name="locale"
       ariaLabel={I18n.t('language')}

--- a/client/app/widgets/ToggleLocale/index.jsx
+++ b/client/app/widgets/ToggleLocale/index.jsx
@@ -44,7 +44,7 @@ export const ToggleLocale = (props: Props): Node => {
     <Input
       id={id}
       type="select"
-      name="locale"
+      name={id}
       ariaLabel={I18n.t('language')}
       value={locale}
       options={options(locales)}

--- a/spec/helpers/header_helper_spec.rb
+++ b/spec/helpers/header_helper_spec.rb
@@ -49,7 +49,9 @@ describe HeaderHelper do
               { name: 'Sign out', url: '/users/sign_out', dataMethod: 'delete', hideInMobile: true }
             ],
             mobileOnly: mobile_only,
-            profile: profile
+            profile: profile,
+            locale: nil,
+            locales: nil
           )
         end
       end
@@ -66,7 +68,9 @@ describe HeaderHelper do
               { name: 'Sign out', url: '/users/sign_out', dataMethod: 'delete', hideInMobile: true }
             ],
             mobileOnly: mobile_only,
-            profile: profile
+            profile: profile,
+            locale: nil,
+            locales: nil
           )
         end
       end
@@ -90,7 +94,9 @@ describe HeaderHelper do
               { name: 'Sign in', url: '/users/sign_in', active: false }
             ],
             mobileOnly: nil,
-            profile: nil
+            profile: nil,
+            locale: nil,
+            locales: nil
           )
         end
       end
@@ -108,7 +114,9 @@ describe HeaderHelper do
               { name: 'Sign in', url: '/users/sign_in', active: true }
             ],
             mobileOnly: nil,
-            profile: nil
+            profile: nil,
+            locale: nil,
+            locales: nil
           )
         end
       end


### PR DESCRIPTION
# Description

Surfaces the language switcher in the navbar so users no longer have to scroll to the footer to change languages. The existing `ToggleLocale` widget is reused as-is and rendered in two new places via the `Header` component:

- **Desktop:** right-aligned in the nav bar (after the links).
- **Mobile:** inside the hamburger menu.

## More Details

`locale`/`locales` are threaded through `header_props`; they were already assigned for every request in `ApplicationController` (the footer uses the same values), so no controller or routing changes are needed. The selector only renders when a current locale and available locales are present, so existing `Header` usages are unaffected. A `WithLanguageSelector` story is added to the existing Header stories so the new state is visible in Storybook.

No new gems/npm packages are introduced — this reuses the existing `ToggleLocale` widget.

The footer toggle is kept in place as well. Happy to **remove it from the footer** if you'd prefer the navbar to be the single location — that felt like a product call for you to make rather than assume.

**Testing:** `Header.spec.jsx` passes 7/7 (4 existing + 3 new, covering desktop render, no-render without locales, and render inside the open mobile menu). ESLint, Flow, Prettier, and Stylelint are clean on the changed files. I was unable to run the full Ruby/Rails suite or RuboCop locally (no Ruby toolchain in my environment) — happy to address anything CI flags.

## Corresponding Issue

Closes #2322

# Screenshots

Captured from the `Components/Header` Storybook story (mulberry background).

**Desktop** — selector right-aligned after the nav links:

![Language selector in desktop navbar](https://raw.githubusercontent.com/kenlacroix/ifme/screenshots-2322/header-desktop.png)

**Mobile** — selector inside the open hamburger menu:

![Language selector in mobile menu](https://raw.githubusercontent.com/kenlacroix/ifme/screenshots-2322/header-mobile.png)
