### PR TITLE
JS performance improvements

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -125,7 +125,24 @@ module ApplicationHelper
     'fa fa-globe'
   end
 
+  def i18n_translations_json
+    Rails.cache.fetch("i18n_translations/#{I18n.locale}") do
+      flatten_translations(I18n.t('.', locale: I18n.locale)).to_json
+    end
+  end
+
   private
+
+  def flatten_translations(hash, prefix = nil)
+    hash.each_with_object({}) do |(key, value), result|
+      full_key = prefix ? "#{prefix}.#{key}" : key.to_s
+      if value.is_a?(Hash)
+        result.merge!(flatten_translations(value, full_key))
+      elsif !value.is_a?(Proc)
+        result[full_key] = value.to_s
+      end
+    end
+  end
 
   def current_controller?(link_path, environment = {})
     link_controller = Rails.application.routes

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
     <% else %>
       <%= stylesheet_pack_tag 'webpack_bundle', media: 'all' %>
     <% end %>
+    <script>window.__I18N__ = <%= raw i18n_translations_json %>;</script>
     <%= javascript_pack_tag 'webpack_bundle', 'data-turbolinks-track': true, defer: true %>
     <!-- Webpack Assets END -->
 

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -3,7 +3,7 @@
     [
       "@babel/env", {
         "useBuiltIns": "usage",
-        "modules": false,
+        "modules": "auto",
         "corejs": "3"
       }
     ],

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -3,7 +3,7 @@
     [
       "@babel/env", {
         "useBuiltIns": "usage",
-        "modules": "commonjs",
+        "modules": false,
         "corejs": "3"
       }
     ],
@@ -13,7 +13,6 @@
   "plugins": [
     "@babel/plugin-transform-class-properties",
     "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-transform-modules-commonjs",
     "@babel/plugin-transform-private-methods",
     "@babel/plugin-transform-private-property-in-object"
   ],

--- a/client/app/components/Accordion/index.jsx
+++ b/client/app/components/Accordion/index.jsx
@@ -3,7 +3,8 @@ import React, { useState } from 'react';
 import type { Node } from 'react';
 import { Utils } from 'utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
+import { faCaretUp } from '@fortawesome/free-solid-svg-icons/faCaretUp';
 import globalCss from 'styles/_global.scss';
 import css from 'components/Input/Input.scss';
 

--- a/client/app/components/Chart/ChartRenderer.jsx
+++ b/client/app/components/Chart/ChartRenderer.jsx
@@ -16,7 +16,10 @@ type chartShape = {
 
 const colorSchemes = ['#6D0839', '#66118', '#7F503F', '#775577', '#CCAADD'];
 
-export default function ChartRenderer({ chartType, ...props }: chartShape): Node {
+export default function ChartRenderer({
+  chartType,
+  ...props
+}: chartShape): Node {
   return chartType === 'Line' ? (
     <LineChart {...props} colors={colorSchemes} />
   ) : (

--- a/client/app/components/Chart/ChartRenderer.jsx
+++ b/client/app/components/Chart/ChartRenderer.jsx
@@ -1,0 +1,25 @@
+// @flow
+/* eslint react/jsx-props-no-spreading: 0 */
+import { Chart as ChartJS } from 'chart.js';
+import React from 'react';
+import type { Node } from 'react';
+import { AreaChart, LineChart } from 'react-chartkick';
+
+ChartJS.defaults.global.defaultFontFamily = 'Lato';
+
+type chartShape = {
+  xtitle?: string,
+  ytitle?: string,
+  data?: Object | any[],
+  chartType: 'Line' | 'Area',
+};
+
+const colorSchemes = ['#6D0839', '#66118', '#7F503F', '#775577', '#CCAADD'];
+
+export default function ChartRenderer({ chartType, ...props }: chartShape): Node {
+  return chartType === 'Line' ? (
+    <LineChart {...props} colors={colorSchemes} />
+  ) : (
+    <AreaChart {...props} colors={colorSchemes} />
+  );
+}

--- a/client/app/components/Chart/__tests__/Chart.spec.jsx
+++ b/client/app/components/Chart/__tests__/Chart.spec.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { Chart } from 'components/Chart/index';
 
 const renderComponent = ({ chartType }) => render(
@@ -16,13 +16,17 @@ const renderComponent = ({ chartType }) => render(
 );
 
 describe('Chart', () => {
-  it('renders a Line chart', () => {
+  it('renders a Line chart', async () => {
     const { container } = renderComponent({ chartType: 'Line' });
-    expect(container.querySelector('canvas')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(container.querySelector('canvas')).toBeInTheDocument();
+    });
   });
 
-  it('renders an Area chart', () => {
+  it('renders an Area chart', async () => {
     const { container } = renderComponent({ chartType: 'Area' });
-    expect(container.querySelector('canvas')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(container.querySelector('canvas')).toBeInTheDocument();
+    });
   });
 });

--- a/client/app/components/Chart/__tests__/ChartControl.spec.jsx
+++ b/client/app/components/Chart/__tests__/ChartControl.spec.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AreaChart } from 'react-chartkick';
 import { ChartControl } from 'components/Chart/ChartControl';
@@ -21,7 +21,7 @@ describe('ChartControl', () => {
     AreaChart.mockClear();
   });
 
-  it('renders', () => {
+  it('renders', async () => {
     const { container } = render(
       <ChartControl
         types={['Moments']}
@@ -40,7 +40,9 @@ describe('ChartControl', () => {
     const button = screen.getByRole('button', { name: 'Moments' });
     expect(button).toBeInTheDocument();
     // using querySelector as a last resort for canvas
-    expect(container.querySelector('canvas')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(container.querySelector('canvas')).toBeInTheDocument();
+    });
   });
 
   it('passes down the expected data for the selected type', async () => {

--- a/client/app/components/Chart/index.jsx
+++ b/client/app/components/Chart/index.jsx
@@ -1,11 +1,8 @@
 // @flow
-/* eslint react/jsx-props-no-spreading: 0 */
-import { Chart as ChartJS } from 'chart.js';
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import type { Node } from 'react';
-import { AreaChart, LineChart } from 'react-chartkick';
 
-ChartJS.defaults.global.defaultFontFamily = 'Lato';
+const ChartRenderer = lazy(() => import('./ChartRenderer'));
 
 type chartShape = {
   xtitle?: string,
@@ -14,12 +11,10 @@ type chartShape = {
   chartType: 'Line' | 'Area',
 };
 
-const colorSchemes = ['#6D0839', '#66118', '#7F503F', '#775577', '#CCAADD'];
-
-export function Chart({ chartType, ...props }: chartShape): Node {
-  return chartType === 'Line' ? (
-    <LineChart {...props} colors={colorSchemes} />
-  ) : (
-    <AreaChart {...props} colors={colorSchemes} />
+export function Chart(props: chartShape): Node {
+  return (
+    <Suspense fallback={null}>
+      <ChartRenderer {...props} />
+    </Suspense>
   );
 }

--- a/client/app/components/Chart/index.jsx
+++ b/client/app/components/Chart/index.jsx
@@ -1,4 +1,5 @@
 // @flow
+/* eslint react/jsx-props-no-spreading: 0 */
 import React, { Suspense, lazy } from 'react';
 import type { Node } from 'react';
 

--- a/client/app/components/Header/HeaderProfile.jsx
+++ b/client/app/components/Header/HeaderProfile.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBell } from '@fortawesome/free-solid-svg-icons';
+import { faBell } from '@fortawesome/free-solid-svg-icons/faBell';
 import { Utils } from 'utils';
 import globalCSS from 'styles/_global.scss';
 import { Notifications } from 'widgets/Notifications';

--- a/client/app/components/Header/index.jsx
+++ b/client/app/components/Header/index.jsx
@@ -3,7 +3,8 @@ import React, {
   useState, useRef, useEffect, type Node,
 } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { Utils } from 'utils';
 import { I18n } from 'libs/i18n';
 import { Logo } from 'components/Logo';

--- a/client/app/components/Input/InputCheckbox.jsx
+++ b/client/app/components/Input/InputCheckbox.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { faQuestion } from '@fortawesome/free-solid-svg-icons';
+import { faQuestion } from '@fortawesome/free-solid-svg-icons/faQuestion';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Tooltip } from 'components/Tooltip';
 import type { Node } from 'react';

--- a/client/app/components/Input/InputError.jsx
+++ b/client/app/components/Input/InputError.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faExclamation } from '@fortawesome/free-solid-svg-icons/faExclamation';
 import { I18n } from 'libs/i18n';
 import css from './Input.scss';
 

--- a/client/app/components/Input/InputLabel.jsx
+++ b/client/app/components/Input/InputLabel.jsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAsterisk, faQuestion } from '@fortawesome/free-solid-svg-icons';
+import { faAsterisk } from '@fortawesome/free-solid-svg-icons/faAsterisk';
+import { faQuestion } from '@fortawesome/free-solid-svg-icons/faQuestion';
 import globalCss from 'styles/_global.scss';
 import { Tooltip } from 'components/Tooltip';
 import css from './Input.scss';

--- a/client/app/components/Input/InputMultiSelect.jsx
+++ b/client/app/components/Input/InputMultiSelect.jsx
@@ -2,7 +2,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretUp, faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import { faCaretUp } from '@fortawesome/free-solid-svg-icons/faCaretUp';
+import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import { InputCheckbox } from 'components/Input/InputCheckbox';
 import css from './InputMultiSelect.scss';
 import type { Checkbox } from './utils';

--- a/client/app/components/Input/InputPassword.jsx
+++ b/client/app/components/Input/InputPassword.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
+import { faEyeSlash } from '@fortawesome/free-solid-svg-icons/faEyeSlash';
 import { I18n } from 'libs/i18n';
 import css from 'components/Input/InputPassword.scss';
 import inputCss from './Input.scss';

--- a/client/app/components/Input/InputSelect.jsx
+++ b/client/app/components/Input/InputSelect.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { Node } from 'react';
 import React, { useState } from 'react';

--- a/client/app/components/Input/InputSwitch.jsx
+++ b/client/app/components/Input/InputSwitch.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { I18n } from 'libs/i18n';
 import { Utils } from 'utils';
 import { InputCheckbox } from 'components/Input/InputCheckbox';

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -5,7 +5,8 @@ import { sanitize } from 'dompurify';
 import ReactDOMServer from 'react-dom/server';
 import { init, exec } from 'pell';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faImage, faLink } from '@fortawesome/free-solid-svg-icons';
+import { faImage } from '@fortawesome/free-solid-svg-icons/faImage';
+import { faLink } from '@fortawesome/free-solid-svg-icons/faLink';
 import css from './InputTextarea.scss';
 import inputCss from './Input.scss';
 

--- a/client/app/components/Input/InputTextarea.jsx
+++ b/client/app/components/Input/InputTextarea.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { useState, useEffect, useRef } from 'react';
 import type { Node } from 'react';
-import { sanitize } from 'dompurify';
+import DOMPurify from 'dompurify';
 import ReactDOMServer from 'react-dom/server';
 import { init, exec } from 'pell';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -81,12 +81,14 @@ export function InputTextarea(props: Props): Node {
   const {
     id, name, value: propValue, required, hasError, myRef, dark,
   } = props;
-  const [value, setValue] = useState<string>(sanitize(propValue) || '');
+  const [value, setValue] = useState<string>(
+    DOMPurify.sanitize(propValue) || '',
+  );
   const editorRef = useRef<?HTMLDivElement>(null);
   const editor = useRef<?PellEditor>(null);
 
   const onChange = (updatedValue: string) => {
-    setValue(sanitize(updatedValue));
+    setValue(DOMPurify.sanitize(updatedValue));
   };
 
   const onBlur = () => {
@@ -110,7 +112,7 @@ export function InputTextarea(props: Props): Node {
     const clipboardData = (e.originalEvent && e.originalEvent.clipboardData) || e.clipboardData;
     const text = clipboardData ? clipboardData.getData('text/plain') : '';
 
-    document.execCommand('insertHTML', false, sanitize(text));
+    document.execCommand('insertHTML', false, DOMPurify.sanitize(text));
   };
 
   useEffect(() => {

--- a/client/app/components/Input/__tests__/InputSwitch.spec.jsx
+++ b/client/app/components/Input/__tests__/InputSwitch.spec.jsx
@@ -14,15 +14,16 @@ describe('InputSwitch', () => {
 
   describe('with mouse', () => {
     it('toggles correctly', async () => {
+      const user = userEvent.setup();
       render(component);
       const inputSwitch = screen.getByRole('switch');
 
       expect(screen.getByRole('checkbox')).not.toBeChecked();
 
-      await userEvent.click(inputSwitch);
+      await user.click(inputSwitch);
       expect(screen.getByRole('checkbox')).toBeChecked();
 
-      await userEvent.click(inputSwitch);
+      await user.click(inputSwitch);
       expect(screen.getByRole('checkbox')).not.toBeChecked();
     });
   });

--- a/client/app/components/Modal/index.jsx
+++ b/client/app/components/Modal/index.jsx
@@ -4,7 +4,7 @@ import React, {
   useState, useRef, type Node, useEffect,
 } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { I18n } from 'libs/i18n';
 import { Utils } from 'utils';
 import { Avatar } from 'components/Avatar';

--- a/client/app/components/Story/StoryActions.jsx
+++ b/client/app/components/Story/StoryActions.jsx
@@ -3,19 +3,17 @@ import React from 'react';
 import type { Node } from 'react';
 import { I18n } from 'libs/i18n';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faPencilAlt,
-  faTrash,
-  faLock,
-  faDoorOpen,
-  faDoorClosed,
-  faExclamationTriangle,
-  faEyeSlash,
-  faCalendarPlus,
-  faCalendarMinus,
-  faChartLine,
-  faKey,
-} from '@fortawesome/free-solid-svg-icons';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons/faPencilAlt';
+import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
+import { faLock } from '@fortawesome/free-solid-svg-icons/faLock';
+import { faDoorOpen } from '@fortawesome/free-solid-svg-icons/faDoorOpen';
+import { faDoorClosed } from '@fortawesome/free-solid-svg-icons/faDoorClosed';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
+import { faEyeSlash } from '@fortawesome/free-solid-svg-icons/faEyeSlash';
+import { faCalendarPlus } from '@fortawesome/free-solid-svg-icons/faCalendarPlus';
+import { faCalendarMinus } from '@fortawesome/free-solid-svg-icons/faCalendarMinus';
+import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine';
+import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { Tooltip } from 'components/Tooltip';
 import css from './Story.scss';
 

--- a/client/app/components/Toast/index.jsx
+++ b/client/app/components/Toast/index.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import type { Node } from 'react';
 import { I18n } from 'libs/i18n';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import css from './Toast.scss';
 
 type Props = {

--- a/client/app/libs/i18n/index.js
+++ b/client/app/libs/i18n/index.js
@@ -10,6 +10,7 @@ let testTranslations = null;
 
 function getTranslations(locale: string): Object {
   if (!isTestEnv && typeof window !== 'undefined') {
+    // eslint-disable-next-line no-underscore-dangle
     return window.__I18N__ || {};
   }
   if (isTestEnv) {

--- a/client/app/libs/i18n/index.js
+++ b/client/app/libs/i18n/index.js
@@ -1,6 +1,26 @@
 // @flow
 import Cookies from 'js-cookie';
-import translations from './translations.json';
+
+// In browser builds, Rails injects only the current locale's translations via
+// window.__I18N__ (see application.html.erb). In the test environment webpack's
+// dead-code elimination keeps the require() below; in production/development
+// builds the entire isTestEnv branch is stripped at compile time.
+const isTestEnv = process.env.NODE_ENV === 'test';
+let testTranslations = null;
+
+function getTranslations(locale: string): Object {
+  if (!isTestEnv && typeof window !== 'undefined') {
+    return window.__I18N__ || {};
+  }
+  if (isTestEnv) {
+    if (!testTranslations) {
+      // eslint-disable-next-line global-require
+      testTranslations = require('./translations.json');
+    }
+    return testTranslations[locale] || {};
+  }
+  return {};
+}
 
 type Options = {
   [key: string]: string,
@@ -20,7 +40,8 @@ const getValue = (options: ?Options, option: string): string => {
 export const I18n = {
   t: (scope: string, options?: Options): string => {
     const locale = Cookies.get('locale') || 'en';
-    let result = translations[locale][scope] || missingResult(locale, scope);
+    const translations = getTranslations(locale);
+    let result = translations[scope] || missingResult(locale, scope);
     const resultOptions = result.match(/\{(.*?)\}/g);
     if (resultOptions) {
       resultOptions.forEach((option: string) => {

--- a/client/app/libs/moment-compat.js
+++ b/client/app/libs/moment-compat.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-underscore-dangle */
+// Dayjs-based drop-in for the moment.js API subset used by chart.js v2.
+// chart.js requires moment for its time cartesian scale; this shim satisfies
+// that API without pulling in the full 70 KB moment bundle.
+const dayjs = require('dayjs');
+const customParseFormat = require('dayjs/plugin/customParseFormat');
+const localizedFormat = require('dayjs/plugin/localizedFormat');
+const utc = require('dayjs/plugin/utc');
+
+dayjs.extend(customParseFormat);
+dayjs.extend(localizedFormat);
+dayjs.extend(utc);
+
+function wrap(d) {
+  const m = {
+    _m: d,
+    valueOf() {
+      return d.valueOf();
+    },
+    toDate() {
+      return d.toDate();
+    },
+    unix() {
+      return Math.floor(d.valueOf() / 1000);
+    },
+    isValid() {
+      return d.isValid();
+    },
+    format(fmt) {
+      return d.format(fmt);
+    },
+    diff(other, unit, float) {
+      const o = other && other._m ? other._m : dayjs(other);
+      return d.diff(o, unit, float);
+    },
+    add(amount, unit) {
+      return wrap(d.add(amount, unit));
+    },
+    subtract(amount, unit) {
+      return wrap(d.subtract(amount, unit));
+    },
+    startOf(unit) {
+      return wrap(d.startOf(unit));
+    },
+    endOf(unit) {
+      return wrap(d.endOf(unit));
+    },
+    clone() {
+      return wrap(dayjs(d.toDate()));
+    },
+    isBefore(other, unit) {
+      return d.isBefore(other && other._m ? other._m : dayjs(other), unit);
+    },
+    isAfter(other, unit) {
+      return d.isAfter(other && other._m ? other._m : dayjs(other), unit);
+    },
+    isSame(other, unit) {
+      return d.isSame(other && other._m ? other._m : dayjs(other), unit);
+    },
+    lang() {
+      return m;
+    },
+    locale() {
+      return m;
+    },
+    localeData() {
+      return {
+        firstDayOfWeek() {
+          return 0;
+        },
+      };
+    },
+  };
+  return m;
+}
+
+function momentCompat(input, format) {
+  if (input && input._m) return input;
+  return wrap(format ? dayjs(input, format) : dayjs(input));
+}
+
+momentCompat.isMoment = (obj) => !!(obj && obj._m);
+momentCompat.unix = (val) => wrap(dayjs.unix(val));
+momentCompat.utc = (val) => wrap(dayjs.utc ? dayjs.utc(val) : dayjs(val));
+momentCompat.lang = () => {};
+momentCompat.locale = () => 'en';
+momentCompat.localeData = () => ({
+  firstDayOfWeek() {
+    return 0;
+  },
+});
+momentCompat.normalizeUnits = (unit) => unit;
+momentCompat.relativeTimeThreshold = () => false;
+
+module.exports = momentCompat;

--- a/client/app/libs/testHelper.js
+++ b/client/app/libs/testHelper.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 
+window.Element.prototype.scrollIntoView = jest.fn();
+
 Object.defineProperty(window, 'alert', {
   value: () => {},
   writable: true,

--- a/client/app/utils/index.js
+++ b/client/app/utils/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { fetchWrapper } from 'utils/fetchWrapper';
-import { sanitize } from 'dompurify';
+import DOMPurify from 'dompurify';
 import React from 'react';
 import parse from 'html-react-parser';
 
@@ -37,7 +37,7 @@ const getPusher = (): Object | null => {
 
 const renderContent = (content: string | any, attributes: Object = {}): any => {
   if (typeof content === 'string') {
-    return parse(sanitize(content));
+    return parse(DOMPurify.sanitize(content));
   }
   if (React.isValidElement(content)) {
     return React.cloneElement(content, attributes);

--- a/client/app/widgets/CrisisPrevention/index.jsx
+++ b/client/app/widgets/CrisisPrevention/index.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faHeart } from '@fortawesome/free-solid-svg-icons';
+import { faHeart } from '@fortawesome/free-solid-svg-icons/faHeart';
 import { I18n } from 'libs/i18n';
 import Modal from 'components/Modal';
 import css from './CrisisPrevention.scss';

--- a/client/flow/browser.js
+++ b/client/flow/browser.js
@@ -97,5 +97,14 @@ declare var window: {
   },
   alert(message?: string): void,
   prompt(message?: string): null | string,
+  __I18N__?: { [string]: string },
+  ...
+};
+
+declare var process: {
+  env: {
+    NODE_ENV: string,
+    ...
+  },
   ...
 };

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "build:production": "yarn build:i18n && NODE_ENV=production webpack --config webpack.config.js",
     "build:development": "yarn build:i18n && NODE_ENV=development webpack -w --config webpack.config.js",
     "build:production:debug": "yarn build:production --display-modules --sort-modules-by size",
+    "analyze": "yarn build:i18n && BUNDLE_ANALYZE=true NODE_ENV=production webpack --config webpack.config.js",
     "build:storybook": "npm run build:i18n && build-storybook -c .storybook -o .out",
     "lint:flow": "flow",
     "lint:eslint": "eslint 'app/**/*.js' 'app/**/*.jsx'",
@@ -120,6 +121,7 @@
     "terser-webpack-plugin": "^5.3.6",
     "url-loader": "^4.0.0",
     "webpack": "^5.104.1",
+    "webpack-bundle-analyzer": "^5.3.0",
     "webpack-cli": "^5.1.4",
     "webpack-manifest-plugin": "^5.0.0",
     "yml-loader": "^2.1.0"

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "chart.js": "^2.9.4",
     "chartkick": "^3.1.1",
     "core-js": "3",
+    "dayjs": "^1.11.21",
     "dompurify": "^3.4.11",
     "dot-prop": "^5.1.1",
     "font-awesome": "^4.7.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -12,6 +12,7 @@ const webpackConfigLoader = require('react-on-rails/webpackConfigLoader');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const configPath = resolve('..', 'config');
 const devOrTestMode = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
@@ -104,6 +105,7 @@ const config = {
     // only load moment.js data for locales we support (see config/locale.rb)
     new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en|es|de|it|nb|nl|pt-BR|sv|vi|fr/),
     new NodePolyfillPlugin(),
+    ...(process.env.BUNDLE_ANALYZE ? [new BundleAnalyzerPlugin({ analyzerMode: 'static', openAnalyzer: false })] : []),
   ],
 
   module: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -45,6 +45,7 @@ const config = {
       mocks: resolve(__dirname, 'app/mocks'),
       widgets: resolve(__dirname, 'app/widgets'),
       pages: resolve(__dirname, 'app/pages'),
+      moment: resolve(__dirname, 'app/libs/moment-compat.js'),
     },
     extensions: ['.js', '.jsx', '.scss'],
   },
@@ -57,8 +58,7 @@ const config = {
     // Name comes from the entry section.
     filename: `${outputFilename}.js`,
     chunkFilename: `${outputFilename}.chunk.js`,
-    // Leading slash is necessary
-    publicPath: `/${output.publicPath}`,
+    publicPath: output.publicPath,
     path: output.path,
   },
 
@@ -102,8 +102,6 @@ const config = {
       chunkFilename: `${outputFilename}.chunk.css`,
     }),
     new WebpackManifestPlugin({ publicPath: output.publicPath, writeToFileEmit: true }),
-    // only load moment.js data for locales we support (see config/locale.rb)
-    new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en|es|de|it|nb|nl|pt-BR|sv|vi|fr/),
     new NodePolyfillPlugin(),
     ...(process.env.BUNDLE_ANALYZE ? [new BundleAnalyzerPlugin({ analyzerMode: 'static', openAnalyzer: false })] : []),
   ],

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6544,6 +6544,11 @@ date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
+dayjs@^1.11.21:
+  version "1.11.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -11500,9 +11505,9 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 moment@^2.10.2:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moniker@0.1.2:
   version "0.1.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1393,6 +1393,11 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@discoveryjs/json-ext@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz#f13c7c205915eb91ae54c557f5e92bddd8be0e83"
+  integrity sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==
+
 "@emnapi/core@1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
@@ -2171,6 +2176,11 @@
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
     source-map "^0.7.3"
+
+"@polka/url@^1.0.0-next.24":
+  version "1.0.0-next.29"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
+  integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
 "@sentry-internal/browser-utils@8.33.0":
   version "8.33.0"
@@ -4009,7 +4019,7 @@ acorn-walk@^7.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.2:
+acorn-walk@^8.0.0, acorn-walk@^8.0.2:
   version "8.3.5"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
   integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
@@ -4020,6 +4030,11 @@ acorn@^7.1.1, acorn@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.0.4:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
+  integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
 
 acorn@^8.1.0, acorn@^8.11.0, acorn@^8.8.1:
   version "8.16.0"
@@ -5863,6 +5878,11 @@ commander@^11.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
+commander@^14.0.2:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
+
 commander@^2.11.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -7261,6 +7281,11 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escodegen@^2.0.0:
   version "2.0.0"
@@ -9044,6 +9069,11 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-escaper@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-3.0.3.tgz#4d336674652beb1dcbc29ef6b6ba7f6be6fdfed6"
+  integrity sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==
 
 html-minifier-terser@^5.0.1:
   version "5.1.1"
@@ -11486,6 +11516,11 @@ moo-color@^1.0.2:
   dependencies:
     color-name "^1.1.4"
 
+mrmime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
+  integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -11954,6 +11989,11 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optimize-css-assets-webpack-plugin@^6.0.1:
   version "6.0.1"
@@ -14391,6 +14431,15 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+sirv@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.2.tgz#f775fccf10e22a40832684848d636346f41cd970"
+  integrity sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==
+  dependencies:
+    "@polka/url" "^1.0.0-next.24"
+    mrmime "^2.0.0"
+    totalist "^3.0.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -15403,6 +15452,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+totalist@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
+
 tough-cookie@^4.1.2:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
@@ -16083,6 +16137,22 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
+webpack-bundle-analyzer@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-5.3.0.tgz#ca289e08f2f5e39964a9988c38ff3090559392bf"
+  integrity sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.6.3"
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    commander "^14.0.2"
+    escape-string-regexp "^5.0.0"
+    html-escaper "^3.0.3"
+    opener "^1.5.2"
+    picocolors "^1.0.0"
+    sirv "^3.0.2"
+    ws "^8.19.0"
+
 webpack-cli@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
@@ -16437,6 +16507,11 @@ ws@^8.11.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+
+ws@^8.19.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 ws@^8.2.3:
   version "8.18.0"

--- a/spec/features/user_auth_spec.rb
+++ b/spec/features/user_auth_spec.rb
@@ -8,7 +8,7 @@ feature 'UserAuthLogin', type: :feature, js: true do
 
       visit moments_path
 
-      expect(page.body).to_not have_content("confirm your email")
+      expect(page).to_not have_content("confirm your email")
       expect(page).to have_current_path moments_path
     end
   end

--- a/spec/requests/profile_spec.rb
+++ b/spec/requests/profile_spec.rb
@@ -24,7 +24,7 @@ describe "Profile", type: :request do
         context "when user has no moments and strategies" do
           it "does not have the Stories section" do
             get profile_index_path, params: {uid: user.uid}
-            expect(response.body).to_not include("Stories")
+            expect(response.body).to_not include("StoryContainer")
           end
         end
 
@@ -34,7 +34,7 @@ describe "Profile", type: :request do
             strategy = create(:strategy, user: user)
 
             get profile_index_path, params: {uid: user.uid}
-            expect(response.body).to include("Stories")
+            expect(response.body).to include("StoryContainer")
             expect(response.body).to include(moment.name)
             expect(response.body).to include(strategy.name)
           end
@@ -50,7 +50,7 @@ describe "Profile", type: :request do
         end
 
         it "does not have the Stories section" do
-          expect(response.body).to_not include("Stories")
+          expect(response.body).to_not include("StoryContainer")
         end
 
         it "returns the profile for the owner" do


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->
This MR makes various JS performance improvements, particularly with respect to bundle size.

## More Details

<!--[More details on your changes, remove if not applicable]-->

The changes includes

- Setup `webpack-bundle-analyzer`
- Git rid of barrel imports for `fortawesome` imports
- Lazy load the Chart.js components
- Remove translation.json from the bundle — the i18n module now reads from a browser object, and translations are no longer re-downloaded on every deploy; they're rendered fresh by Rails on each page load.
- Enable full treeshaking

## Corresponding Issue

<!--[Link to GitHub issue related to this PR here, remove if not applicable]-->

#1024

# Screenshots

<!--[
  Screenshots (required for user interface work), remove if not applicable
  Create a GIF: https://www.cockos.com/licecap
]-->

Before: 

<img width="2385" height="1327" alt="image" src="https://github.com/user-attachments/assets/ae8e2670-5b40-473f-bf2d-9003b7208b3b" />

After:

<img width="2425" height="1325" alt="image" src="https://github.com/user-attachments/assets/17e7a0a0-70dd-43bc-a565-4fb882778ab1" />

---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
