### PR TITLE
Handle CrisisPreventionModal per Moments post

### DIFF
--- a/app/controllers/moments_controller.rb
+++ b/app/controllers/moments_controller.rb
@@ -8,7 +8,7 @@ class MomentsController < ApplicationController
   include Shared
   include TagsHelper
 
-  before_action :set_moment, only: %i[show edit update destroy picture]
+  before_action :set_moment, only: %i[show edit update destroy picture acknowledge_crisis_prevention]
   before_action :load_viewers, only: %i[new edit create update picture]
 
   # GET /moments
@@ -68,6 +68,34 @@ class MomentsController < ApplicationController
   def destroy
     @moment.destroy
     redirect_to_path(moments_path)
+  end
+
+  # POST /moments/acknowledge_all_crisis_prevention
+  def acknowledge_all_crisis_prevention
+    current_user.moments
+                .where(crisis_prevention_acknowledged: false)
+                .where('created_at >= ?', 1.month.ago)
+                .each do |moment|
+      moment.update!(
+        crisis_prevention_acknowledged: true,
+        crisis_prevention_acknowledged_text: moment.why
+      )
+    end
+    render json: { acknowledged: true }
+  end
+
+  # POST /moments/1/acknowledge_crisis_prevention
+  def acknowledge_crisis_prevention
+    unless @moment.owned_by?(current_user)
+      render json: { error: 'Unauthorized' }, status: :unauthorized
+      return
+    end
+
+    @moment.update!(
+      crisis_prevention_acknowledged: true,
+      crisis_prevention_acknowledged_text: @moment.why
+    )
+    render json: { acknowledged: true }
   end
 
   # POST /moments/1/picture

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,6 +15,7 @@ class PagesController < ApplicationController
     if user_signed_in?
       setup_stories
       load_dashboard_data if @stories.present? && @stories.count.positive?
+      @show_crisis_prevention_index = recent_unacknowledged_crisis_moments?
     else
       @blurbs = set_blurbs
       @posts = fetch_posts
@@ -68,6 +69,16 @@ class PagesController < ApplicationController
   def privacy; end
 
   private
+
+  def recent_unacknowledged_crisis_moments?
+    current_user.moments
+                .where(crisis_prevention_acknowledged: false)
+                .where('created_at >= ?', 1.month.ago)
+                .any? do |moment|
+      ResourceRecommendations.new(moment: moment, current_user: current_user)
+                             .has_crisis_keywords?
+    end
+  end
 
   def filter_keywords
     return [] if params[:filter].nil? || !params[:filter].is_a?(Array)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'cgi'
+
 module ApplicationHelper
   include ViewersHelper
   include AssetsHelper
@@ -19,7 +21,7 @@ module ApplicationHelper
   end
 
   def page_title
-    t('app_name') +
+    CGI.unescapeHTML(t('app_name') +
       if sign_in_path?
         " | #{t('account.sign_in')}"
       elsif join_path?
@@ -40,7 +42,7 @@ module ApplicationHelper
         " | #{t('devise.confirmations.resend_confirmation')}"
       else
         " | #{title_content}"
-      end
+      end)
   end
 
   def title_content

--- a/app/models/moment.rb
+++ b/app/models/moment.rb
@@ -3,21 +3,23 @@
 #
 # Table name: moments
 #
-#  id                       :bigint           not null, primary key
-#  name                     :string
-#  why                      :text
-#  fix                      :text
-#  created_at               :datetime
-#  updated_at               :datetime
-#  user_id                  :integer
-#  viewers                  :text
-#  comment                  :boolean
-#  slug                     :string
-#  secret_share_identifier  :uuid
-#  secret_share_expires_at  :datetime
-#  published_at             :datetime
-#  bookmarked               :boolean          default(FALSE)
-#  resource_recommendations :boolean          default(TRUE)
+#  id                                  :bigint           not null, primary key
+#  name                                :string
+#  why                                 :text
+#  fix                                 :text
+#  created_at                          :datetime
+#  updated_at                          :datetime
+#  user_id                             :integer
+#  viewers                             :text
+#  comment                             :boolean
+#  slug                                :string
+#  secret_share_identifier             :uuid
+#  secret_share_expires_at             :datetime
+#  published_at                        :datetime
+#  bookmarked                          :boolean          default(FALSE)
+#  resource_recommendations            :boolean          default(TRUE)
+#  crisis_prevention_acknowledged      :boolean          default(FALSE), not null
+#  crisis_prevention_acknowledged_text :text
 #
 
 class Moment < ApplicationRecord
@@ -49,6 +51,7 @@ class Moment < ApplicationRecord
     elements_array_data(%w[category mood strategy])
   end
   before_save :viewers_array_data
+  before_update :reset_crisis_prevention_if_significant_change
 
   belongs_to :user
 
@@ -99,5 +102,39 @@ class Moment < ApplicationRecord
 
   def comments
     Comment.comments_from(self)
+  end
+
+  private
+
+  def reset_crisis_prevention_if_significant_change
+    return unless crisis_prevention_acknowledged?
+    return if crisis_prevention_acknowledged_text.blank?
+    return unless will_save_change_to_why?
+
+    if significant_text_change?(crisis_prevention_acknowledged_text, why)
+      self.crisis_prevention_acknowledged = false
+      self.crisis_prevention_acknowledged_text = nil
+    end
+  end
+
+  def significant_text_change?(old_text, new_text)
+    old_clean = ActionController::Base.helpers.strip_tags(old_text.to_s).downcase.strip
+    new_clean = ActionController::Base.helpers.strip_tags(new_text.to_s).downcase.strip
+
+    return false if old_clean == new_clean
+    return true if old_clean.blank?
+
+    old_words = old_clean.split
+    return true if old_words.empty?
+
+    new_word_tally = new_clean.split.tally
+    matching = old_words.count do |word|
+      if new_word_tally[word].to_i > 0
+        new_word_tally[word] -= 1
+        true
+      end
+    end
+
+    (1.0 - (matching.to_f / old_words.size)) > 0.30
   end
 end

--- a/app/services/resource_recommendations.rb
+++ b/app/services/resource_recommendations.rb
@@ -2,6 +2,8 @@
 
 CRISIS_PREVENTION_TAGS = %w[
   die dead died dying death passed_away kill_myself hurt_myself suicidal suicide
+  want_to_die end_my_life take_my_life end_it_all self_harm
+  no_reason_to_live not_worth_living overdose
 ].freeze
 
 class ResourceRecommendations
@@ -30,14 +32,17 @@ class ResourceRecommendations
 
   def show_crisis_prevention
     if same_user? && same_date?
-      @moment_keywords = MomentKeywords.new(@moment).call
-
-      return CRISIS_PREVENTION_TAGS.any? do |tag|
-        @moment_keywords.match?(get_crisis_prevention_tag(tag))
-      end
+      return has_crisis_keywords?
     end
 
     false
+  end
+
+  def has_crisis_keywords?
+    @moment_keywords = MomentKeywords.new(@moment).call
+    CRISIS_PREVENTION_TAGS.any? do |tag|
+      @moment_keywords.match?(get_crisis_prevention_tag(tag))
+    end
   end
 
   private

--- a/app/views/moments/show.html.erb
+++ b/app/views/moments/show.html.erb
@@ -61,7 +61,10 @@
 <% end %>
 
 <% if @show_crisis_prevention %>
-  <%= react_component('CrisisPrevention') %>
+  <%= react_component('CrisisPrevention', props: {
+    momentId: @moment.id,
+    acknowledged: @moment.crisis_prevention_acknowledged
+  }) %>
 <% end %>
 
 <% if @moment.owned_by?(current_user) && @moment.shared? %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -6,6 +6,10 @@
   <% title t('pages.home.signed_in_empty.main_message_one', name: current_user.name) %>
 <% end %>
 
+<% if @show_crisis_prevention_index %>
+  <%= react_component('CrisisPrevention', props: { acknowledged: false }) %>
+<% end %>
+
 <% if !user_signed_in? %>
   <%= render partial: 'not_signed_in' %>
 <% elsif @stories.any? %>

--- a/client/app/components/Form/index.jsx
+++ b/client/app/components/Form/index.jsx
@@ -217,6 +217,7 @@ export const Form = ({ action, inputs: inputsProps }: Props): Node => {
   }, [registerSaveCallback]);
 
   const handleError = (id: string, error: boolean): void => {
+    if (errors[id] === error) return;
     const newErrors = { ...errors };
     newErrors[id] = error;
     setErrors(newErrors);

--- a/client/app/components/Form/utils.js
+++ b/client/app/components/Form/utils.js
@@ -39,6 +39,10 @@ export const getNewInputs = ({
       return false;
     }
 
+    if (!element) {
+      return false;
+    }
+
     if (
       input.type === 'number'
       && typeof element.value !== 'undefined'

--- a/client/app/widgets/CrisisPrevention/__tests___/index.spec.jsx
+++ b/client/app/widgets/CrisisPrevention/__tests___/index.spec.jsx
@@ -1,13 +1,97 @@
+/* eslint react/jsx-props-no-spreading: 0 */
 import React from 'react';
-import { render } from '@testing-library/react';
+import {
+  render, screen, fireEvent, waitFor,
+} from '@testing-library/react';
+import { fetchWrapper } from 'utils/fetchWrapper';
 import CrisisPrevention from 'widgets/CrisisPrevention';
 
+jest.mock('utils/fetchWrapper', () => ({
+  fetchWrapper: {
+    post: jest.fn(() => Promise.resolve({ data: { acknowledged: true } })),
+  },
+}));
+
 describe('CrisisPrevention', () => {
-  it('renders the component', () => {
-    let container;
-    expect(() => {
-      container = render(<CrisisPrevention />);
-    }).not.toThrow();
+  const defaultProps = { momentId: 42, acknowledged: false };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the modal when not yet acknowledged', () => {
+    const { container } = render(<CrisisPrevention {...defaultProps} />);
     expect(container).not.toBeNull();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does not render the modal when already acknowledged', () => {
+    const { container } = render(
+      <CrisisPrevention momentId={42} acknowledged />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the acknowledge button', () => {
+    render(<CrisisPrevention {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: /acknowledged/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a link to the care plan', () => {
+    render(<CrisisPrevention {...defaultProps} />);
+    const link = screen.getByRole('link', { name: /care plan/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/care_plan');
+  });
+
+  it('calls the acknowledge API and hides the modal when the button is clicked', async () => {
+    render(<CrisisPrevention {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /acknowledged/i }));
+
+    await waitFor(() => {
+      expect(fetchWrapper.post).toHaveBeenCalledWith(
+        '/moments/42/acknowledge_crisis_prevention',
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides the modal even if the API call fails', async () => {
+    fetchWrapper.post.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<CrisisPrevention {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /acknowledged/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('bulk mode (no momentId)', () => {
+    it('renders the modal when no momentId is provided', () => {
+      render(<CrisisPrevention acknowledged={false} />);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('calls the bulk acknowledge endpoint when no momentId is provided', async () => {
+      render(<CrisisPrevention acknowledged={false} />);
+      fireEvent.click(screen.getByRole('button', { name: /acknowledged/i }));
+
+      await waitFor(() => {
+        expect(fetchWrapper.post).toHaveBeenCalledWith(
+          '/moments/acknowledge_all_crisis_prevention',
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/client/app/widgets/CrisisPrevention/index.jsx
+++ b/client/app/widgets/CrisisPrevention/index.jsx
@@ -1,37 +1,70 @@
 // @flow
-import React from 'react';
+import React, { useState } from 'react';
 import type { Node } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHeart } from '@fortawesome/free-solid-svg-icons/faHeart';
 import { I18n } from 'libs/i18n';
 import Modal from 'components/Modal';
+import { fetchWrapper } from 'utils/fetchWrapper';
+import globalCss from 'styles/_global.scss';
 import css from './CrisisPrevention.scss';
 
-const CrisisPrevention = (): Node => (
-  <Modal
-    title={I18n.t('pages.resources.crisis_prevention.title')}
-    body={(
-      <>
-        <a
-          href={`/resources?filter[]=${I18n.t(
-            'pages.resources.tags.hotlines',
-          )}`}
-        >
-          {I18n.t('pages.resources.emergency')}
-        </a>
-        <p>
-          {I18n.t('pages.resources.crisis_prevention.description')}
-          {' '}
-          <FontAwesomeIcon
-            icon={faHeart}
-            className={css.heart}
-            aria-disabled="true"
-          />
-        </p>
-      </>
-    )}
-    open
-  />
-);
+type Props = {
+  momentId?: number,
+  acknowledged: boolean,
+};
+
+const CrisisPrevention = ({ momentId, acknowledged }: Props): Node => {
+  const [isVisible, setIsVisible] = useState(!acknowledged);
+
+  if (!isVisible) return null;
+
+  const handleAcknowledge = () => {
+    const url = momentId
+      ? `/moments/${momentId}/acknowledge_crisis_prevention`
+      : '/moments/acknowledge_all_crisis_prevention';
+    fetchWrapper.post(url).catch(() => {});
+    setIsVisible(false);
+  };
+
+  return (
+    <Modal
+      title={I18n.t('pages.resources.crisis_prevention.title')}
+      body={(
+        <>
+          <a
+            href={`/resources?filter[]=${I18n.t(
+              'pages.resources.tags.hotlines',
+            )}`}
+          >
+            {I18n.t('pages.resources.emergency')}
+          </a>
+          <p>
+            {I18n.t('pages.resources.crisis_prevention.description')}
+            {' '}
+            <FontAwesomeIcon
+              icon={faHeart}
+              className={css.heart}
+              aria-disabled="true"
+            />
+          </p>
+          <p>
+            <a href="/care_plan">
+              {I18n.t('pages.resources.crisis_prevention.care_plan_link')}
+            </a>
+          </p>
+          <button
+            type="button"
+            className={globalCss.buttonDarkM}
+            onClick={handleAcknowledge}
+          >
+            {I18n.t('pages.resources.crisis_prevention.acknowledge')}
+          </button>
+        </>
+      )}
+      open
+    />
+  );
+};
 
 export default CrisisPrevention;

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -515,6 +515,8 @@ bg:
       crisis_prevention:
         title: Как си?
         description: Ти си обичан независимо от всичко
+        acknowledge: "Прието, ще се погрижа за нуждите си."
+        care_plan_link: "Можете също да проверите своя план за грижа за ресурси и контакти."
         die: умирам
         dead: мъртъв
         died: починал
@@ -525,6 +527,14 @@ bg:
         hurt_myself: да се нараня
         suicide: самоубийство
         suicidal: суициден
+        want_to_die: искам да умра
+        end_my_life: да сложа край на живота си
+        take_my_life: да взема живота си
+        end_it_all: да сложа край на всичко
+        self_harm: самонараняване
+        no_reason_to_live: няма причина да живея
+        not_worth_living: не си заслужава да живея
+        overdose: предозиране
       tags:
         ai: AI
         communities: общности

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -719,6 +719,8 @@ ca:
       crisis_prevention:
         title: Com estàs?
         description: Siguis com siguis, ets estimat
+        acknowledge: "Reconegut, vaig a tenir cura de les meves necessitats."
+        care_plan_link: "També podeu consultar el vostre Pla d'atenció per obtenir recursos i contactes."
         die: morir
         dead: mort
         died: va morir
@@ -729,6 +731,14 @@ ca:
         hurt_myself: fer-me mal
         suicide: suïcidi
         suicidal: suïcida
+        want_to_die: vull morir
+        end_my_life: acabar amb la meva vida
+        take_my_life: prendre la meva vida
+        end_it_all: acabar amb tot
+        self_harm: autolesió
+        no_reason_to_live: cap raó per viure
+        not_worth_living: no val la pena viure
+        overdose: sobredosi
       tags:
         ai: AI
         communities: comunitats

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -793,6 +793,8 @@ de:
       crisis_prevention:
         title: Wie geht es dir?
         description: 'Du wirst geliebt, egal was'
+        acknowledge: "Verstanden, ich werde mich um meine Bedürfnisse kümmern."
+        care_plan_link: "Sie können auch Ihren Pflegeplan nach Ressourcen und Kontakten durchsuchen."
         die: stirb
         dead: tot
         died: gestorben
@@ -803,6 +805,14 @@ de:
         hurt_myself: verletze mich selbst
         suicide: selbstmord
         suicidal: selbstmörderisch
+        want_to_die: sterben wollen
+        end_my_life: mein Leben beenden
+        take_my_life: mein Leben nehmen
+        end_it_all: alles beenden
+        self_harm: selbstverletzung
+        no_reason_to_live: keinen grund zu leben
+        not_worth_living: nicht wert zu leben
+        overdose: überdosis
       tags:
         ai: AI
         communities: Gemeinschaften

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -691,6 +691,8 @@ en:
       crisis_prevention:
         title: How are you doing?
         description: You are loved no matter what
+        acknowledge: "Acknowledged, I am going to tend to my needs."
+        care_plan_link: "You can also check your Care Plan for resources and contacts."
         die: die
         dead: dead
         died: died
@@ -701,6 +703,14 @@ en:
         hurt_myself: hurt myself
         suicide: suicide
         suicidal: suicidal
+        want_to_die: want to die
+        end_my_life: end my life
+        take_my_life: take my life
+        end_it_all: end it all
+        self_harm: self harm
+        no_reason_to_live: no reason to live
+        not_worth_living: not worth living
+        overdose: overdose
       tags:
         ai: AI
         communities: communities

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -739,6 +739,8 @@ es:
       crisis_prevention:
         title: ¿Cómo estás?
         description: Eres amado pase lo que pase
+        acknowledge: "Reconocido, voy a atender mis necesidades."
+        care_plan_link: "También puede consultar su Plan de cuidado para obtener recursos y contactos."
         die: muere
         dead: muerto
         died: murió
@@ -749,6 +751,14 @@ es:
         hurt_myself: herirme a mí mismo
         suicide: suicidio
         suicidal: suicida
+        want_to_die: quiero morir
+        end_my_life: terminar con mi vida
+        take_my_life: quitarme la vida
+        end_it_all: acabar con todo
+        self_harm: autolesión
+        no_reason_to_live: sin razón para vivir
+        not_worth_living: no vale la pena vivir
+        overdose: sobredosis
       tags:
         ai: AI
         communities: comunidades

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -730,6 +730,8 @@ fr:
       crisis_prevention:
         title: Comment ça va?
         description: Vous êtes aimé quoi qu'il arrive
+        acknowledge: "Reconnu, je vais prendre soin de mes besoins."
+        care_plan_link: "Vous pouvez également consulter votre Plan de soins pour des ressources et des contacts."
         die: meurs
         dead: mort
         died: mort
@@ -740,6 +742,14 @@ fr:
         hurt_myself: me faire du mal
         suicide: suicide
         suicidal: suicidaire
+        want_to_die: vouloir mourir
+        end_my_life: mettre fin à ma vie
+        take_my_life: prendre ma vie
+        end_it_all: en finir
+        self_harm: automutilation
+        no_reason_to_live: aucune raison de vivre
+        not_worth_living: ne vaut pas la peine de vivre
+        overdose: surdose
       tags:
         ai: AI
         communities: communauté

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -714,6 +714,8 @@ hi:
       crisis_prevention:
         title: आप कैसे हैं?
         description: आपको कोई फर्क नहीं पड़ता प्यार किया जाता है
+        acknowledge: "स्वीकार किया, मैं अपनी जरूरतों का ख्याल रखूंगा।"
+        care_plan_link: "आप संसाधनों और संपर्कों के लिए अपनी देखभाल योजना भी देख सकते हैं।"
         die: मरना
         dead: मृत
         died: मर गए
@@ -724,6 +726,14 @@ hi:
         hurt_myself: मुझे ठेस पहूंचाता है
         suicide: आत्महत्या
         suicidal: आत्मघात
+        want_to_die: मरना चाहता हूं
+        end_my_life: अपनी जिंदगी खत्म करना
+        take_my_life: अपनी जान लेना
+        end_it_all: सब कुछ खत्म करना
+        self_harm: खुद को नुकसान पहुंचाना
+        no_reason_to_live: जीने की कोई वजह नहीं
+        not_worth_living: जीने लायक नहीं
+        overdose: ओवरडोज
       tags:
         ai: AI
         communities: समुदाय

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -718,6 +718,8 @@ id:
       crisis_prevention:
         title: Bagaimana kabar Anda?
         description: Anda dicintai apa pun yang terjadi
+        acknowledge: "Diakui, saya akan memenuhi kebutuhan saya."
+        care_plan_link: "Anda juga dapat memeriksa Rencana Perawatan Anda untuk sumber daya dan kontak."
         die: meninggal
         dead: meninggal
         died: meninggal
@@ -728,6 +730,14 @@ id:
         hurt_myself: menyakiti diri saya sendiri
         suicide: bunuh diri
         suicidal: kecenderungan bunuh diri
+        want_to_die: ingin mati
+        end_my_life: mengakhiri hidup saya
+        take_my_life: mengambil hidup saya
+        end_it_all: mengakhiri semuanya
+        self_harm: menyakiti diri sendiri
+        no_reason_to_live: tidak ada alasan untuk hidup
+        not_worth_living: tidak layak untuk hidup
+        overdose: overdosis
       tags:
         ai: AI
         communities: komunitas

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -731,6 +731,8 @@ it:
       crisis_prevention:
         title: Come te la passi?
         description: 'Sei amato, non importa quale'
+        acknowledge: "Riconosciuto, mi prenderò cura dei miei bisogni."
+        care_plan_link: "Puoi anche controllare il tuo Piano di cura per risorse e contatti."
         die: morire
         dead: morto
         died: morto
@@ -741,6 +743,14 @@ it:
         hurt_myself: ferirmi
         suicide: suicidio
         suicidal: suicida
+        want_to_die: voglio morire
+        end_my_life: porre fine alla mia vita
+        take_my_life: togliermi la vita
+        end_it_all: farla finita
+        self_harm: autolesionismo
+        no_reason_to_live: nessun motivo per vivere
+        not_worth_living: non vale la pena vivere
+        overdose: overdose
       tags:
         ai: AI
         communities: community

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -605,6 +605,8 @@ ko:
       crisis_prevention:
         title: 어떻게 지내요?
         description: 당신은 무슨 일이 있어도 사랑 받습니다.
+        acknowledge: "인정합니다, 저는 제 필요를 돌볼 것입니다."
+        care_plan_link: "리소스와 연락처를 위해 돌봄 계획을 확인할 수도 있습니다."
         die: 죽다
         dead: 죽었던
         died: 죽은
@@ -615,6 +617,14 @@ ko:
         hurt_myself: 자해하다
         suicide: 자살
         suicidal: 자살할 것 같은
+        want_to_die: 죽고 싶다
+        end_my_life: 내 삶을 끝내다
+        take_my_life: 내 목숨을 끊다
+        end_it_all: 모든 것을 끝내다
+        self_harm: 자해
+        no_reason_to_live: 살 이유가 없다
+        not_worth_living: 살 가치가 없다
+        overdose: 과다복용
       tags:
         ai: AI
         communities: 커뮤니티들

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -700,6 +700,8 @@ nb:
       crisis_prevention:
         title: Hvordan går det?
         description: Du er elsket uansett hva
+        acknowledge: "Forstått, jeg skal ta vare på mine behov."
+        care_plan_link: "Du kan også sjekke din Pleieplan for ressurser og kontakter."
         die: dø
         dead: død
         died: døde
@@ -710,6 +712,14 @@ nb:
         hurt_myself: skadet meg selv
         suicide: selvmord
         suicidal: suicidal
+        want_to_die: vil dø
+        end_my_life: avslutte livet mitt
+        take_my_life: ta livet mitt
+        end_it_all: avslutte alt
+        self_harm: selvskading
+        no_reason_to_live: ingen grunn til å leve
+        not_worth_living: ikke verdt å leve
+        overdose: overdose
       tags:
         ai: AI
         communities: samfunn

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -742,6 +742,8 @@ nl:
       crisis_prevention:
         title: Hoe gaat het?
         description: Je bent hoe dan ook geliefd
+        acknowledge: "Begrepen, ik ga voor mijn behoeften zorgen."
+        care_plan_link: "U kunt ook uw Zorgplan controleren op middelen en contacten."
         die: dood gaan
         dead: dood
         died: ging dood
@@ -752,6 +754,14 @@ nl:
         hurt_myself: mezelf pijn doen
         suicide: zelfmoord
         suicidal: suïcidaal
+        want_to_die: wil doodgaan
+        end_my_life: mijn leven beëindigen
+        take_my_life: mijn leven nemen
+        end_it_all: alles beëindigen
+        self_harm: zelfbeschadiging
+        no_reason_to_live: geen reden om te leven
+        not_worth_living: niet waard om te leven
+        overdose: overdosis
       tags:
         ai: AI
         communities: gemeenschappen

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -743,6 +743,8 @@ pt-BR:
       crisis_prevention:
         title: Como vai você?
         description: 'Você é amado, não importa o que'
+        acknowledge: "Reconhecido, vou cuidar das minhas necessidades."
+        care_plan_link: "Você também pode verificar seu Plano de cuidados para recursos e contatos."
         die: morrer
         dead: morto
         died: morreu
@@ -753,6 +755,14 @@ pt-BR:
         hurt_myself: me machucar
         suicide: suicídio
         suicidal: suicida
+        want_to_die: quero morrer
+        end_my_life: acabar com minha vida
+        take_my_life: tirar minha vida
+        end_it_all: acabar com tudo
+        self_harm: automutilação
+        no_reason_to_live: sem razão para viver
+        not_worth_living: não vale a pena viver
+        overdose: overdose
       tags:
         ai: AI
         communities: grupos comunitários

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -705,6 +705,8 @@ sv:
       crisis_prevention:
         title: Hur mår du?
         description: Du är älskad oavsett vad
+        acknowledge: "Bekräftat, jag kommer att ta hand om mina behov."
+        care_plan_link: "Du kan också kolla din Vårdplan för resurser och kontakter."
         die: dö
         dead: död-
         died: dog
@@ -715,6 +717,14 @@ sv:
         hurt_myself: skada mig själv
         suicide: självmord
         suicidal: självmords
+        want_to_die: vill dö
+        end_my_life: avsluta mitt liv
+        take_my_life: ta mitt liv
+        end_it_all: avsluta allt
+        self_harm: självskada
+        no_reason_to_live: ingen anledning att leva
+        not_worth_living: inte värt att leva
+        overdose: överdos
       tags:
         ai: AI
         communities: gemenskaperna

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -719,6 +719,8 @@ vi:
       crisis_prevention:
         title: Bạn đang làm gì?
         description: Bạn được yêu bất kể điều gì
+        acknowledge: "Đã ghi nhận, tôi sẽ chăm sóc bản thân mình."
+        care_plan_link: "Bạn cũng có thể kiểm tra Kế hoạch chăm sóc của mình để tìm tài nguyên và liên hệ."
         die: chết
         dead: đã chết
         died: chết
@@ -729,6 +731,14 @@ vi:
         hurt_myself: làm tổn thương chính minh
         suicide: tự sát
         suicidal: tự tử
+        want_to_die: muốn chết
+        end_my_life: kết thúc cuộc sống của tôi
+        take_my_life: lấy đi cuộc sống của tôi
+        end_it_all: kết thúc tất cả
+        self_harm: tự làm hại bản thân
+        no_reason_to_live: không có lý do để sống
+        not_worth_living: không đáng để sống
+        overdose: dùng quá liều
       tags:
         ai: AI
         communities: cộng đồng

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -571,6 +571,8 @@ zh-CN:
       crisis_prevention:
         title: 你好吗？
         description: 不管你爱你
+        acknowledge: "已确认，我会照顾好自己的需求。"
+        care_plan_link: "您也可以查看您的护理计划以获取资源和联系人。"
         die: 死
         dead: 死
         died: 死了
@@ -581,6 +583,14 @@ zh-CN:
         hurt_myself: 伤害我自己
         suicide: 自杀
         suicidal: 自杀的
+        want_to_die: 想死
+        end_my_life: 结束我的生命
+        take_my_life: 夺取我的生命
+        end_it_all: 结束这一切
+        self_harm: 自残
+        no_reason_to_live: 没有理由活着
+        not_worth_living: 不值得活着
+        overdose: 过量服药
       tags:
         ai: AI
         communities: 社区

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -592,6 +592,8 @@ zh-TW:
       crisis_prevention:
         title: 您好嗎？
         description: 不論如何，您都是被愛的
+        acknowledge: "已確認，我將照顧好我的需求。"
+        care_plan_link: "您也可以查看您的護理計劃以獲取資源和聯繫人。"
         die: 死
         dead: 死了
         died: 過世
@@ -602,6 +604,14 @@ zh-TW:
         hurt_myself: 傷害自己
         suicide: 自殺
         suicidal: 有自殺傾向
+        want_to_die: 想死
+        end_my_life: 結束我的生命
+        take_my_life: 奪取我的生命
+        end_it_all: 結束這一切
+        self_harm: 自殘
+        no_reason_to_live: 沒有理由活著
+        not_worth_living: 不值得活著
+        overdose: 過量服藥
       tags:
         ai: AI
         communities: 社群

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,11 @@ Rails.application.routes.draw do
   end
 
   resources :moments do
+    member do
+      post :acknowledge_crisis_prevention
+    end
     collection do
+      post :acknowledge_all_crisis_prevention
       post 'picture', to: 'moments#picture', as: 'picture'
       get 'tagged', defaults: { format: 'json' }
     end

--- a/db/migrate/20260627000001_add_crisis_prevention_acknowledged_to_moments.rb
+++ b/db/migrate/20260627000001_add_crisis_prevention_acknowledged_to_moments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCrisisPreventionAcknowledgedToMoments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :moments, :crisis_prevention_acknowledged, :boolean,
+               default: false, null: false
+    add_column :moments, :crisis_prevention_acknowledged_text, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_06_20_000001) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_27_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -164,6 +164,8 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_20_000001) do
     t.datetime "published_at", precision: nil
     t.boolean "bookmarked", default: false
     t.boolean "resource_recommendations", default: true
+    t.boolean "crisis_prevention_acknowledged", default: false, null: false
+    t.text "crisis_prevention_acknowledged_text"
     t.index ["secret_share_identifier"], name: "index_moments_on_secret_share_identifier", unique: true
     t.index ["slug"], name: "index_moments_on_slug", unique: true
   end

--- a/spec/features/user_acknowledges_crisis_prevention_spec.rb
+++ b/spec/features/user_acknowledges_crisis_prevention_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+feature 'UserAcknowledgesCrisisPrevention', type: :feature, js: true do
+  let(:user) { create :user2 }
+  let(:crisis_why) do
+    'I am struggling a lot and sometimes think about dying.'
+  end
+  let!(:moment) do
+    create :moment, :with_published_at, user: user, name: 'My Hard Day',
+                                        why: crisis_why,
+                                        crisis_prevention_acknowledged: false
+  end
+
+  before do
+    login_as user
+  end
+
+  feature 'Viewing a moment with crisis keywords' do
+    it 'shows the crisis prevention modal' do
+      visit moment_path(moment)
+      within('.modal') do
+        expect(page).to have_content('How are you doing?')
+      end
+    end
+
+    it 'dismissing the modal does not persist acknowledgment' do
+      visit moment_path(moment)
+      within('.modal') do
+        find('.modalClose').click
+      end
+      expect(page).not_to have_selector('.modal')
+
+      # Revisit — modal should reappear since it was only dismissed
+      visit moment_path(moment)
+      expect(page).to have_selector('.modal')
+      expect(moment.reload.crisis_prevention_acknowledged).to be false
+    end
+
+    it 'clicking the acknowledge button persists the state and closes the modal' do
+      visit moment_path(moment)
+      within('.modal') do
+        expect(page).to have_content('How are you doing?')
+        click_button 'Acknowledged, I am going to tend to my needs.'
+      end
+
+      expect(page).not_to have_selector('.modal')
+
+      # Revisit — modal should not reappear
+      visit moment_path(moment)
+      expect(page).not_to have_selector('.modal')
+      expect(moment.reload.crisis_prevention_acknowledged).to be true
+    end
+  end
+
+  feature 'Editing a moment after acknowledging' do
+    let!(:acknowledged_moment) do
+      create :moment, :with_published_at, user: user,
+                                          name: 'My Acknowledged Moment',
+                                          why: crisis_why,
+                                          crisis_prevention_acknowledged: true,
+                                          crisis_prevention_acknowledged_text: crisis_why
+    end
+
+    it 'keeps acknowledgment when the text changes by 30% or less' do
+      visit edit_moment_path(acknowledged_moment)
+      # Append a few words — small change
+      fill_in_textarea("#{crisis_why} Feeling a bit better now.", '#moment_why')
+      find('#submit').click
+
+      expect(acknowledged_moment.reload.crisis_prevention_acknowledged).to be true
+      expect(page).not_to have_selector('.modal')
+    end
+
+    it 'resets acknowledgment when the text changes by more than 30%' do
+      visit edit_moment_path(acknowledged_moment)
+      fill_in_textarea(
+        'I have been thinking about dying every day and cannot stop these dark thoughts.',
+        '#moment_why',
+      )
+      find('#submit').click
+
+      # Modal should now be shown again
+      within('.modal') do
+        expect(page).to have_content('How are you doing?')
+      end
+      expect(acknowledged_moment.reload.crisis_prevention_acknowledged).to be false
+    end
+  end
+end

--- a/spec/models/moment_spec.rb
+++ b/spec/models/moment_spec.rb
@@ -114,4 +114,59 @@ describe Moment do
       it { is_expected.to be false }
     end
   end
+
+  describe 'crisis prevention acknowledgment reset' do
+    let(:original_why) { 'I am feeling overwhelmed and need support.' }
+    let(:moment) do
+      create(:moment, :with_user,
+             why: original_why,
+             crisis_prevention_acknowledged: true,
+             crisis_prevention_acknowledged_text: original_why)
+    end
+
+    context 'when the why text has not changed' do
+      it 'keeps the acknowledgment' do
+        moment.update!(name: 'Updated name')
+        expect(moment.reload.crisis_prevention_acknowledged).to be true
+      end
+    end
+
+    context 'when the why text changes by 30% or less' do
+      it 'keeps the acknowledgment' do
+        # Change one word in a longer sentence (well under 30%)
+        new_why = 'I am feeling overwhelmed and need support today.'
+        moment.update!(why: new_why)
+        expect(moment.reload.crisis_prevention_acknowledged).to be true
+      end
+    end
+
+    context 'when the why text changes by more than 30%' do
+      it 'resets the acknowledgment' do
+        moment.update!(why: 'Completely different content about something else entirely now.')
+        expect(moment.reload.crisis_prevention_acknowledged).to be false
+        expect(moment.reload.crisis_prevention_acknowledged_text).to be_nil
+      end
+    end
+
+    context 'when the why text is completely replaced' do
+      it 'resets the acknowledgment' do
+        moment.update!(why: 'New text with no overlap from the original entry.')
+        expect(moment.reload.crisis_prevention_acknowledged).to be false
+      end
+    end
+
+    context 'when the moment is not yet acknowledged' do
+      let(:moment) do
+        create(:moment, :with_user,
+               why: original_why,
+               crisis_prevention_acknowledged: false,
+               crisis_prevention_acknowledged_text: nil)
+      end
+
+      it 'does not change acknowledged state on update' do
+        moment.update!(why: 'Completely different content about something else entirely now.')
+        expect(moment.reload.crisis_prevention_acknowledged).to be false
+      end
+    end
+  end
 end

--- a/spec/requests/moments_spec.rb
+++ b/spec/requests/moments_spec.rb
@@ -321,4 +321,117 @@ describe 'Moments', type: :request do
       expect(assigns(:react_moments)[create_time]).to eq(1)
     end
   end
+
+  describe '#acknowledge_all_crisis_prevention' do
+    let!(:crisis_moment1) do
+      create(:moment, user: user, why: 'I feel like dying.',
+                      crisis_prevention_acknowledged: false,
+                      created_at: 2.weeks.ago)
+    end
+    let!(:crisis_moment2) do
+      create(:moment, user: user, why: 'Thinking about suicide a lot.',
+                      crisis_prevention_acknowledged: false,
+                      created_at: 3.days.ago)
+    end
+    let!(:old_moment) do
+      create(:moment, user: user, why: 'I feel like dying.',
+                      crisis_prevention_acknowledged: false,
+                      created_at: 2.months.ago)
+    end
+
+    context 'when the user is logged in' do
+      before do
+        sign_in user
+        post acknowledge_all_crisis_prevention_moments_path,
+             headers: { 'ACCEPT' => 'application/json' }
+      end
+
+      it 'returns success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns acknowledged: true in JSON' do
+        expect(JSON.parse(response.body)).to eq({ 'acknowledged' => true })
+      end
+
+      it 'acknowledges recent unacknowledged moments' do
+        expect(crisis_moment1.reload.crisis_prevention_acknowledged).to be true
+        expect(crisis_moment2.reload.crisis_prevention_acknowledged).to be true
+      end
+
+      it 'stores the why text at time of acknowledgment' do
+        expect(crisis_moment1.reload.crisis_prevention_acknowledged_text).to eq(crisis_moment1.why)
+        expect(crisis_moment2.reload.crisis_prevention_acknowledged_text).to eq(crisis_moment2.why)
+      end
+
+      it 'does not acknowledge moments older than one month' do
+        expect(old_moment.reload.crisis_prevention_acknowledged).to be false
+      end
+    end
+
+    context 'when the user is not logged in' do
+      before do
+        post acknowledge_all_crisis_prevention_moments_path
+      end
+
+      it_behaves_like :with_no_logged_in_user
+    end
+  end
+
+  describe '#acknowledge_crisis_prevention' do
+    let!(:moment) { create(:moment, user: user, why: 'I have been feeling very sad lately.') }
+
+    context 'when the user is logged in' do
+      before { sign_in user }
+
+      context 'when the moment belongs to the current user' do
+        before do
+          post acknowledge_crisis_prevention_moment_path(moment.id),
+               headers: { 'ACCEPT' => 'application/json' }
+        end
+
+        it 'returns success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'sets crisis_prevention_acknowledged to true' do
+          expect(moment.reload.crisis_prevention_acknowledged).to be true
+        end
+
+        it 'stores the current why text in crisis_prevention_acknowledged_text' do
+          expect(moment.reload.crisis_prevention_acknowledged_text).to eq(moment.why)
+        end
+
+        it 'returns acknowledged: true in JSON' do
+          expect(JSON.parse(response.body)).to eq({ 'acknowledged' => true })
+        end
+      end
+
+      context 'when the moment does not belong to the current user' do
+        let(:other_user) { create(:user) }
+        let!(:other_moment) { create(:moment, user: other_user) }
+
+        before do
+          post acknowledge_crisis_prevention_moment_path(other_moment.id),
+               headers: { 'ACCEPT' => 'application/json' }
+        end
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+
+        it 'does not acknowledge the moment' do
+          expect(other_moment.reload.crisis_prevention_acknowledged).to be false
+        end
+      end
+    end
+
+    context 'when the user is not logged in' do
+      before do
+        post acknowledge_crisis_prevention_moment_path(moment.id)
+      end
+
+      it_behaves_like :with_no_logged_in_user
+    end
+  end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -20,6 +20,55 @@ describe "Pages", type: :request do
     context "logged in" do
       before { sign_in user }
 
+      context "with recent unacknowledged crisis moments" do
+        before do
+          create(:moment, user: user,
+                          why: 'I have been feeling suicidal.',
+                          crisis_prevention_acknowledged: false,
+                          created_at: 1.week.ago)
+        end
+
+        it "sets show_crisis_prevention_index to true" do
+          get pages_home_path
+          expect(assigns(:show_crisis_prevention_index)).to be true
+        end
+      end
+
+      context "without recent unacknowledged crisis moments" do
+        it "sets show_crisis_prevention_index to false" do
+          get pages_home_path
+          expect(assigns(:show_crisis_prevention_index)).to be false
+        end
+      end
+
+      context "when recent moments are already acknowledged" do
+        before do
+          create(:moment, user: user,
+                          why: 'I have been feeling suicidal.',
+                          crisis_prevention_acknowledged: true,
+                          created_at: 1.week.ago)
+        end
+
+        it "sets show_crisis_prevention_index to false" do
+          get pages_home_path
+          expect(assigns(:show_crisis_prevention_index)).to be false
+        end
+      end
+
+      context "when crisis moments are older than one month" do
+        before do
+          create(:moment, user: user,
+                          why: 'I have been feeling suicidal.',
+                          crisis_prevention_acknowledged: false,
+                          created_at: 6.weeks.ago)
+        end
+
+        it "sets show_crisis_prevention_index to false" do
+          get pages_home_path
+          expect(assigns(:show_crisis_prevention_index)).to be false
+        end
+      end
+
       it "has no stories" do
         list = double
         allow(Kaminari).to receive(:paginate_array).and_return(list)

--- a/spec/services/resource_recommendations_spec.rb
+++ b/spec/services/resource_recommendations_spec.rb
@@ -19,4 +19,30 @@ describe ResourceRecommendations do
       expect(resources.call).not_to eq(available_resource)
     end
   end
+
+  describe '#has_crisis_keywords?' do
+    context 'when the moment contains a crisis keyword' do
+      let(:moment) { FactoryBot.build(:moment, why: 'I have been feeling suicidal lately.') }
+
+      it 'returns true' do
+        expect(resources.has_crisis_keywords?).to be true
+      end
+    end
+
+    context 'when the moment does not contain crisis keywords' do
+      let(:moment) { FactoryBot.build(:moment, why: 'I had a really good day today.') }
+
+      it 'returns false' do
+        expect(resources.has_crisis_keywords?).to be false
+      end
+    end
+
+    context 'when the crisis keyword is in HTML (Pell editor output)' do
+      let(:moment) { FactoryBot.build(:moment, why: '<p>Sometimes I think about <strong>dying</strong>.</p>') }
+
+      it 'returns true after stripping HTML' do
+        expect(resources.has_crisis_keywords?).to be true
+      end
+    end
+  end
 end

--- a/spec/support/textarea_support.rb
+++ b/spec/support/textarea_support.rb
@@ -3,9 +3,14 @@
 module TextareaSupport
   def fill_in_textarea(text, locator)
     within(locator) do
-      find('.editorContent', visible: false).send_keys('')
-      find('.editorContent', visible: false).send_keys(text)
+      editor = find('.editorContent', visible: false)
+      editor.send_keys([modifier_key, 'a'])
+      editor.send_keys(text)
     end
+  end
+
+  def modifier_key
+    /darwin/i.match?(RbConfig::CONFIG['host_os']) ? :meta : :control
   end
 end
 


### PR DESCRIPTION
<!--[
  Thank you for contributing! Please use this pull request (PR) template.

  Need help? Post in the #dev channel on Slack
  Use the "wip" label if this PR is not ready for review

  Check out our Pull Request Practices guide if you haven't already: https://github.com/ifmeorg/ifme/wiki/Pull-Request-Practices
  Join our organization if you haven't already: https://github.com/ifmeorg/ifme/wiki/Join-Our-Slack
  We encourage everyone to add themselves to our Contribute page: https://github.com/ifmeorg/ifme/wiki/Contributor-Blurb
]-->
# Description

<!--[A few sentences describing your changes]-->

Be able to keep track of displaying the `CrisisiPreventionModal` per Moments post. 

## More Details

<!--[More details on your changes, remove if not applicable]-->

When signed in:

If it's dismissed without acknowledging it, it will continue to appear on that post and on the homepage. If it's acknowledged within the post, then modal will no longer appear. Any other posts that have it unacknowledged with will still have it appear.

If you acknowledge it from the homepage, it will acknowledge it for all posts. If not, those posts will continue to display. The modal also only appears on the homepage when there are posts within a month that have that status.

When editing a post that doesn't have the status or does (and has been acknowledged or dismissed), update the status based on the content of the post if there are 30% changes to the content.


---

Reviewing this pull request? Check out our [Code Review Practices](https://github.com/ifmeorg/ifme/wiki/Code-Review-Practices) guide if you haven't already!
